### PR TITLE
fix(channel): unblock multi-channel startup and load .env into os.environ

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "WeChat channel plugin for Bub framework"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "bub>=0.3.0",
+    "bub>=0.3.1",
     "weixin-agent-sdk @ git+https://github.com/iodone/weixin-agent-sdk",
 ]
 

--- a/src/bub_weixin_channel/channel.py
+++ b/src/bub_weixin_channel/channel.py
@@ -35,7 +35,7 @@ class WeixinChannel(Channel):
     async def start(self, stop_event: asyncio.Event) -> None:
         """Start WeChat bot polling."""
         self._stop_event = stop_event
-        
+
         # Import weixin_agent here to avoid import errors if not installed
         try:
             from weixin_agent import start as weixin_start
@@ -45,7 +45,7 @@ class WeixinChannel(Channel):
             return
 
         logger.info("[weixin] starting bot")
-        
+
         # Start weixin bot in background task
         async def run_bot():
             try:
@@ -63,16 +63,6 @@ class WeixinChannel(Channel):
                     self._stop_event.set()
 
         self._task = asyncio.create_task(run_bot())
-        
-        # Wait for stop signal
-        await stop_event.wait()
-        
-        if self._task and not self._task.done():
-            self._task.cancel()
-            try:
-                await self._task
-            except asyncio.CancelledError:
-                pass
 
     async def stop(self) -> None:
         """Stop WeChat bot."""
@@ -88,8 +78,10 @@ class WeixinChannel(Channel):
 
     async def send(self, message: ChannelMessage) -> None:
         """Send message through WeChat channel.
-        
+
         Note: weixin-agent-sdk handles sending internally through the Agent.chat() response.
         This method is not used for normal flow, but kept for interface compatibility.
         """
-        logger.debug(f"weixin.send called (handled by agent.chat): {message.content[:50]}...")
+        logger.debug(
+            f"weixin.send called (handled by agent.chat): {message.content[:50]}..."
+        )

--- a/src/bub_weixin_channel/plugin.py
+++ b/src/bub_weixin_channel/plugin.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+from pathlib import Path
 from typing import Any
 
 from bub.framework import BubFramework
@@ -9,6 +11,25 @@ from bub.hookspecs import hookimpl
 from bub.types import MessageHandler
 
 from bub_weixin_channel.channel import WeixinChannel
+
+
+def _load_dotenv_to_environ() -> None:
+    """Load .env file into os.environ so subprocess calls inherit env vars."""
+    env_path = Path.cwd() / ".env"
+    if not env_path.exists():
+        return
+    for line in env_path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip().strip("'\"")
+        if key and key not in os.environ:
+            os.environ[key] = value
+
+
+_load_dotenv_to_environ()
 
 
 class WeixinPlugin:

--- a/uv.lock
+++ b/uv.lock
@@ -237,7 +237,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bub", specifier = ">=0.3.0" },
+    { name = "bub", specifier = ">=0.3.1" },
     { name = "weixin-agent-sdk", git = "https://github.com/iodone/weixin-agent-sdk" },
 ]
 


### PR DESCRIPTION
## Changes

- Remove `await stop_event.wait()` from `WeixinChannel.start()` that blocked subsequent channels (telegram) from starting
- Add `_load_dotenv_to_environ()` to inject `.env` vars into `os.environ` so subprocess calls (skills) can access `BUB_*` tokens
- Bump `bub` dependency to `>=0.3.1`

## Motivation

`ChannelManager.listen_and_run()` iterates channels sequentially with `await channel.start(stop_event)`. The weixin channel's `start()` was blocking on `stop_event.wait()`, preventing telegram and other channels from ever starting.

Additionally, `.env` variables were only loaded by `pydantic_settings` into model instances, not into `os.environ`, causing skill subprocess calls (e.g., `telegram_send.py`) to fail with missing `BUB_TELEGRAM_TOKEN`.

## Testing

- [x] Verified telegram channel starts after weixin
- [x] Verified `BUB_TELEGRAM_TOKEN` is available in subprocess calls