### PR TITLE
fix: 使用飞书卡片消息渲染 Markdown 表格

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,6 @@ packages = ["src/bub_im_bridge"]
 
 [tool.hatch.metadata]
 allow-direct-references = true
+
+[tool.uv.sources]
+bub = { path = "/Users/mi/work/github/bub", editable = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,5 +24,3 @@ packages = ["src/bub_im_bridge"]
 [tool.hatch.metadata]
 allow-direct-references = true
 
-[tool.uv.sources]
-bub = { path = "/Users/mi/work/github/bub", editable = true }

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -8,6 +8,7 @@ import json
 import os
 import threading
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import Any, ClassVar
 
 import lark_oapi as lark
@@ -352,6 +353,7 @@ class FeishuChannel(Channel):
             "chat_type": message.chat_type,
             "sender_id": message.sender_open_id or "",
             "sender_name": message.sender_display,
+            "create_time": _format_feishu_timestamp(message.create_time),
         }
         await self._on_receive(
             ChannelMessage(
@@ -548,6 +550,18 @@ def _extract_outbound_text(message: ChannelMessage) -> str:
 
 
 import re
+
+
+def _format_feishu_timestamp(ts: str | None) -> str:
+    """Convert Feishu millisecond timestamp to local time string."""
+    if not ts:
+        return ""
+    try:
+        epoch_ms = int(ts)
+        dt = datetime.fromtimestamp(epoch_ms / 1000).astimezone()
+        return dt.strftime("%Y-%m-%d %H:%M:%S")
+    except (ValueError, OSError):
+        return ts or ""
 
 
 # Patterns that indicate rich content needing card rendering

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -550,11 +550,13 @@ def _extract_outbound_text(message: ChannelMessage) -> str:
 def _build_outbound_content(text: str) -> tuple[str, str]:
     """Build ``(msg_type, content_json)`` for a Feishu outbound message.
 
-    Uses ``interactive`` card with ``markdown`` element.
-    Card structure: {"config": {...}, "elements": [{"tag": "markdown", "content": "..."}]}
+    Uses ``i18n_elements`` structure with ``lark_md`` tag for rich text.
+    Supports: **bold**, *italic*, ~~strikethrough~~, links, <font> tags.
+    Does NOT support: # headings, --- hr, standard markdown tables.
     """
     card = {
-        "config": {"wide_screen_mode": True},
-        "elements": [{"tag": "markdown", "content": text}],
+        "i18n_elements": {
+            "zh_cn": [{"tag": "div", "text": {"tag": "lark_md", "content": text}}]
+        }
     }
     return "interactive", json.dumps(card, ensure_ascii=False)

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -391,6 +391,12 @@ class FeishuChannel(Channel):
 
     def _reply_message(self, message_id: str, msg_type: str, content_json: str) -> None:
         assert self._api_client is not None
+        logger.info(
+            "feishu.reply_message message_id={} msg_type={} content_preview={}",
+            message_id,
+            msg_type,
+            content_json[:200],
+        )
         req = (
             ReplyMessageRequest.builder()
             .message_id(message_id)
@@ -410,9 +416,17 @@ class FeishuChannel(Channel):
                 resp.msg,
                 message_id,
             )
+        else:
+            logger.info("feishu.reply success message_id={}", message_id)
 
     def _create_message(self, chat_id: str, msg_type: str, content_json: str) -> None:
         assert self._api_client is not None
+        logger.info(
+            "feishu.create_message chat_id={} msg_type={} content_preview={}",
+            chat_id,
+            msg_type,
+            content_json[:200],
+        )
         req = (
             CreateMessageRequest.builder()
             .receive_id_type("chat_id")
@@ -433,6 +447,8 @@ class FeishuChannel(Channel):
                 resp.msg,
                 chat_id,
             )
+        else:
+            logger.info("feishu.create success chat_id={}", chat_id)
 
 
 # ---------------------------------------------------------------------------

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -550,13 +550,12 @@ def _extract_outbound_text(message: ChannelMessage) -> str:
 def _build_outbound_content(text: str) -> tuple[str, str]:
     """Build ``(msg_type, content_json)`` for a Feishu outbound message.
 
-    Uses ``i18n_elements`` structure with ``lark_md`` tag for rich text.
-    Supports: **bold**, *italic*, ~~strikethrough~~, links, <font> tags.
-    Does NOT support: # headings, --- hr, standard markdown tables.
+    Uses Card JSON 2.0 structure (``schema: "2.0"``) which supports full
+    standard Markdown syntax including headings, tables, lists, code blocks,
+    bold, italic, colored text, and dividers.
     """
-    card = {
-        "i18n_elements": {
-            "zh_cn": [{"tag": "div", "text": {"tag": "lark_md", "content": text}}]
-        }
+    card: dict[str, Any] = {
+        "schema": "2.0",
+        "body": {"elements": [{"tag": "markdown", "content": text}]},
     }
     return "interactive", json.dumps(card, ensure_ascii=False)

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -355,6 +355,7 @@ class FeishuChannel(Channel):
             "sender_name": message.sender_display,
             "create_time": _format_feishu_timestamp(message.create_time),
         }
+        local_time = _format_feishu_timestamp(message.create_time)
         await self._on_receive(
             ChannelMessage(
                 session_id=session_id,
@@ -362,6 +363,7 @@ class FeishuChannel(Channel):
                 chat_id=message.chat_id,
                 content=json.dumps(payload, ensure_ascii=False),
                 is_active=True,
+                context={"date": local_time} if local_time else {},
             )
         )
 

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -23,6 +23,8 @@ from bub.channels.base import Channel
 from bub.channels.message import ChannelMessage
 from bub.types import MessageHandler
 
+from bub_im_bridge.feishu.feishu_prompts import FEISHU_OUTPUT_INSTRUCTION
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -345,7 +347,7 @@ class FeishuChannel(Channel):
             return
 
         payload = {
-            "message": message.text,
+            "message": message.text + FEISHU_OUTPUT_INSTRUCTION,
             "message_id": message.message_id,
             "chat_type": message.chat_type,
             "sender_id": message.sender_open_id or "",
@@ -375,22 +377,19 @@ class FeishuChannel(Channel):
         if not text:
             return
 
-        content_json = json.dumps(
-            {"zh_cn": {"title": "", "content": [[{"tag": "md", "text": text}]]}},
-            ensure_ascii=False,
-        )
+        msg_type, content_json = _build_outbound_content(text)
 
         reply_to = self._last_message_id.get(chat_id)
         if reply_to:
-            self._reply_message(reply_to, content_json)
+            self._reply_message(reply_to, msg_type, content_json)
         else:
             logger.warning(
                 "feishu.send no message_id to reply, sending as new message chat_id={}",
                 chat_id,
             )
-            self._create_message(chat_id, content_json)
+            self._create_message(chat_id, msg_type, content_json)
 
-    def _reply_message(self, message_id: str, content_json: str) -> None:
+    def _reply_message(self, message_id: str, msg_type: str, content_json: str) -> None:
         assert self._api_client is not None
         req = (
             ReplyMessageRequest.builder()
@@ -398,7 +397,7 @@ class FeishuChannel(Channel):
             .request_body(
                 ReplyMessageRequestBody.builder()
                 .content(content_json)
-                .msg_type("post")
+                .msg_type(msg_type)
                 .build()
             )
             .build()
@@ -412,7 +411,7 @@ class FeishuChannel(Channel):
                 message_id,
             )
 
-    def _create_message(self, chat_id: str, content_json: str) -> None:
+    def _create_message(self, chat_id: str, msg_type: str, content_json: str) -> None:
         assert self._api_client is not None
         req = (
             CreateMessageRequest.builder()
@@ -420,7 +419,7 @@ class FeishuChannel(Channel):
             .request_body(
                 CreateMessageRequestBody.builder()
                 .receive_id(chat_id)
-                .msg_type("post")
+                .msg_type(msg_type)
                 .content(content_json)
                 .build()
             )
@@ -530,3 +529,14 @@ def _extract_outbound_text(message: ChannelMessage) -> str:
             if isinstance(text, str) and text.strip():
                 return text
     return content.strip() if isinstance(content, str) else ""
+
+
+def _build_outbound_content(text: str) -> tuple[str, str]:
+    """Build ``(msg_type, content_json)`` for a Feishu outbound message.
+
+    Always uses ``interactive`` card with ``markdown`` element.
+    All messages follow Feishu card markdown syntax as specified in
+    FEISHU_OUTPUT_INSTRUCTION injected into user prompts.
+    """
+    card = {"elements": [{"tag": "markdown", "content": text}]}
+    return "interactive", json.dumps(card, ensure_ascii=False)

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -550,9 +550,11 @@ def _extract_outbound_text(message: ChannelMessage) -> str:
 def _build_outbound_content(text: str) -> tuple[str, str]:
     """Build ``(msg_type, content_json)`` for a Feishu outbound message.
 
-    Always uses ``interactive`` card with ``markdown`` element.
-    All messages follow Feishu card markdown syntax as specified in
-    FEISHU_OUTPUT_INSTRUCTION injected into user prompts.
+    Uses ``interactive`` card with ``markdown`` element.
+    Card structure: {"config": {...}, "elements": [{"tag": "markdown", "content": "..."}]}
     """
-    card = {"elements": [{"tag": "markdown", "content": text}]}
+    card = {
+        "config": {"wide_screen_mode": True},
+        "elements": [{"tag": "markdown", "content": text}],
+    }
     return "interactive", json.dumps(card, ensure_ascii=False)

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -547,13 +547,30 @@ def _extract_outbound_text(message: ChannelMessage) -> str:
     return content.strip() if isinstance(content, str) else ""
 
 
+import re
+
+
+# Patterns that indicate rich content needing card rendering
+_RICH_CONTENT_RE = re.compile(
+    r"[#|*~`>\-]"  # headings, tables, bold, strikethrough, code, quote, list, hr
+    r"|<font\b"  # colored text
+)
+
+
+def _needs_card(text: str) -> bool:
+    """Return True if text contains markdown formatting that needs card rendering."""
+    return bool(_RICH_CONTENT_RE.search(text))
+
+
 def _build_outbound_content(text: str) -> tuple[str, str]:
     """Build ``(msg_type, content_json)`` for a Feishu outbound message.
 
-    Uses Card JSON 2.0 structure (``schema: "2.0"``) which supports full
-    standard Markdown syntax including headings, tables, lists, code blocks,
-    bold, italic, colored text, and dividers.
+    Simple plain text → ``text`` message (like a normal human reply).
+    Rich content (markdown formatting) → Card JSON 2.0 ``interactive`` message.
     """
+    if not _needs_card(text):
+        return "text", json.dumps({"text": text}, ensure_ascii=False)
+
     card: dict[str, Any] = {
         "schema": "2.0",
         "body": {"elements": [{"tag": "markdown", "content": text}]},

--- a/src/bub_im_bridge/feishu/feishu_prompts.py
+++ b/src/bub_im_bridge/feishu/feishu_prompts.py
@@ -2,156 +2,20 @@
 
 FEISHU_OUTPUT_INSTRUCTION = """\
 
-<output_format_for_feishu_markdown_guide>
-You are replying on the Feishu (Lark) platform. Your output will be rendered via the Feishu card markdown component.
-You MUST strictly follow the syntax below. Do NOT use any unsupported markdown syntax.
+<output_format>
+Your response will be rendered in a Feishu card. The card's markdown element supports LIMITED syntax only.
 
-## Basic Syntax
+SUPPORTED:
+- **bold**, *italic*, ~~strikethrough~~
+- [link text](url)
+- Newlines (use \\n\\n for paragraphs)
 
-### Text Styles
-**bold text**
-*italic text*
-~~strikethrough text~~
-***~~mixed styles~~***
+NOT SUPPORTED (will show as plain text):
+- # Headings (use **bold** instead)
+- --- Horizontal rules
+- - Lists (use • or numbered text instead)
+- ``` Code blocks (use inline text instead)
+- Tables (describe data in text or use bullet points)
 
-### Links
-[link text](https://example.com)
-
-### Images
-![hover text](https://image.url)
-
-### Headings
-# First-level heading
-## Second-level heading
-IMPORTANT: Only # and ## are supported. Do NOT use ### or deeper headings.
-
-### Horizontal Rule
-Place a blank line before ---
-
-text above
-
----
-
-text below
-
-### Unordered List
-- item1
-- item2
-IMPORTANT: Indentation/nesting is NOT supported. Only text and links are supported as item content.
-
-### Ordered List
-1. item1
-2. item2
-IMPORTANT: Indentation/nesting is NOT supported. Only text and links are supported as item content.
-
-### Code Block
-```json
-{"key": "value"}
-```
-Specify language after opening ```, e.g. ```python, ```go, ```sql
-
-## Advanced Components
-
-### Colored Text
-<font color="red">red text</font>
-<font color="green">green text</font>
-<font color="grey">grey text</font>
-Only red, green, and grey are supported.
-
-### Table
-CRITICAL: Do NOT use standard markdown table syntax (| col1 | col2 |). It will NOT render.
-You MUST use the Feishu <table> component:
-
-<table columns={[{"tag":"plain_text","text":"Column1"},{"tag":"plain_text","text":"Column2"}]} data={[{"Column1":"value1","Column2":"value2"},{"Column1":"value3","Column2":"value4"}]} />
-
-Rules:
-- columns: array of column definitions, each with {"tag":"plain_text","text":"column name"}
-- data: array of row objects, keys must match column text exactly
-- Maximum 10 columns per table
-- Maximum 5 tables per card
-
-### Chart
-<chart chartSpec={VEGA_LITE_SPEC_JSON} />
-chartSpec follows the Vega-Lite specification.
-
-### Column Layout
-<row>
-  <col flex=1> content1 </col>
-  <col flex=2> content2 </col>
-</row>
-Use flex attribute to control width ratio.
-
-### Record Detail
-<record fields={[{"tag":"plain_text","text":"Field1"},{"tag":"plain_text","text":"Field2"}]} data={{"Field1":"value1","Field2":"value2"}} />
-
-### Note (auxiliary text)
-<note> auxiliary description text </note>
-
-### Highlight Block
-<highlight>
-highlighted content line 1
-highlighted content line 2
-</highlight>
-IMPORTANT: Multi-line content must NOT be on the same line as <highlight> or </highlight> tags. Only grey color is supported.
-
-### Button
-<button type="primary" width="default" action="navigate" url="https://example.com">
-  Click to visit
-</button>
-type: primary | default
-action: navigate (open URL) | message (send message)
-
-### Card Title
-<title style="blue">Title content</title>
-Supported styles: blue, wathet, turquoise, green, yellow, orange, red, carmine, violet, purple, indigo, grey
-
-### Mention User
-<at id='all'></at>
-<at id='{user_open_id}'></at>
-<at email='{user_email}'></at>
-
-## Prohibited Syntax
-
-Do NOT use any of the following — they will NOT render correctly:
-
-1. Standard markdown tables:
-   | col1 | col2 |
-   |------|------|
-   | a    | b    |
-   Use <table> component instead.
-
-2. Headings level 3 and deeper:
-   ### This will NOT work
-   #### This will NOT work
-   Only use # and ##.
-
-3. Nested/indented lists:
-   - item
-     - sub-item    <-- NOT supported
-   Keep lists flat.
-
-## Complete Example
-
-# Sales Report
-
-## Overview
-
-<table columns={[{"tag":"plain_text","text":"Metric"},{"tag":"plain_text","text":"Value"}]} data={[{"Metric":"Total Revenue","Value":"$1.2M"},{"Metric":"Active Users","Value":"4,740"},{"Metric":"Growth Rate","Value":"12.5%"}]} />
-
-## Highlights
-
-<font color="green">Revenue increased by 12.5% compared to last month.</font>
-
-Key achievements:
-1. Expanded to 3 new regions
-2. Launched premium tier
-
-<highlight>
-Action items:
-- Review Q2 targets
-- Schedule team sync
-</highlight>
-
-<note> Data as of 2026-04-02. Source: internal analytics. </note>
-
-</output_format_for_feishu_markdown_guide>"""
+Keep responses simple and use only bold, italic, links, and paragraphs.
+</output_format>"""

--- a/src/bub_im_bridge/feishu/feishu_prompts.py
+++ b/src/bub_im_bridge/feishu/feishu_prompts.py
@@ -3,19 +3,26 @@
 FEISHU_OUTPUT_INSTRUCTION = """\
 
 <output_format>
-Your response will be rendered in a Feishu card. The card's markdown element supports LIMITED syntax only.
+Your response will be rendered in Feishu using lark_md format. Follow these rules strictly:
 
 SUPPORTED:
 - **bold**, *italic*, ~~strikethrough~~
 - [link text](url)
-- Newlines (use \\n\\n for paragraphs)
+- <font color='blue' size='4'>Large title text</font>
+- <font color='grey' size='3'>Subtitle text</font>
+- <font color='red'>Red text</font>, <font color='green'>Green text</font>
+- Line breaks: use \\n\\n for paragraphs
 
 NOT SUPPORTED (will show as plain text):
-- # Headings (use **bold** instead)
+- # Headings → use <font color='blue' size='4'>Title</font> instead
 - --- Horizontal rules
-- - Lists (use • or numbered text instead)
-- ``` Code blocks (use inline text instead)
-- Tables (describe data in text or use bullet points)
+- - Lists → use • or numbered text instead
+- ``` Code blocks → use plain text instead
+- | Tables | → describe data in bullet points or use text layout
 
-Keep responses simple and use only bold, italic, links, and paragraphs.
+For titles: <font color='blue' size='4'>Main Title</font>
+For subtitles: <font color='grey' size='3'>Subtitle</font>
+For emphasis: **bold text**
+
+Keep responses simple. Use font tags for structure, bold for emphasis, and plain text for data.
 </output_format>"""

--- a/src/bub_im_bridge/feishu/feishu_prompts.py
+++ b/src/bub_im_bridge/feishu/feishu_prompts.py
@@ -3,19 +3,17 @@
 FEISHU_OUTPUT_INSTRUCTION = """\
 
 <output_format>
-Your response will be rendered in a Feishu card (Card JSON 2.0) which supports standard Markdown.
+Your response will be rendered in Feishu. Use standard Markdown with these rules:
 
-Supported syntax:
-- # Heading 1 through ###### Heading 6
-- **bold**, *italic*, ~~strikethrough~~
-- [link text](url)
-- Standard markdown tables: | col1 | col2 |
-- Ordered lists (1. item) and unordered lists (- item), with nesting (4 spaces indent)
-- Code blocks: ```language ... ```
-- Inline code: `code`
-- Blockquote: > text
-- Divider: --- (on its own line)
-- Colored text: <font color='green'>text</font> (red, green, grey, blue, etc.)
+1. Headings: start from ### (max level), then ####, #####, ###### for sub-levels. Do NOT use # or ##.
+2. Tables: standard markdown | col1 | col2 | syntax
+3. Text: **bold**, *italic*, ~~strikethrough~~, [link](url)
+4. Lists: - unordered, 1. ordered (nesting with 4 spaces)
+5. Code: ```language ... ``` or `inline`
+6. Quote: > text
+7. Divider: --- on its own line
+8. Color: <font color='green'>text</font> (red, green, grey, blue)
 
-Use standard Markdown freely. Keep responses well-structured with headings and tables where appropriate.
+For simple conversational replies, respond naturally without formatting — like a normal person chatting.
+Only use rich formatting (headings, tables, lists) when the content benefits from structure.
 </output_format>"""

--- a/src/bub_im_bridge/feishu/feishu_prompts.py
+++ b/src/bub_im_bridge/feishu/feishu_prompts.py
@@ -3,26 +3,19 @@
 FEISHU_OUTPUT_INSTRUCTION = """\
 
 <output_format>
-Your response will be rendered in Feishu using lark_md format. Follow these rules strictly:
+Your response will be rendered in a Feishu card (Card JSON 2.0) which supports standard Markdown.
 
-SUPPORTED:
+Supported syntax:
+- # Heading 1 through ###### Heading 6
 - **bold**, *italic*, ~~strikethrough~~
 - [link text](url)
-- <font color='blue' size='4'>Large title text</font>
-- <font color='grey' size='3'>Subtitle text</font>
-- <font color='red'>Red text</font>, <font color='green'>Green text</font>
-- Line breaks: use \\n\\n for paragraphs
+- Standard markdown tables: | col1 | col2 |
+- Ordered lists (1. item) and unordered lists (- item), with nesting (4 spaces indent)
+- Code blocks: ```language ... ```
+- Inline code: `code`
+- Blockquote: > text
+- Divider: --- (on its own line)
+- Colored text: <font color='green'>text</font> (red, green, grey, blue, etc.)
 
-NOT SUPPORTED (will show as plain text):
-- # Headings → use <font color='blue' size='4'>Title</font> instead
-- --- Horizontal rules
-- - Lists → use • or numbered text instead
-- ``` Code blocks → use plain text instead
-- | Tables | → describe data in bullet points or use text layout
-
-For titles: <font color='blue' size='4'>Main Title</font>
-For subtitles: <font color='grey' size='3'>Subtitle</font>
-For emphasis: **bold text**
-
-Keep responses simple. Use font tags for structure, bold for emphasis, and plain text for data.
+Use standard Markdown freely. Keep responses well-structured with headings and tables where appropriate.
 </output_format>"""

--- a/src/bub_im_bridge/feishu/feishu_prompts.py
+++ b/src/bub_im_bridge/feishu/feishu_prompts.py
@@ -1,0 +1,157 @@
+"""Feishu-specific output format instructions appended to user messages."""
+
+FEISHU_OUTPUT_INSTRUCTION = """\
+
+<output_format_for_feishu_markdown_guide>
+You are replying on the Feishu (Lark) platform. Your output will be rendered via the Feishu card markdown component.
+You MUST strictly follow the syntax below. Do NOT use any unsupported markdown syntax.
+
+## Basic Syntax
+
+### Text Styles
+**bold text**
+*italic text*
+~~strikethrough text~~
+***~~mixed styles~~***
+
+### Links
+[link text](https://example.com)
+
+### Images
+![hover text](https://image.url)
+
+### Headings
+# First-level heading
+## Second-level heading
+IMPORTANT: Only # and ## are supported. Do NOT use ### or deeper headings.
+
+### Horizontal Rule
+Place a blank line before ---
+
+text above
+
+---
+
+text below
+
+### Unordered List
+- item1
+- item2
+IMPORTANT: Indentation/nesting is NOT supported. Only text and links are supported as item content.
+
+### Ordered List
+1. item1
+2. item2
+IMPORTANT: Indentation/nesting is NOT supported. Only text and links are supported as item content.
+
+### Code Block
+```json
+{"key": "value"}
+```
+Specify language after opening ```, e.g. ```python, ```go, ```sql
+
+## Advanced Components
+
+### Colored Text
+<font color="red">red text</font>
+<font color="green">green text</font>
+<font color="grey">grey text</font>
+Only red, green, and grey are supported.
+
+### Table
+CRITICAL: Do NOT use standard markdown table syntax (| col1 | col2 |). It will NOT render.
+You MUST use the Feishu <table> component:
+
+<table columns={[{"tag":"plain_text","text":"Column1"},{"tag":"plain_text","text":"Column2"}]} data={[{"Column1":"value1","Column2":"value2"},{"Column1":"value3","Column2":"value4"}]} />
+
+Rules:
+- columns: array of column definitions, each with {"tag":"plain_text","text":"column name"}
+- data: array of row objects, keys must match column text exactly
+- Maximum 10 columns per table
+- Maximum 5 tables per card
+
+### Chart
+<chart chartSpec={VEGA_LITE_SPEC_JSON} />
+chartSpec follows the Vega-Lite specification.
+
+### Column Layout
+<row>
+  <col flex=1> content1 </col>
+  <col flex=2> content2 </col>
+</row>
+Use flex attribute to control width ratio.
+
+### Record Detail
+<record fields={[{"tag":"plain_text","text":"Field1"},{"tag":"plain_text","text":"Field2"}]} data={{"Field1":"value1","Field2":"value2"}} />
+
+### Note (auxiliary text)
+<note> auxiliary description text </note>
+
+### Highlight Block
+<highlight>
+highlighted content line 1
+highlighted content line 2
+</highlight>
+IMPORTANT: Multi-line content must NOT be on the same line as <highlight> or </highlight> tags. Only grey color is supported.
+
+### Button
+<button type="primary" width="default" action="navigate" url="https://example.com">
+  Click to visit
+</button>
+type: primary | default
+action: navigate (open URL) | message (send message)
+
+### Card Title
+<title style="blue">Title content</title>
+Supported styles: blue, wathet, turquoise, green, yellow, orange, red, carmine, violet, purple, indigo, grey
+
+### Mention User
+<at id='all'></at>
+<at id='{user_open_id}'></at>
+<at email='{user_email}'></at>
+
+## Prohibited Syntax
+
+Do NOT use any of the following — they will NOT render correctly:
+
+1. Standard markdown tables:
+   | col1 | col2 |
+   |------|------|
+   | a    | b    |
+   Use <table> component instead.
+
+2. Headings level 3 and deeper:
+   ### This will NOT work
+   #### This will NOT work
+   Only use # and ##.
+
+3. Nested/indented lists:
+   - item
+     - sub-item    <-- NOT supported
+   Keep lists flat.
+
+## Complete Example
+
+# Sales Report
+
+## Overview
+
+<table columns={[{"tag":"plain_text","text":"Metric"},{"tag":"plain_text","text":"Value"}]} data={[{"Metric":"Total Revenue","Value":"$1.2M"},{"Metric":"Active Users","Value":"4,740"},{"Metric":"Growth Rate","Value":"12.5%"}]} />
+
+## Highlights
+
+<font color="green">Revenue increased by 12.5% compared to last month.</font>
+
+Key achievements:
+1. Expanded to 3 new regions
+2. Launched premium tier
+
+<highlight>
+Action items:
+- Review Q2 targets
+- Schedule team sync
+</highlight>
+
+<note> Data as of 2026-04-02. Source: internal analytics. </note>
+
+</output_format_for_feishu_markdown_guide>"""

--- a/src/bub_im_bridge/feishu/plugin.py
+++ b/src/bub_im_bridge/feishu/plugin.py
@@ -20,8 +20,4 @@ class FeishPlugin:
     @hookimpl
     def provide_channels(self, message_handler: MessageHandler) -> list[Any]:
         """Provide Feishu channel to Bub."""
-        return [
-            FeishuChannel(
-                on_receive=message_handler,
-            )
-        ]
+        return [FeishuChannel(on_receive=message_handler)]

--- a/uv.lock
+++ b/uv.lock
@@ -205,7 +205,7 @@ wheels = [
 [[package]]
 name = "bub"
 version = "0.3.1"
-source = { editable = "../bub" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "any-llm-sdk" },
@@ -218,44 +218,12 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rapidfuzz" },
     { name = "republic" },
-    { name = "requests" },
     { name = "rich" },
-    { name = "telegramify-markdown" },
     { name = "typer" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "aiohttp", specifier = ">=3.13.3" },
-    { name = "any-llm-sdk", extras = ["anthropic"] },
-    { name = "loguru", specifier = ">=0.7.2" },
-    { name = "pluggy", specifier = ">=1.6.0" },
-    { name = "prompt-toolkit", specifier = ">=3.0.0" },
-    { name = "pydantic", specifier = ">=2.0.0" },
-    { name = "pydantic-settings", specifier = ">=2.0.0" },
-    { name = "python-telegram-bot", specifier = ">=21.0" },
-    { name = "pyyaml", specifier = ">=6.0.0" },
-    { name = "rapidfuzz", specifier = ">=3.14.3" },
-    { name = "republic", specifier = ">=0.5.4" },
-    { name = "requests", specifier = ">=2.32.5" },
-    { name = "rich", specifier = ">=13.0.0" },
-    { name = "telegramify-markdown", specifier = ">=1.1.1" },
-    { name = "typer", specifier = ">=0.9.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "mkdocs", specifier = ">=1.4.2" },
-    { name = "mkdocs-terminal", specifier = ">=4.7.0" },
-    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.26.1" },
-    { name = "mypy", specifier = ">=0.991" },
-    { name = "prek", specifier = ">=0.3.1" },
-    { name = "pytest", specifier = ">=7.2.0" },
-    { name = "pytest-asyncio", specifier = ">=1.3.0" },
-    { name = "ruff", specifier = ">=0.11.5" },
-    { name = "rust-just", specifier = ">=1.42.0" },
-    { name = "tox-uv", specifier = ">=1.11.3" },
-    { name = "types-pyyaml", specifier = ">=6.0.12" },
+sdist = { url = "https://files.pythonhosted.org/packages/16/f0/767166fc7c5076c0f2a013e8606ddd49f0ce772aacce1f2d4938ae378fc9/bub-0.3.1.tar.gz", hash = "sha256:4990cfc9f76d5596a34bcc64476eff61df9465cf306ece72c2059f7a2b3e39ae", size = 80457, upload-time = "2026-03-22T10:57:48.965Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/5e/6453364d825859d37ac8cd5634fd115daf91c767cf9eac6897b943239bf4/bub-0.3.1-py3-none-any.whl", hash = "sha256:acdb28440309ecb94fdb059647880a464ab0588463436e8298dcceaf5fc72320", size = 77399, upload-time = "2026-03-22T10:57:47.873Z" },
 ]
 
 [[package]]
@@ -270,7 +238,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bub", editable = "../bub" },
+    { name = "bub", specifier = ">=0.3.1" },
     { name = "lark-oapi", specifier = ">=1.3.0" },
     { name = "weixin-agent-sdk", git = "https://github.com/iodone/weixin-agent-sdk" },
 ]
@@ -1142,142 +1110,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyromark"
-version = "0.9.10"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/90/d1/79622b7d164490a02066a74e4a710d931c1252aea225640bd4453cce2310/pyromark-0.9.10.tar.gz", hash = "sha256:87a2a8e01e4214014a5697f87c9afd3563e2e2623e2926d97e9535651cae2c07", size = 9066, upload-time = "2026-03-22T12:47:18.26Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/2f/81fbd40eaf1914fa484096d83e37f9da2284b20a1ec8fb60f40ed35ac575/pyromark-0.9.10-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:73c6329ab75921d1853de52c0b0af1630218fd90ba29baf03fdfa6158c75639a", size = 346942, upload-time = "2026-03-22T12:43:17.139Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/3e/acac3b2129227d091311c5e7c064f8a6655041ed72e31e5349ca2fe7c15e/pyromark-0.9.10-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:11614f83f81a339c639c7a5ef33f78d40b0769ffc30fb57cad967ada447cd69a", size = 329828, upload-time = "2026-03-22T12:45:19.011Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/db/5756831650054597fcf23e27b425703dff21840fd7cd7ceb3ad0bba6a0d0/pyromark-0.9.10-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fe5a06515e5ef71e42d484e6cf2d69198689f660ed76fbbe0139cc59c7825742", size = 363246, upload-time = "2026-03-22T12:46:03.121Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/ad/fe3024b4e475392468620bb7e9c4e9982c159bdb0c8a16e6bb95c726d610/pyromark-0.9.10-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3044e618ffb279725e5f6a9e13e849125c9d446ae7dbb52050f981891e59b5a0", size = 361930, upload-time = "2026-03-22T12:43:40.715Z" },
-    { url = "https://files.pythonhosted.org/packages/67/a1/614b4a19b114acb2c74650de48b22eee139d5ba84bacc00a469714434b68/pyromark-0.9.10-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c6ae5ea96dbe2b2eaf534ad20b12a752926b5d575adc704d308402bed5552aec", size = 387086, upload-time = "2026-03-22T12:46:57.005Z" },
-    { url = "https://files.pythonhosted.org/packages/73/3a/7a5bed0f2c518a0a6c6d8910a01e5b971c09c673614e121dfd8c3d7cb795/pyromark-0.9.10-cp312-cp312-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:306e60834ddaa55578b908dce1b73fe11d8552c867399e0f6f73de4e347a21a1", size = 418898, upload-time = "2026-03-22T12:43:34.248Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/a7/d9f2498c0b3593e97cca70e8abb92985fca1abf6a94b02dcd307fa9ce48b/pyromark-0.9.10-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b312a37c628bd3e34edb465aec85c4022e1ddffd938f231961515b402d0457cf", size = 409937, upload-time = "2026-03-22T12:42:42.527Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/5f/bc2ba0e806d44601370865e7e81ef35d5ec0902b7160b5c7beaff4b2dcbe/pyromark-0.9.10-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1ec705a0cedff51ad99941ad881965d8d88ef499f8f8a4dac52b7e6d73f3e252", size = 451509, upload-time = "2026-03-22T12:44:57.809Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/7d/f2e3b52bae22b530e4ffc1f56dcaaacfae3ae25acf4b89453ba35bf917e4/pyromark-0.9.10-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:013650245157ce435816dc2f66116c36e9103453165fe1a58fe712b65cb88ef7", size = 371722, upload-time = "2026-03-22T12:47:56.482Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/9a/83d63ef009515af352eaea34fc64f3e077cb8a88063629500855f82302ce/pyromark-0.9.10-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:b6aa487af21ee3f8f389d7ebe1cee346092d15ce63a6ed85b07515337310a305", size = 363888, upload-time = "2026-03-22T12:44:32.57Z" },
-    { url = "https://files.pythonhosted.org/packages/72/7d/9fea010b3f337016c03e574155f19fe52b7f73238bfcaef9ea5d8a2ad48a/pyromark-0.9.10-cp312-cp312-manylinux_2_28_armv7l.whl", hash = "sha256:a4d51cb6e3ac8edff4a649e5b826d0929b630316a90ed495be3824c465551954", size = 361916, upload-time = "2026-03-22T12:44:03.891Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/10/938d96100d37f98ad65888a4990d3310d08b18e4dc3270cab3b19b7c85f7/pyromark-0.9.10-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:f985f00dd7813e3ec6a2bbbf085404e7ed574edc364f71aec2c98005075f6aa9", size = 387383, upload-time = "2026-03-22T12:45:42.807Z" },
-    { url = "https://files.pythonhosted.org/packages/18/7a/48330440c1b062ed9fbfcae4b424d57c8de26a935089a02f5114dabb87f7/pyromark-0.9.10-cp312-cp312-manylinux_2_28_ppc64le.whl", hash = "sha256:9c40414c044c7f48a116a9a5e843d7d2f4035d815c8bb4853eea9cd8c001df7c", size = 410047, upload-time = "2026-03-22T12:44:26.211Z" },
-    { url = "https://files.pythonhosted.org/packages/73/a3/16a6fc3caea432d557189ae0b64d7da2a377157df8e832dd4e664d892615/pyromark-0.9.10-cp312-cp312-manylinux_2_28_s390x.whl", hash = "sha256:b1ccab87e071de956929edbf7c3b14751fa9e0fb9b71ea2d2d66bfddd363b7f6", size = 451080, upload-time = "2026-03-22T12:42:47.658Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/6a/5a5e5677f66d416252650f2dbaf29806ef92b7017e616b2259b7f5cbecdf/pyromark-0.9.10-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:a9377e0bd45cfcacb66135375fe1305f549dbfdb8ed189740cba465ecd74b6a0", size = 372032, upload-time = "2026-03-22T12:42:46.261Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/6d/cc6b9b83f9e8b87b8997740dfd0e793ac4477f6fa897684cf5dabfe6e82f/pyromark-0.9.10-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:a580159ed41f1176f355375d0723a2d9d6249c8ab3cf21e8da8c4b5f80cf8f90", size = 372541, upload-time = "2026-03-22T12:43:13.461Z" },
-    { url = "https://files.pythonhosted.org/packages/17/53/a1ef122bade959b7f0a2e5c15f14d9b551723f420104532f821861c84af6/pyromark-0.9.10-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:442b9147c3ad6a7a66db6ffcb44e03ee90ac965b807d67e99f3b80f4705d5e0b", size = 540788, upload-time = "2026-03-22T12:42:55.056Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/94/cfeef8c0fd953e6b4fcc922594ba33c74324949e65a40d89198885143f2e/pyromark-0.9.10-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:daa313fbeba07eaf893c38252fd23d1f33071fbd7373b7d6bc8ad9e0d25a80e5", size = 638367, upload-time = "2026-03-22T12:47:45.988Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/b6/5591cfe0092427f9d718d17a18226971cbc52f088dd108e335a6d5c3c056/pyromark-0.9.10-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:64203fe6a2ffda13eb7280e229a30206e9174417aee1f836ecf1a49f78690414", size = 604956, upload-time = "2026-03-22T12:44:05.264Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/8f/23c4848bfb0eee774b8c6ac86fbd634464c7a71895a688b1cf0dfcac5598/pyromark-0.9.10-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:fc352f3257023beb72b1d5d66b2bb831c19588914acb1b653b9e9e77934cad1e", size = 540616, upload-time = "2026-03-22T12:47:25.576Z" },
-    { url = "https://files.pythonhosted.org/packages/25/f9/768acacf22e94ebbbf6c88bf2c335aa77791f12dcdb9e864fcf841aa7180/pyromark-0.9.10-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:be7366ad2736652a5ff32cad75c8b9c532769b8895ed9e49f709fe75578615a7", size = 546625, upload-time = "2026-03-22T12:45:20.759Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/d8/64f2844100adda4330eea2260755cbd33ad3f73b9fca1267bff738c08cb5/pyromark-0.9.10-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7ca386b4450366d36c618610022d9e7dae318978a7a0ae19ab75298914d1f31c", size = 591017, upload-time = "2026-03-22T12:45:53.004Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/09/7cc1f7497f16423ea120a131605cdaa23b318120ff6049b505e522b95b1e/pyromark-0.9.10-cp312-cp312-win32.whl", hash = "sha256:44a95c55b94f8d5a129a1288889d699feca19120be8e46bacd9b63f44db4f3aa", size = 261067, upload-time = "2026-03-22T12:43:32.776Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/b5/1547f1a8fb910d3c8d37cbc1b5a1d69ac222970cff20404701803f2b525e/pyromark-0.9.10-cp312-cp312-win_amd64.whl", hash = "sha256:0218905b27b735dd2c792414ca26fcb1e78ccc35e0911807a4901af61f4c7efe", size = 274046, upload-time = "2026-03-22T12:45:24.671Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/51/7bc6b4c2ac2e8b82765de7fda81df5830ec9dadcb376e34552f3eb1988ad/pyromark-0.9.10-cp312-cp312-win_arm64.whl", hash = "sha256:46fd29653024ee209de5c83948201f6d967a2fa564cd942f6220f6c4cb76567d", size = 259589, upload-time = "2026-03-22T12:43:35.958Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/d4/4566556252a50810f484562548683b8a5526fd99e609cf4fc7a2b6cb0e55/pyromark-0.9.10-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:a52d398af8abcde5a46764a2144e1780f7f10862c7dd61b1cf9fb43485a51f21", size = 346503, upload-time = "2026-03-22T12:46:32.362Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/d7/af7535545681f1301991f56947fd92c10824de02237587735a0d6dd0634b/pyromark-0.9.10-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e52bfed0818dbbc69b623099cf0d3ae1f45dd6e6ba6955adf715740edfd83727", size = 329460, upload-time = "2026-03-22T12:44:56.07Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/2b/bf3461f047ef5c28df0b6a487296fc448e8ac24d5b1f6658c39f7acee059/pyromark-0.9.10-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a6d890912d14b37f960727c2ee9063f1882f2577898d48fd957711d1f8f1e923", size = 362872, upload-time = "2026-03-22T12:47:03.962Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/5e/eb835944c7b2cc32f0d268aa0552e5859fed3e71f0255cbff306af27c13a/pyromark-0.9.10-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d66c73f516f5090243e4b9b7ef81315cfcd792723365de035c6cfd8376a867c7", size = 361327, upload-time = "2026-03-22T12:46:13.228Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/90/9e89897fd193497b3cedf23f4b01b361eedd370aaec22d0542b287d94bcb/pyromark-0.9.10-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0b1d7348c9f7ac224b9b95f41956dfa61c306d8f6fc5bb431d61167b59e04c98", size = 386656, upload-time = "2026-03-22T12:43:42.316Z" },
-    { url = "https://files.pythonhosted.org/packages/63/0c/68788c2994a03f5f4c935dbf95f1e6ae3b5b747e59229604b34f427ed401/pyromark-0.9.10-cp313-cp313-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:0e1b54775f9225f086b87c6dcf7e181f04e30d7527e598131030886c1e7ebebf", size = 418232, upload-time = "2026-03-22T12:46:24.105Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/c3/fb1dcd730ea245df66ddb90e6e805a362a0fde782f82e1ee9c11a3758722/pyromark-0.9.10-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f3ad41e294c7c92b25a44b432a926300a883da8550ada49afb778ea9da8a22c5", size = 409160, upload-time = "2026-03-22T12:44:46.355Z" },
-    { url = "https://files.pythonhosted.org/packages/19/c1/43c8c9c995e436445f146bb67f92b31f59ae031bdf8565bd9ffdabc22b95/pyromark-0.9.10-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4f4d6821d177e7cb3e8502260a90fc5b6b5f68770930d34b639318c709dfb176", size = 450994, upload-time = "2026-03-22T12:46:28.223Z" },
-    { url = "https://files.pythonhosted.org/packages/20/4a/f2f80f485b5e8f37a90b1d5b50a4e5333b9eb2238016e54613f7f70d5231/pyromark-0.9.10-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:df2f966fcdbc0a7297d34a2123aab9f99fa2d5e405a708d628ad5563807f3332", size = 370891, upload-time = "2026-03-22T12:45:50.455Z" },
-    { url = "https://files.pythonhosted.org/packages/86/71/0821b90cf605ed526ff19d0f90637144d099caa14813b941d0422a3d8945/pyromark-0.9.10-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:929ec243b426961b71393f3ca982d544ea503bbf417f9678b69407b4b457cb41", size = 363588, upload-time = "2026-03-22T12:42:27.211Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/87/f7ec775b3968180f387fa2c148612be5b010b9bbb7ff4ff8afc4694cfe87/pyromark-0.9.10-cp313-cp313-manylinux_2_28_armv7l.whl", hash = "sha256:6784c08b52bf9690382aca58881bad03ca789c3280ef695f333fba03ebe9d1db", size = 361276, upload-time = "2026-03-22T12:47:33.532Z" },
-    { url = "https://files.pythonhosted.org/packages/29/fa/ef9d643a204ae938c2a5adf0c41719c8c142d162c06b111583a9935d4f4d/pyromark-0.9.10-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:b7f0207b9a1b6626e2f3c00bad32e2713700ff8e540689677889f91043f6811f", size = 387049, upload-time = "2026-03-22T12:42:25.558Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/21/4293ed32493c3174be57644692f7eed52bcfe3f29e02d1c710909972e34f/pyromark-0.9.10-cp313-cp313-manylinux_2_28_ppc64le.whl", hash = "sha256:ad14b10efe77b788f61837db49d3cf7ae67db696a7edff7dfb3c0eff01c32069", size = 409304, upload-time = "2026-03-22T12:44:54.542Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/7f/0e8245e5459057e335f05a05f5114edc87de9a1b49ad3094335565d166bd/pyromark-0.9.10-cp313-cp313-manylinux_2_28_s390x.whl", hash = "sha256:ece3c4d0168277c8ac8f197baec47456e8a229ff41e9e6699de57ffa31abf650", size = 450598, upload-time = "2026-03-22T12:42:35.156Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/9d/ad827228441bc0a06bcbc8d2f30385ea4ca1c03255700e618e207551741c/pyromark-0.9.10-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:75a4f6849236f53adda853cb4cbc6d0e8263c5e61c6afdab4089208ad0436052", size = 371341, upload-time = "2026-03-22T12:43:03.533Z" },
-    { url = "https://files.pythonhosted.org/packages/64/af/a1a7b27e9b95240e5adfd4a80b5d2e57ae899ae10bd04ee9cee23347f63f/pyromark-0.9.10-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:d4a28da24ef81aac7f3c0ef799f351eff4f82bea25df9b0149563a374301193b", size = 371943, upload-time = "2026-03-22T12:45:04.825Z" },
-    { url = "https://files.pythonhosted.org/packages/32/1b/b60fc82aee1d8c65c31d35be67fcf87e6e80986c100c2ffbe96455c42ac1/pyromark-0.9.10-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ea6581b9ac2c0c17daad37d64cf6ece482cb9b40267117be85fadf09ac0b3206", size = 540593, upload-time = "2026-03-22T12:44:22.72Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/30/0cc9c2a0d88dc42aa49ef5ca735a2a5e68c6f5616236552f622227a9e3c3/pyromark-0.9.10-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:7e7c29e94f88d23b9ce6aa5fcc8a32a9fb1f1d3b7f2de7f441b01548156087dd", size = 637784, upload-time = "2026-03-22T12:42:53.681Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/96/53f7fa6033acfa644d918e1f64c1d9fed6d49ae0f7591f9eeb15a3c5312c/pyromark-0.9.10-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:93cef16fb1bd62c5a8b751b2575bb5c47ef48c894b3f6882472638b2a2d9bed3", size = 604605, upload-time = "2026-03-22T12:43:04.627Z" },
-    { url = "https://files.pythonhosted.org/packages/54/df/b308539b6718ef0888510ef7ac5fdad476f880350adf28d1d5057985b2dd/pyromark-0.9.10-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:2ed700d5e181552ec1c9af57a90728acf5045343a96c55fee84d4b111cbcb816", size = 539705, upload-time = "2026-03-22T12:45:58.942Z" },
-    { url = "https://files.pythonhosted.org/packages/76/6a/739dc1c4fd6c8892966d8b5ee43a75d6ca65bba0fa7b570eef300d011820/pyromark-0.9.10-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:919aab36bf53292b9da27e1950bc1470dc277696785755cca5c66ac8ba125fd3", size = 546076, upload-time = "2026-03-22T12:46:30.322Z" },
-    { url = "https://files.pythonhosted.org/packages/07/23/167efcd3f6f779a1cf824167339adec0a8c394eb52377b6fa9727babb237/pyromark-0.9.10-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bf9d7ed83231ebfe0d3fa2dc58f3c3d9d642924fbd57030e5bede99df0937da0", size = 590416, upload-time = "2026-03-22T12:45:54.908Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/59/a7783779612f5c69e35c22872e14808aa57e4d5d3f224223e4e862f88e59/pyromark-0.9.10-cp313-cp313-win32.whl", hash = "sha256:da2497ec61e318118c4f775bde5f23f76b6e47ef44246295af76fcab2b1ce6cf", size = 260663, upload-time = "2026-03-22T12:46:43.49Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/c5/8955b40669e18213ba5d58b7ec95a6656b75724a81f062f695e9ffaeca16/pyromark-0.9.10-cp313-cp313-win_amd64.whl", hash = "sha256:fc6ddd74ae34c395200858d8a66e65e9f8a36e43fec09a3d50463554811113fb", size = 273489, upload-time = "2026-03-22T12:45:41.023Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/57/441b7af981672772998774b03fc4eba4a63aa398c4ad52338a445fcf1cf7/pyromark-0.9.10-cp313-cp313-win_arm64.whl", hash = "sha256:3d2920e35cd0a07a2b8997fe6804b281f8f7893dd7f45cf75ff70947e570fffd", size = 259173, upload-time = "2026-03-22T12:43:02.519Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/f5/a97bf8edd773b711c0fffe1c59953141dd5685b35e71c57bdac276242a9e/pyromark-0.9.10-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:9f2009867ebb9bf181f7d2e77cc49bea95ca898512e09ef5476196855189b997", size = 345132, upload-time = "2026-03-22T12:44:43.218Z" },
-    { url = "https://files.pythonhosted.org/packages/79/23/34f9f42f25501fdd1b1252b8b09c6e3d28eabba2c0872ed84e098756cd96/pyromark-0.9.10-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:be2d524ca2e1581d92ceae9a825ef81c1ffe91deb543322d7258714f4466d1a7", size = 328232, upload-time = "2026-03-22T12:44:51.2Z" },
-    { url = "https://files.pythonhosted.org/packages/31/c4/5e684ee30e302141cc880f4eba00e557346423cf6b87d1c5923a2bbb8d22/pyromark-0.9.10-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ce3140396c22a95d04b11f7f16239217b3be596616e45deefb3fff1f7864dd6", size = 361134, upload-time = "2026-03-22T12:46:15.535Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/4b/40530c1f05138ce3d59d61e1614e8811e71b2de8fe67a028f940afc8acb7/pyromark-0.9.10-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:080f3608ae6af99d578a7723723cec6903fc00a63f5e3bb3502b28e51b30c2e9", size = 359130, upload-time = "2026-03-22T12:45:35.058Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/f5/896b2366ba47bac4c9c937ed1a1d1a2f422f2bb3bdbb01ae3029a343e2b3/pyromark-0.9.10-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:056ce6e78b9005fba197fab8c4f55b7a39f01b4ff97a5a818c1c60c1ba5bb8b8", size = 384873, upload-time = "2026-03-22T12:43:44.912Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/22/631bf49ec3f969ad76f9a03d0f821018e299e051b4d1be730ab503d0042c/pyromark-0.9.10-cp313-cp313t-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:bdab82e66086cb1a8e33b55fc421474497748a72069c912a3670b90ddde8aa5e", size = 416347, upload-time = "2026-03-22T12:47:53.934Z" },
-    { url = "https://files.pythonhosted.org/packages/88/9d/51749adf6d85a595deee0761c0d58a25a8e94245febacbfe9ce350127c1a/pyromark-0.9.10-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b9ed716ed6a14526d5ed96466f5dd0e75c0dabb874c76176330c7edb3f607568", size = 406490, upload-time = "2026-03-22T12:47:20.421Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/ef/2faf9d6d3480c518dbe547ff7d0e15ced1d044001a5c45daa9f4a159a6b8/pyromark-0.9.10-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d24004ebebba763d129786bfd8c0b815fe635cb6f70139f0bb2279bb6091ee77", size = 448619, upload-time = "2026-03-22T12:46:36.925Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/93/1df3b1124333a9a0300920c50e3db851289ed7fd4a479237ffe8f984d10a/pyromark-0.9.10-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:525206008f40f6c2f42c363286b39da1eb54a721161e65a71300d14c1c122c65", size = 369215, upload-time = "2026-03-22T12:44:20.979Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/53/767bda011359bea3c84db7f41585a91667ce9a54590640cd77a73dcfb4c5/pyromark-0.9.10-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d2458a58ceb281acafef97ad8ab3695cad2ab248a55a7f9fb8174491d7ec365e", size = 361965, upload-time = "2026-03-22T12:44:44.859Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/b1/7d9e5d7351511e32eeb906007f56f222f99a67d1ebe1219e29b47b071e83/pyromark-0.9.10-cp313-cp313t-manylinux_2_28_armv7l.whl", hash = "sha256:da7da71c5ed0ca129ee5b2bb6d8dd258bc3f884ccd336852e4072a48eac1601e", size = 359071, upload-time = "2026-03-22T12:45:08.517Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/91/21548fbd07fe0a377927466ff1d03dd86af1479836f65784028a342116e5/pyromark-0.9.10-cp313-cp313t-manylinux_2_28_i686.whl", hash = "sha256:7ef5e25fe5c5c461c00bf9b66cadbd62e97b8299e201effe81fcc4f48e522755", size = 385280, upload-time = "2026-03-22T12:45:28.074Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/cd/735f8e87649a831c5f845fd2cd347663bde0e32aa19c36164705791daebe/pyromark-0.9.10-cp313-cp313t-manylinux_2_28_ppc64le.whl", hash = "sha256:d629c301d22c170a3d45c39b1d492cbac03142d90010b40127757aa4bd057e97", size = 406544, upload-time = "2026-03-22T12:44:24.431Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/f9/e754f0a4f30179196e772c3e4cd16e470ca7afaa1512fa66d4639c43b39e/pyromark-0.9.10-cp313-cp313t-manylinux_2_28_s390x.whl", hash = "sha256:435cb2382bab76d871ccb54794c012bbd938ea8f5dd9872b6eb56cb7fcbc0fd3", size = 448169, upload-time = "2026-03-22T12:46:59.467Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/31/7115c6dd5025fe46a5564a030208c15aede001d63213fbcf72dbeafc5525/pyromark-0.9.10-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:630a087aea4ba2c40338cc8f95e068d9e598f3ac4b7d1c1c0f2ed9b6c2d2a8dd", size = 369593, upload-time = "2026-03-22T12:47:40.736Z" },
-    { url = "https://files.pythonhosted.org/packages/62/81/5b212f8423d1eaf8fafc2f5ad4e9251fbc9e8da6f06e140f716637d1da8e/pyromark-0.9.10-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:839b31fe481074b51c7fdd77616b278012930fc04bb2c482606274a1b82a39e8", size = 370347, upload-time = "2026-03-22T12:47:10.939Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/c8/1fa079a851d8bfe5ec1bbcdd8e03d30145f1bc5506cf45591da0430d8c65/pyromark-0.9.10-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:b4a5cbd6a0642043a2feff0bb1ab34ef482a29ec1a230d21d018ee1a1c968068", size = 539137, upload-time = "2026-03-22T12:42:43.873Z" },
-    { url = "https://files.pythonhosted.org/packages/78/ec/897782e2b6ca3c7ff5e28f3aca6627a2da7bc8e87295c967d3bd3e95691a/pyromark-0.9.10-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:0c4edb54565fab084d9ee6aa7605d2eb514b68abc544aac11a765761cd0bed96", size = 635706, upload-time = "2026-03-22T12:43:26.453Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/4a/a18c696c903ed69f57c3ab2c8e603ecbfaf263589dea72e7efaa3e27f779/pyromark-0.9.10-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:1a977273745da365b86befaa78e1eda51c028ba8d2ad249563a75d065d6beb69", size = 602739, upload-time = "2026-03-22T12:44:37.004Z" },
-    { url = "https://files.pythonhosted.org/packages/88/5e/173f025ba8752f74cddb544de7d3f4578a5bf2f3a2373b9361def469b8cc/pyromark-0.9.10-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:56a79a1ae00470125a8d0eb42cbea45c88834c11337198a75fd70cb14077192b", size = 537874, upload-time = "2026-03-22T12:46:54.483Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/cd/3740b4fd194d512a9d1f9d04d4b11acd63be59018186aecdf3f9e55650c4/pyromark-0.9.10-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:2afb6169b7f1f75f42bdc8cc07d0bf3b2312d291d6a68a1b24929cc43a4cf831", size = 544041, upload-time = "2026-03-22T12:44:13.488Z" },
-    { url = "https://files.pythonhosted.org/packages/09/50/348ea5f1b6ea36777170286de52edbc8db02824f0a0adb557d96f57934f0/pyromark-0.9.10-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c447322247f9ec4830523944ce6093377e421100bf13e5f8e6b556bcb29145e8", size = 589022, upload-time = "2026-03-22T12:43:22.297Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/3c/7981b73bf2899174141e0c89cce40b3cb5d9e2106dda77422dcc935d1496/pyromark-0.9.10-cp313-cp313t-win32.whl", hash = "sha256:ea58e51d4e0da74338575b0438d9ad68e85a373221ea3f7dd80fdbcf8ac3924d", size = 260449, upload-time = "2026-03-22T12:43:09.912Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/98/da2844c54e64448bb6817cb99fad7db368d7b04d21ce985a26ab86c389f1/pyromark-0.9.10-cp313-cp313t-win_amd64.whl", hash = "sha256:4228500fe57507f696701d1d11d9ca967fe051b62007dcdee5ae3163eda53acd", size = 273134, upload-time = "2026-03-22T12:46:34.852Z" },
-    { url = "https://files.pythonhosted.org/packages/13/c8/77739a1e32a3636fa29fdd131bdccd6ac2af60f8de4fbe40a69c3d55c3bb/pyromark-0.9.10-cp313-cp313t-win_arm64.whl", hash = "sha256:df7c3ae5ea73cccc49d5e59dca20eb6c83fca510dd38012f3027ab856e1bf667", size = 258115, upload-time = "2026-03-22T12:45:11.959Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/70/13a06c4fc45665e6dde0b248f8564bb203825e08cfbc0478014b5b8ebe17/pyromark-0.9.10-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:94d01f562ff8a54fc406bc29979d2b11189998eb76e174328ca8cfa4a9b90e94", size = 346541, upload-time = "2026-03-22T12:45:10.105Z" },
-    { url = "https://files.pythonhosted.org/packages/63/bc/ccb70805ec1fe2cfeb558154b7b85be812e32af8b65ea9e6f83590abb3dc/pyromark-0.9.10-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5cc2c96def6e49b3cb0677dffc744f6f3a24b42726cafa80bb8b072265ffa97b", size = 329370, upload-time = "2026-03-22T12:45:56.913Z" },
-    { url = "https://files.pythonhosted.org/packages/23/3b/104d5d8f75717be901587ca9df55ad9b08a5b42aa1dcce492b608e65f8cb/pyromark-0.9.10-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c00265b0d5196dfdf89a744dc9a3602d0dff3cf4ee231a07b00e9ffc615b089", size = 362589, upload-time = "2026-03-22T12:43:48.789Z" },
-    { url = "https://files.pythonhosted.org/packages/79/36/bb5232f3c5368f26c03f5ea9b906f35550a6c2c2c06526e1b06e27f1bba0/pyromark-0.9.10-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:09b14ce543da03fe3a5f4466a5fe2c456a1f59b3834e350de7b2dc16bc7e5440", size = 361138, upload-time = "2026-03-22T12:43:56.886Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/ec/2791c257ef50cc51755b7aea73c1a71f5132e5d8e9629e64207a6a03229b/pyromark-0.9.10-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:53fc86c5089e5f62585a5262eec86d7006d1fa4b36211e8f7456d8853aa73622", size = 386461, upload-time = "2026-03-22T12:43:00.301Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/93/d77635523eedba395e35ba3fb84ad32bd030a868b2d5027cb3dac1d6c8bf/pyromark-0.9.10-cp314-cp314-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:f4608eed63b0a490366f9197a4c518eb852c8084a43b0762de3603d8b687f055", size = 418428, upload-time = "2026-03-22T12:44:38.495Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/c6/84524aaf65d33e43df2be97e37e22b170772e3ba1f48744982c9923b90e0/pyromark-0.9.10-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6613e8321523e60f1427ea29061dede8333f77631bd6978898f69eac80ec3e29", size = 408915, upload-time = "2026-03-22T12:47:38.341Z" },
-    { url = "https://files.pythonhosted.org/packages/06/d3/e5a79b7127fbefa8fdce1a4b3095fb95b5cb61a6f621a60965fe07d8a93f/pyromark-0.9.10-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8f08e75cb1286476c4c67a691a4140d4022fdd4758158dfaf280eb7eefdc5edd", size = 450282, upload-time = "2026-03-22T12:43:52.915Z" },
-    { url = "https://files.pythonhosted.org/packages/69/f5/d626c2c27a1d09979b1e5228525e4d6d0b83e7c24641d0d7a477165e46e8/pyromark-0.9.10-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:60555b9bddc10f519854396dfa20922376fe90104cab9360608c13524aab641d", size = 370879, upload-time = "2026-03-22T12:43:28.999Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/2c/46f2be6f3021018a2e1199c02495b9d45f023b4874aac385ca229269e981/pyromark-0.9.10-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:a999f18b6d2c7aaf2b810444226f1929c6165af63e540cc10cfb45427712d25c", size = 363263, upload-time = "2026-03-22T12:45:13.703Z" },
-    { url = "https://files.pythonhosted.org/packages/44/0d/155555a3773eedc45839042221d9be7ee9fa689d053c83237f802d1fe038/pyromark-0.9.10-cp314-cp314-manylinux_2_28_armv7l.whl", hash = "sha256:3356dcf0f926edea50400ba906493923551e64fb3ad60bfa464e570affe8eced", size = 361156, upload-time = "2026-03-22T12:44:33.977Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/cc/fbafd7adeeaac1bfa0f223e19094a9dfc22981bbb513404d2eab0d41fffb/pyromark-0.9.10-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:7166158bf9f6e9887c7d78ca15d0ba5d467198c36460b3067f8d04c05e46a7bb", size = 386852, upload-time = "2026-03-22T12:43:07.417Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/7a/3dad5173e56ab627b842a164640702352ddd72fed44f680e470ac3685a1b/pyromark-0.9.10-cp314-cp314-manylinux_2_28_ppc64le.whl", hash = "sha256:5f6667f5f6eb271a60f7e33afceb352b949cd914dfcd36ac409bc2bb54a4733e", size = 409029, upload-time = "2026-03-22T12:45:46.748Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/4a/c821cd96796f084b4be97e3bd3235c7b5e6ec4de6344db90dc73e97fbce3/pyromark-0.9.10-cp314-cp314-manylinux_2_28_s390x.whl", hash = "sha256:4f7d5907733b08fb1c37ac2188a99e7576b4ff833865da9032463935a3715b4e", size = 450565, upload-time = "2026-03-22T12:47:59.265Z" },
-    { url = "https://files.pythonhosted.org/packages/df/92/e80ffbda699f761bec5fd0c58043ddbbe7bdbec35a199a471b97e9192695/pyromark-0.9.10-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:a446ee22bc5430e667ec4abbc8daf7a6811ed5d61f0a87215af417c4ab2cd328", size = 371130, upload-time = "2026-03-22T12:46:49.769Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/69/4a7ea487efc4734951286df570bcd6316152d64cdbdce7a0d32348f32579/pyromark-0.9.10-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:47d70ec0405bc47e661b151104c2ebab5455c1b93326ef4756a782bd84aa41db", size = 371905, upload-time = "2026-03-22T12:43:24.938Z" },
-    { url = "https://files.pythonhosted.org/packages/02/54/52720922cd0c9f98b3e52585d440f50288fbcafee133a508a29ca595b68b/pyromark-0.9.10-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:706a11371fd5eabbe78c7eaade837868c070d0bb20be216ecd27dcb832ccbc47", size = 540391, upload-time = "2026-03-22T12:43:46.344Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/37/c4554802798edde50e8364c63182832b198abec9d97720fd36ca87cae5ca/pyromark-0.9.10-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:838841ff13ea93742318b4e2396dc0f445ad295e0aca62404b4e2a801645fefc", size = 637637, upload-time = "2026-03-22T12:43:18.24Z" },
-    { url = "https://files.pythonhosted.org/packages/43/dd/99eaa1eee23c2dbf7ab475c7f44e9cb70586f2373a9727f6e75e451e7bbf/pyromark-0.9.10-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:b8bed724baef6ee5adf2fadf9226a598749882254337a9ea769b44b00a18725c", size = 604527, upload-time = "2026-03-22T12:47:01.763Z" },
-    { url = "https://files.pythonhosted.org/packages/67/3e/e930312b3c18ea02dc10691e1156b130d7bf03afffb1ca57384d4f9d944e/pyromark-0.9.10-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:dbb1566788a2e5d53ca21e00fe6cf69b70b9ed2c8f690b0c389d6c67e7398fe5", size = 539457, upload-time = "2026-03-22T12:45:02.895Z" },
-    { url = "https://files.pythonhosted.org/packages/69/b6/5f22b048e2aa9adb7afd2431fb4b6e561e3a9912812c348798c1515f1bf3/pyromark-0.9.10-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:88aba6fedac5b9f4f44240a10321a937fdd374ee7197a78c231eadb694ceaab5", size = 546052, upload-time = "2026-03-22T12:43:51.441Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/6f/6670aa0f861c51df6cae4322658fc90d307d54043ce0b53b8f24018c2a0e/pyromark-0.9.10-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:369a20d208acb7b5dde8c7512e4464d0bc6a8e53ef07dc9007ac885404cb85d7", size = 590284, upload-time = "2026-03-22T12:46:00.898Z" },
-    { url = "https://files.pythonhosted.org/packages/23/f7/d7bfb15d0e95c33f0b95caa9b349b99b479a5cbbdb54f4d1d70d6fc1ed3c/pyromark-0.9.10-cp314-cp314-win32.whl", hash = "sha256:d63eec43df5a436c252dd8aafbb939f22fe3d5fadb62c43c34c33544576de730", size = 260700, upload-time = "2026-03-22T12:43:14.571Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/13/5a7f2a43776c06e89479580f2239eff39d76ae811dbabe7123e16454cb3d/pyromark-0.9.10-cp314-cp314-win_amd64.whl", hash = "sha256:8cff3c5394127e4b89928b3c38a5a27fc28bf45a28cfd94554e0eae4aab9d949", size = 273208, upload-time = "2026-03-22T12:44:29.41Z" },
-    { url = "https://files.pythonhosted.org/packages/30/9d/36bfd3da4ac10287c6112d259f1c34a5fc6fb3da53b1bf392440608e414d/pyromark-0.9.10-cp314-cp314-win_arm64.whl", hash = "sha256:00c92b76ef117e7b78f966a5607748990e2fd168a71bb0509df0270fad106204", size = 258954, upload-time = "2026-03-22T12:46:41.169Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/bb/5a9136f50748656bf53391df524157d5e3cca7188fd00ca3f7aec1f011b7/pyromark-0.9.10-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:e994e6b010d62293130c30fb8fa25415a6e7a5940052f92b675d1b4e3334c968", size = 345113, upload-time = "2026-03-22T12:45:31.615Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/9b/7c484479541b978f76f5547598f7cf741aa918508bc7d2d4aa795fa56bcd/pyromark-0.9.10-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:339140de786303d0703f114b4a575d837b52df62bff927a03763d38aaeae93c2", size = 328128, upload-time = "2026-03-22T12:43:30.427Z" },
-    { url = "https://files.pythonhosted.org/packages/89/2a/1683c462a8308fdb0f88cb17f0e7f5f8cad7eda8235df8bf4ffc77bd7ff2/pyromark-0.9.10-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:898d705905056159d63a10355bbc20e60e4f2a595f6aca3eaeebdecad533f15e", size = 361106, upload-time = "2026-03-22T12:44:02.486Z" },
-    { url = "https://files.pythonhosted.org/packages/14/b8/44c1d373a4ac682cf08f5346636fcd5810d438d03de1f24a9ea636b41441/pyromark-0.9.10-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e3f32f704c185489329c5f8b374ea3e0cfbf5a130b66450a4a2369d028bab674", size = 359208, upload-time = "2026-03-22T12:44:16.195Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/8b/8c82e2cb52a4f0855fe72c3defa9ffb7656bf2b29e031fd50b11b1c12127/pyromark-0.9.10-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b5015d8b169e0039959c39d5715d1fc419b9800dc544e60d50b04e8cd19c8623", size = 384654, upload-time = "2026-03-22T12:42:39.493Z" },
-    { url = "https://files.pythonhosted.org/packages/86/44/c212870714378038be8a2284eeaf6f402e49fc66b6e66145ab0811b17df3/pyromark-0.9.10-cp314-cp314t-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:27fa2a36bfcc2a16d6b28a5839be471f18c5e780f70642e5cf8a2ffa8985d1a0", size = 416113, upload-time = "2026-03-22T12:42:58.993Z" },
-    { url = "https://files.pythonhosted.org/packages/41/97/8f3015c15f14dcda13026410d847db6e845afef297aee6f4e97f9ba9a17b/pyromark-0.9.10-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b3e92bdfb9ac46a829fe605ebc8516ca0b2af30cd6f55710bc1840dcd904abba", size = 406520, upload-time = "2026-03-22T12:47:13.468Z" },
-    { url = "https://files.pythonhosted.org/packages/af/37/0f576a466b4ea5d4b6c351686ecb9737130cbf17a9ffcab181a0c043581f/pyromark-0.9.10-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dc7761df494e42444de2720398d511e69200c69dee4825717b34084a3438f407", size = 447975, upload-time = "2026-03-22T12:45:33.327Z" },
-    { url = "https://files.pythonhosted.org/packages/84/c5/e8dd51d416dbbca5c69338dea70622aa38d24b23e4b6b1296f67c4663ed8/pyromark-0.9.10-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:88554879a603c1b12451507e80133ee7496aa31bb91e32a4c203df7a75e77d01", size = 369190, upload-time = "2026-03-22T12:43:47.557Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/3f/4791c4aab3f25552be92437df1dc29805740abafe8c0b4010a3ae59bf5df/pyromark-0.9.10-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:3565ad65a60ea637558d1a11c69a3aa1f0e089f4c74cc8da3466154a77513a32", size = 361852, upload-time = "2026-03-22T12:47:23.156Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/ca/22d3ae1e7553425652c18459922182cdb465e4a68e2211f2a10f3597c00b/pyromark-0.9.10-cp314-cp314t-manylinux_2_28_armv7l.whl", hash = "sha256:3e9e5b451432d019a5301f91d16916c434bd9a178bb3b19367bd57fc9208de3f", size = 359112, upload-time = "2026-03-22T12:42:38.59Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/86/2ad78b301a6661000f05714b435b3412cdba073151aa9fb375c544b83f31/pyromark-0.9.10-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:27c403034795367ccc318f723cec3d1c63d26fd1b0c4d6b7d5867f5d42520138", size = 385027, upload-time = "2026-03-22T12:46:09.345Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/e7/6ca82f55c55799cc6b13b2f129318fb7d6abcf39d15d9be88b793bbe9afe/pyromark-0.9.10-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:8c84d1dba7abd6404f35655a676172bc5ae1f1f97f6e39c5eb9bf0c864e5b1a8", size = 406499, upload-time = "2026-03-22T12:44:41.55Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/52/d81dd65198b7a6bd952e5187d391d4837a5dbfda834938c16933809efea8/pyromark-0.9.10-cp314-cp314t-manylinux_2_28_s390x.whl", hash = "sha256:582150c7bc05e5df8ef962614c36e1321f9a3d7c07ed3c410ecd65aed74e96d4", size = 448287, upload-time = "2026-03-22T12:44:59.464Z" },
-    { url = "https://files.pythonhosted.org/packages/10/ad/71c4b8e41b7a27ab2e21de453145cc7ed9e5f869d532683669c85e991169/pyromark-0.9.10-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:b9e90ac2e18aa6feacdd3e92647e47ed0a433d4d1f918466b9f4b9aa7f95b46f", size = 369471, upload-time = "2026-03-22T12:47:35.881Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/bb/6f82599d4407a671f7f797d98ebb53c9184c802e1d58111d5a71be77ef71/pyromark-0.9.10-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f58de15053efc81d55757316191aad53128d52b47e2399d1f71aa4a773d3b23b", size = 370239, upload-time = "2026-03-22T12:44:11.823Z" },
-    { url = "https://files.pythonhosted.org/packages/12/b0/6a49b2af6568c11e0e4ee9203a76e010ab35b510a78a6b0efa4c7a1d022b/pyromark-0.9.10-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c7af63a1d56981aebff37fc075573346c252b5f78d0091b01ddd0478068a4b18", size = 539108, upload-time = "2026-03-22T12:44:35.504Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/3e/f635c494a15f2bb5c944366c0199d101ccf77eedbdc1fce7a6838a301a11/pyromark-0.9.10-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:770836297d0cca34e2c85b083fb4e7b8314cbe4588f313bb61838d02bb879656", size = 635605, upload-time = "2026-03-22T12:46:39.01Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/d2/2648d624c8c666986aa3b15cd1f3d6089e443e13ce2d06781e5ffa844909/pyromark-0.9.10-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:6ee98e2a1a71f7482ca76fc0ee82d188de49d4aeb38134bfb618eb4ff897c5f0", size = 602635, upload-time = "2026-03-22T12:44:52.847Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/76/7bfa77613f9928cfc729571e1289af10e946f493afa2193b9cab32ecef77/pyromark-0.9.10-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:fc8e5727eb1f25053f63cb811c4df080e44855b9f9ae0c0353f57ab3eaec8673", size = 537854, upload-time = "2026-03-22T12:43:01.408Z" },
-    { url = "https://files.pythonhosted.org/packages/94/3e/b651e682b618d03136eaf226938926f19c289bcf3301b5598d0ee5cbcd52/pyromark-0.9.10-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:44a4d21becf02bbc9663284e33a393f7fdbc460ef98dda451406f4342027f774", size = 543902, upload-time = "2026-03-22T12:42:28.363Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/8b/885f4c7b1581cd9850a7913fdcc46da89926caa5b72effa6aaa80cc76da5/pyromark-0.9.10-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:274b2c785e4a33b66646b6980ea3bc5fb0b3d04cda316cc6e3c3f0ea7986e14d", size = 589002, upload-time = "2026-03-22T12:47:43.172Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/8c/fd6716ce80e5c1b981ba83239e21f6a705eae4aa9036b0612c563a3cebd9/pyromark-0.9.10-cp314-cp314t-win32.whl", hash = "sha256:016fa16b4926bd4bb8e21409e3f66ab94a54e165e2b381f4217125babb82f50b", size = 260320, upload-time = "2026-03-22T12:42:50.392Z" },
-    { url = "https://files.pythonhosted.org/packages/17/06/d1d1ac2ad634bab28535d226758fa8753d76d96f225c1e662d2b55205550/pyromark-0.9.10-cp314-cp314t-win_amd64.whl", hash = "sha256:5dc38aebcb81a6d86d6e0d80ffbe194aae443d5072eff6dc65908ba608719071", size = 273015, upload-time = "2026-03-22T12:42:37.534Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/35/b28e282e79e0c3009b0e23912953d18f569982d83b11849a85d1ac6d33d5/pyromark-0.9.10-cp314-cp314t-win_arm64.whl", hash = "sha256:a92de094e7f9c0e62910d8859bef6362baa1c0f170abcee48d67d6f8f3a68308", size = 258076, upload-time = "2026-03-22T12:47:06.217Z" },
-]
-
-[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1491,18 +1323,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
-]
-
-[[package]]
-name = "telegramify-markdown"
-version = "1.1.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyromark" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b0/94/0b29f09c3c9d28cd7b8790c4bc8aa805b126ece87f2ddc5d0c28dc9cb922/telegramify_markdown-1.1.1.tar.gz", hash = "sha256:0fc66835b889e156ef47aa1c70a215368f9673f86cac23e539f5d9fa923a4c35", size = 58615, upload-time = "2026-03-18T04:05:12.865Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/6d/71552ae1f5e959d36c9943ec5a04063ec9db69f9d524643c41a92ba422e7/telegramify_markdown-1.1.1-py3-none-any.whl", hash = "sha256:860348bae4e4e107b3fc02333ff3f592888b1e6bd9da8291aaf210e094dbd005", size = 41506, upload-time = "2026-03-18T04:05:11.636Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -205,7 +205,7 @@ wheels = [
 [[package]]
 name = "bub"
 version = "0.3.1"
-source = { registry = "https://pypi.org/simple" }
+source = { editable = "../bub" }
 dependencies = [
     { name = "aiohttp" },
     { name = "any-llm-sdk" },
@@ -218,12 +218,44 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rapidfuzz" },
     { name = "republic" },
+    { name = "requests" },
     { name = "rich" },
+    { name = "telegramify-markdown" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/16/f0/767166fc7c5076c0f2a013e8606ddd49f0ce772aacce1f2d4938ae378fc9/bub-0.3.1.tar.gz", hash = "sha256:4990cfc9f76d5596a34bcc64476eff61df9465cf306ece72c2059f7a2b3e39ae", size = 80457, upload-time = "2026-03-22T10:57:48.965Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/5e/6453364d825859d37ac8cd5634fd115daf91c767cf9eac6897b943239bf4/bub-0.3.1-py3-none-any.whl", hash = "sha256:acdb28440309ecb94fdb059647880a464ab0588463436e8298dcceaf5fc72320", size = 77399, upload-time = "2026-03-22T10:57:47.873Z" },
+
+[package.metadata]
+requires-dist = [
+    { name = "aiohttp", specifier = ">=3.13.3" },
+    { name = "any-llm-sdk", extras = ["anthropic"] },
+    { name = "loguru", specifier = ">=0.7.2" },
+    { name = "pluggy", specifier = ">=1.6.0" },
+    { name = "prompt-toolkit", specifier = ">=3.0.0" },
+    { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "pydantic-settings", specifier = ">=2.0.0" },
+    { name = "python-telegram-bot", specifier = ">=21.0" },
+    { name = "pyyaml", specifier = ">=6.0.0" },
+    { name = "rapidfuzz", specifier = ">=3.14.3" },
+    { name = "republic", specifier = ">=0.5.4" },
+    { name = "requests", specifier = ">=2.32.5" },
+    { name = "rich", specifier = ">=13.0.0" },
+    { name = "telegramify-markdown", specifier = ">=1.1.1" },
+    { name = "typer", specifier = ">=0.9.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mkdocs", specifier = ">=1.4.2" },
+    { name = "mkdocs-terminal", specifier = ">=4.7.0" },
+    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.26.1" },
+    { name = "mypy", specifier = ">=0.991" },
+    { name = "prek", specifier = ">=0.3.1" },
+    { name = "pytest", specifier = ">=7.2.0" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "ruff", specifier = ">=0.11.5" },
+    { name = "rust-just", specifier = ">=1.42.0" },
+    { name = "tox-uv", specifier = ">=1.11.3" },
+    { name = "types-pyyaml", specifier = ">=6.0.12" },
 ]
 
 [[package]]
@@ -238,7 +270,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bub", specifier = ">=0.3.1" },
+    { name = "bub", editable = "../bub" },
     { name = "lark-oapi", specifier = ">=1.3.0" },
     { name = "weixin-agent-sdk", git = "https://github.com/iodone/weixin-agent-sdk" },
 ]
@@ -1110,6 +1142,142 @@ wheels = [
 ]
 
 [[package]]
+name = "pyromark"
+version = "0.9.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/d1/79622b7d164490a02066a74e4a710d931c1252aea225640bd4453cce2310/pyromark-0.9.10.tar.gz", hash = "sha256:87a2a8e01e4214014a5697f87c9afd3563e2e2623e2926d97e9535651cae2c07", size = 9066, upload-time = "2026-03-22T12:47:18.26Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/2f/81fbd40eaf1914fa484096d83e37f9da2284b20a1ec8fb60f40ed35ac575/pyromark-0.9.10-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:73c6329ab75921d1853de52c0b0af1630218fd90ba29baf03fdfa6158c75639a", size = 346942, upload-time = "2026-03-22T12:43:17.139Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/3e/acac3b2129227d091311c5e7c064f8a6655041ed72e31e5349ca2fe7c15e/pyromark-0.9.10-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:11614f83f81a339c639c7a5ef33f78d40b0769ffc30fb57cad967ada447cd69a", size = 329828, upload-time = "2026-03-22T12:45:19.011Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/db/5756831650054597fcf23e27b425703dff21840fd7cd7ceb3ad0bba6a0d0/pyromark-0.9.10-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fe5a06515e5ef71e42d484e6cf2d69198689f660ed76fbbe0139cc59c7825742", size = 363246, upload-time = "2026-03-22T12:46:03.121Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ad/fe3024b4e475392468620bb7e9c4e9982c159bdb0c8a16e6bb95c726d610/pyromark-0.9.10-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3044e618ffb279725e5f6a9e13e849125c9d446ae7dbb52050f981891e59b5a0", size = 361930, upload-time = "2026-03-22T12:43:40.715Z" },
+    { url = "https://files.pythonhosted.org/packages/67/a1/614b4a19b114acb2c74650de48b22eee139d5ba84bacc00a469714434b68/pyromark-0.9.10-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c6ae5ea96dbe2b2eaf534ad20b12a752926b5d575adc704d308402bed5552aec", size = 387086, upload-time = "2026-03-22T12:46:57.005Z" },
+    { url = "https://files.pythonhosted.org/packages/73/3a/7a5bed0f2c518a0a6c6d8910a01e5b971c09c673614e121dfd8c3d7cb795/pyromark-0.9.10-cp312-cp312-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:306e60834ddaa55578b908dce1b73fe11d8552c867399e0f6f73de4e347a21a1", size = 418898, upload-time = "2026-03-22T12:43:34.248Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/a7/d9f2498c0b3593e97cca70e8abb92985fca1abf6a94b02dcd307fa9ce48b/pyromark-0.9.10-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b312a37c628bd3e34edb465aec85c4022e1ddffd938f231961515b402d0457cf", size = 409937, upload-time = "2026-03-22T12:42:42.527Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/bc2ba0e806d44601370865e7e81ef35d5ec0902b7160b5c7beaff4b2dcbe/pyromark-0.9.10-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1ec705a0cedff51ad99941ad881965d8d88ef499f8f8a4dac52b7e6d73f3e252", size = 451509, upload-time = "2026-03-22T12:44:57.809Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/7d/f2e3b52bae22b530e4ffc1f56dcaaacfae3ae25acf4b89453ba35bf917e4/pyromark-0.9.10-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:013650245157ce435816dc2f66116c36e9103453165fe1a58fe712b65cb88ef7", size = 371722, upload-time = "2026-03-22T12:47:56.482Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/9a/83d63ef009515af352eaea34fc64f3e077cb8a88063629500855f82302ce/pyromark-0.9.10-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:b6aa487af21ee3f8f389d7ebe1cee346092d15ce63a6ed85b07515337310a305", size = 363888, upload-time = "2026-03-22T12:44:32.57Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7d/9fea010b3f337016c03e574155f19fe52b7f73238bfcaef9ea5d8a2ad48a/pyromark-0.9.10-cp312-cp312-manylinux_2_28_armv7l.whl", hash = "sha256:a4d51cb6e3ac8edff4a649e5b826d0929b630316a90ed495be3824c465551954", size = 361916, upload-time = "2026-03-22T12:44:03.891Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/10/938d96100d37f98ad65888a4990d3310d08b18e4dc3270cab3b19b7c85f7/pyromark-0.9.10-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:f985f00dd7813e3ec6a2bbbf085404e7ed574edc364f71aec2c98005075f6aa9", size = 387383, upload-time = "2026-03-22T12:45:42.807Z" },
+    { url = "https://files.pythonhosted.org/packages/18/7a/48330440c1b062ed9fbfcae4b424d57c8de26a935089a02f5114dabb87f7/pyromark-0.9.10-cp312-cp312-manylinux_2_28_ppc64le.whl", hash = "sha256:9c40414c044c7f48a116a9a5e843d7d2f4035d815c8bb4853eea9cd8c001df7c", size = 410047, upload-time = "2026-03-22T12:44:26.211Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a3/16a6fc3caea432d557189ae0b64d7da2a377157df8e832dd4e664d892615/pyromark-0.9.10-cp312-cp312-manylinux_2_28_s390x.whl", hash = "sha256:b1ccab87e071de956929edbf7c3b14751fa9e0fb9b71ea2d2d66bfddd363b7f6", size = 451080, upload-time = "2026-03-22T12:42:47.658Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/6a/5a5e5677f66d416252650f2dbaf29806ef92b7017e616b2259b7f5cbecdf/pyromark-0.9.10-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:a9377e0bd45cfcacb66135375fe1305f549dbfdb8ed189740cba465ecd74b6a0", size = 372032, upload-time = "2026-03-22T12:42:46.261Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/6d/cc6b9b83f9e8b87b8997740dfd0e793ac4477f6fa897684cf5dabfe6e82f/pyromark-0.9.10-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:a580159ed41f1176f355375d0723a2d9d6249c8ab3cf21e8da8c4b5f80cf8f90", size = 372541, upload-time = "2026-03-22T12:43:13.461Z" },
+    { url = "https://files.pythonhosted.org/packages/17/53/a1ef122bade959b7f0a2e5c15f14d9b551723f420104532f821861c84af6/pyromark-0.9.10-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:442b9147c3ad6a7a66db6ffcb44e03ee90ac965b807d67e99f3b80f4705d5e0b", size = 540788, upload-time = "2026-03-22T12:42:55.056Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/94/cfeef8c0fd953e6b4fcc922594ba33c74324949e65a40d89198885143f2e/pyromark-0.9.10-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:daa313fbeba07eaf893c38252fd23d1f33071fbd7373b7d6bc8ad9e0d25a80e5", size = 638367, upload-time = "2026-03-22T12:47:45.988Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/b6/5591cfe0092427f9d718d17a18226971cbc52f088dd108e335a6d5c3c056/pyromark-0.9.10-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:64203fe6a2ffda13eb7280e229a30206e9174417aee1f836ecf1a49f78690414", size = 604956, upload-time = "2026-03-22T12:44:05.264Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/8f/23c4848bfb0eee774b8c6ac86fbd634464c7a71895a688b1cf0dfcac5598/pyromark-0.9.10-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:fc352f3257023beb72b1d5d66b2bb831c19588914acb1b653b9e9e77934cad1e", size = 540616, upload-time = "2026-03-22T12:47:25.576Z" },
+    { url = "https://files.pythonhosted.org/packages/25/f9/768acacf22e94ebbbf6c88bf2c335aa77791f12dcdb9e864fcf841aa7180/pyromark-0.9.10-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:be7366ad2736652a5ff32cad75c8b9c532769b8895ed9e49f709fe75578615a7", size = 546625, upload-time = "2026-03-22T12:45:20.759Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/d8/64f2844100adda4330eea2260755cbd33ad3f73b9fca1267bff738c08cb5/pyromark-0.9.10-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7ca386b4450366d36c618610022d9e7dae318978a7a0ae19ab75298914d1f31c", size = 591017, upload-time = "2026-03-22T12:45:53.004Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/09/7cc1f7497f16423ea120a131605cdaa23b318120ff6049b505e522b95b1e/pyromark-0.9.10-cp312-cp312-win32.whl", hash = "sha256:44a95c55b94f8d5a129a1288889d699feca19120be8e46bacd9b63f44db4f3aa", size = 261067, upload-time = "2026-03-22T12:43:32.776Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/b5/1547f1a8fb910d3c8d37cbc1b5a1d69ac222970cff20404701803f2b525e/pyromark-0.9.10-cp312-cp312-win_amd64.whl", hash = "sha256:0218905b27b735dd2c792414ca26fcb1e78ccc35e0911807a4901af61f4c7efe", size = 274046, upload-time = "2026-03-22T12:45:24.671Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/51/7bc6b4c2ac2e8b82765de7fda81df5830ec9dadcb376e34552f3eb1988ad/pyromark-0.9.10-cp312-cp312-win_arm64.whl", hash = "sha256:46fd29653024ee209de5c83948201f6d967a2fa564cd942f6220f6c4cb76567d", size = 259589, upload-time = "2026-03-22T12:43:35.958Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/d4/4566556252a50810f484562548683b8a5526fd99e609cf4fc7a2b6cb0e55/pyromark-0.9.10-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:a52d398af8abcde5a46764a2144e1780f7f10862c7dd61b1cf9fb43485a51f21", size = 346503, upload-time = "2026-03-22T12:46:32.362Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/af7535545681f1301991f56947fd92c10824de02237587735a0d6dd0634b/pyromark-0.9.10-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e52bfed0818dbbc69b623099cf0d3ae1f45dd6e6ba6955adf715740edfd83727", size = 329460, upload-time = "2026-03-22T12:44:56.07Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/2b/bf3461f047ef5c28df0b6a487296fc448e8ac24d5b1f6658c39f7acee059/pyromark-0.9.10-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a6d890912d14b37f960727c2ee9063f1882f2577898d48fd957711d1f8f1e923", size = 362872, upload-time = "2026-03-22T12:47:03.962Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/eb835944c7b2cc32f0d268aa0552e5859fed3e71f0255cbff306af27c13a/pyromark-0.9.10-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d66c73f516f5090243e4b9b7ef81315cfcd792723365de035c6cfd8376a867c7", size = 361327, upload-time = "2026-03-22T12:46:13.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/90/9e89897fd193497b3cedf23f4b01b361eedd370aaec22d0542b287d94bcb/pyromark-0.9.10-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0b1d7348c9f7ac224b9b95f41956dfa61c306d8f6fc5bb431d61167b59e04c98", size = 386656, upload-time = "2026-03-22T12:43:42.316Z" },
+    { url = "https://files.pythonhosted.org/packages/63/0c/68788c2994a03f5f4c935dbf95f1e6ae3b5b747e59229604b34f427ed401/pyromark-0.9.10-cp313-cp313-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:0e1b54775f9225f086b87c6dcf7e181f04e30d7527e598131030886c1e7ebebf", size = 418232, upload-time = "2026-03-22T12:46:24.105Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/c3/fb1dcd730ea245df66ddb90e6e805a362a0fde782f82e1ee9c11a3758722/pyromark-0.9.10-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f3ad41e294c7c92b25a44b432a926300a883da8550ada49afb778ea9da8a22c5", size = 409160, upload-time = "2026-03-22T12:44:46.355Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c1/43c8c9c995e436445f146bb67f92b31f59ae031bdf8565bd9ffdabc22b95/pyromark-0.9.10-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4f4d6821d177e7cb3e8502260a90fc5b6b5f68770930d34b639318c709dfb176", size = 450994, upload-time = "2026-03-22T12:46:28.223Z" },
+    { url = "https://files.pythonhosted.org/packages/20/4a/f2f80f485b5e8f37a90b1d5b50a4e5333b9eb2238016e54613f7f70d5231/pyromark-0.9.10-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:df2f966fcdbc0a7297d34a2123aab9f99fa2d5e405a708d628ad5563807f3332", size = 370891, upload-time = "2026-03-22T12:45:50.455Z" },
+    { url = "https://files.pythonhosted.org/packages/86/71/0821b90cf605ed526ff19d0f90637144d099caa14813b941d0422a3d8945/pyromark-0.9.10-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:929ec243b426961b71393f3ca982d544ea503bbf417f9678b69407b4b457cb41", size = 363588, upload-time = "2026-03-22T12:42:27.211Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/87/f7ec775b3968180f387fa2c148612be5b010b9bbb7ff4ff8afc4694cfe87/pyromark-0.9.10-cp313-cp313-manylinux_2_28_armv7l.whl", hash = "sha256:6784c08b52bf9690382aca58881bad03ca789c3280ef695f333fba03ebe9d1db", size = 361276, upload-time = "2026-03-22T12:47:33.532Z" },
+    { url = "https://files.pythonhosted.org/packages/29/fa/ef9d643a204ae938c2a5adf0c41719c8c142d162c06b111583a9935d4f4d/pyromark-0.9.10-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:b7f0207b9a1b6626e2f3c00bad32e2713700ff8e540689677889f91043f6811f", size = 387049, upload-time = "2026-03-22T12:42:25.558Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/21/4293ed32493c3174be57644692f7eed52bcfe3f29e02d1c710909972e34f/pyromark-0.9.10-cp313-cp313-manylinux_2_28_ppc64le.whl", hash = "sha256:ad14b10efe77b788f61837db49d3cf7ae67db696a7edff7dfb3c0eff01c32069", size = 409304, upload-time = "2026-03-22T12:44:54.542Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/7f/0e8245e5459057e335f05a05f5114edc87de9a1b49ad3094335565d166bd/pyromark-0.9.10-cp313-cp313-manylinux_2_28_s390x.whl", hash = "sha256:ece3c4d0168277c8ac8f197baec47456e8a229ff41e9e6699de57ffa31abf650", size = 450598, upload-time = "2026-03-22T12:42:35.156Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/9d/ad827228441bc0a06bcbc8d2f30385ea4ca1c03255700e618e207551741c/pyromark-0.9.10-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:75a4f6849236f53adda853cb4cbc6d0e8263c5e61c6afdab4089208ad0436052", size = 371341, upload-time = "2026-03-22T12:43:03.533Z" },
+    { url = "https://files.pythonhosted.org/packages/64/af/a1a7b27e9b95240e5adfd4a80b5d2e57ae899ae10bd04ee9cee23347f63f/pyromark-0.9.10-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:d4a28da24ef81aac7f3c0ef799f351eff4f82bea25df9b0149563a374301193b", size = 371943, upload-time = "2026-03-22T12:45:04.825Z" },
+    { url = "https://files.pythonhosted.org/packages/32/1b/b60fc82aee1d8c65c31d35be67fcf87e6e80986c100c2ffbe96455c42ac1/pyromark-0.9.10-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ea6581b9ac2c0c17daad37d64cf6ece482cb9b40267117be85fadf09ac0b3206", size = 540593, upload-time = "2026-03-22T12:44:22.72Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/30/0cc9c2a0d88dc42aa49ef5ca735a2a5e68c6f5616236552f622227a9e3c3/pyromark-0.9.10-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:7e7c29e94f88d23b9ce6aa5fcc8a32a9fb1f1d3b7f2de7f441b01548156087dd", size = 637784, upload-time = "2026-03-22T12:42:53.681Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/96/53f7fa6033acfa644d918e1f64c1d9fed6d49ae0f7591f9eeb15a3c5312c/pyromark-0.9.10-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:93cef16fb1bd62c5a8b751b2575bb5c47ef48c894b3f6882472638b2a2d9bed3", size = 604605, upload-time = "2026-03-22T12:43:04.627Z" },
+    { url = "https://files.pythonhosted.org/packages/54/df/b308539b6718ef0888510ef7ac5fdad476f880350adf28d1d5057985b2dd/pyromark-0.9.10-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:2ed700d5e181552ec1c9af57a90728acf5045343a96c55fee84d4b111cbcb816", size = 539705, upload-time = "2026-03-22T12:45:58.942Z" },
+    { url = "https://files.pythonhosted.org/packages/76/6a/739dc1c4fd6c8892966d8b5ee43a75d6ca65bba0fa7b570eef300d011820/pyromark-0.9.10-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:919aab36bf53292b9da27e1950bc1470dc277696785755cca5c66ac8ba125fd3", size = 546076, upload-time = "2026-03-22T12:46:30.322Z" },
+    { url = "https://files.pythonhosted.org/packages/07/23/167efcd3f6f779a1cf824167339adec0a8c394eb52377b6fa9727babb237/pyromark-0.9.10-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bf9d7ed83231ebfe0d3fa2dc58f3c3d9d642924fbd57030e5bede99df0937da0", size = 590416, upload-time = "2026-03-22T12:45:54.908Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/59/a7783779612f5c69e35c22872e14808aa57e4d5d3f224223e4e862f88e59/pyromark-0.9.10-cp313-cp313-win32.whl", hash = "sha256:da2497ec61e318118c4f775bde5f23f76b6e47ef44246295af76fcab2b1ce6cf", size = 260663, upload-time = "2026-03-22T12:46:43.49Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c5/8955b40669e18213ba5d58b7ec95a6656b75724a81f062f695e9ffaeca16/pyromark-0.9.10-cp313-cp313-win_amd64.whl", hash = "sha256:fc6ddd74ae34c395200858d8a66e65e9f8a36e43fec09a3d50463554811113fb", size = 273489, upload-time = "2026-03-22T12:45:41.023Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/57/441b7af981672772998774b03fc4eba4a63aa398c4ad52338a445fcf1cf7/pyromark-0.9.10-cp313-cp313-win_arm64.whl", hash = "sha256:3d2920e35cd0a07a2b8997fe6804b281f8f7893dd7f45cf75ff70947e570fffd", size = 259173, upload-time = "2026-03-22T12:43:02.519Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/f5/a97bf8edd773b711c0fffe1c59953141dd5685b35e71c57bdac276242a9e/pyromark-0.9.10-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:9f2009867ebb9bf181f7d2e77cc49bea95ca898512e09ef5476196855189b997", size = 345132, upload-time = "2026-03-22T12:44:43.218Z" },
+    { url = "https://files.pythonhosted.org/packages/79/23/34f9f42f25501fdd1b1252b8b09c6e3d28eabba2c0872ed84e098756cd96/pyromark-0.9.10-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:be2d524ca2e1581d92ceae9a825ef81c1ffe91deb543322d7258714f4466d1a7", size = 328232, upload-time = "2026-03-22T12:44:51.2Z" },
+    { url = "https://files.pythonhosted.org/packages/31/c4/5e684ee30e302141cc880f4eba00e557346423cf6b87d1c5923a2bbb8d22/pyromark-0.9.10-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ce3140396c22a95d04b11f7f16239217b3be596616e45deefb3fff1f7864dd6", size = 361134, upload-time = "2026-03-22T12:46:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/4b/40530c1f05138ce3d59d61e1614e8811e71b2de8fe67a028f940afc8acb7/pyromark-0.9.10-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:080f3608ae6af99d578a7723723cec6903fc00a63f5e3bb3502b28e51b30c2e9", size = 359130, upload-time = "2026-03-22T12:45:35.058Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/f5/896b2366ba47bac4c9c937ed1a1d1a2f422f2bb3bdbb01ae3029a343e2b3/pyromark-0.9.10-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:056ce6e78b9005fba197fab8c4f55b7a39f01b4ff97a5a818c1c60c1ba5bb8b8", size = 384873, upload-time = "2026-03-22T12:43:44.912Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/22/631bf49ec3f969ad76f9a03d0f821018e299e051b4d1be730ab503d0042c/pyromark-0.9.10-cp313-cp313t-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:bdab82e66086cb1a8e33b55fc421474497748a72069c912a3670b90ddde8aa5e", size = 416347, upload-time = "2026-03-22T12:47:53.934Z" },
+    { url = "https://files.pythonhosted.org/packages/88/9d/51749adf6d85a595deee0761c0d58a25a8e94245febacbfe9ce350127c1a/pyromark-0.9.10-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b9ed716ed6a14526d5ed96466f5dd0e75c0dabb874c76176330c7edb3f607568", size = 406490, upload-time = "2026-03-22T12:47:20.421Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/ef/2faf9d6d3480c518dbe547ff7d0e15ced1d044001a5c45daa9f4a159a6b8/pyromark-0.9.10-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d24004ebebba763d129786bfd8c0b815fe635cb6f70139f0bb2279bb6091ee77", size = 448619, upload-time = "2026-03-22T12:46:36.925Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/93/1df3b1124333a9a0300920c50e3db851289ed7fd4a479237ffe8f984d10a/pyromark-0.9.10-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:525206008f40f6c2f42c363286b39da1eb54a721161e65a71300d14c1c122c65", size = 369215, upload-time = "2026-03-22T12:44:20.979Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/53/767bda011359bea3c84db7f41585a91667ce9a54590640cd77a73dcfb4c5/pyromark-0.9.10-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d2458a58ceb281acafef97ad8ab3695cad2ab248a55a7f9fb8174491d7ec365e", size = 361965, upload-time = "2026-03-22T12:44:44.859Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/b1/7d9e5d7351511e32eeb906007f56f222f99a67d1ebe1219e29b47b071e83/pyromark-0.9.10-cp313-cp313t-manylinux_2_28_armv7l.whl", hash = "sha256:da7da71c5ed0ca129ee5b2bb6d8dd258bc3f884ccd336852e4072a48eac1601e", size = 359071, upload-time = "2026-03-22T12:45:08.517Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/91/21548fbd07fe0a377927466ff1d03dd86af1479836f65784028a342116e5/pyromark-0.9.10-cp313-cp313t-manylinux_2_28_i686.whl", hash = "sha256:7ef5e25fe5c5c461c00bf9b66cadbd62e97b8299e201effe81fcc4f48e522755", size = 385280, upload-time = "2026-03-22T12:45:28.074Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/cd/735f8e87649a831c5f845fd2cd347663bde0e32aa19c36164705791daebe/pyromark-0.9.10-cp313-cp313t-manylinux_2_28_ppc64le.whl", hash = "sha256:d629c301d22c170a3d45c39b1d492cbac03142d90010b40127757aa4bd057e97", size = 406544, upload-time = "2026-03-22T12:44:24.431Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/f9/e754f0a4f30179196e772c3e4cd16e470ca7afaa1512fa66d4639c43b39e/pyromark-0.9.10-cp313-cp313t-manylinux_2_28_s390x.whl", hash = "sha256:435cb2382bab76d871ccb54794c012bbd938ea8f5dd9872b6eb56cb7fcbc0fd3", size = 448169, upload-time = "2026-03-22T12:46:59.467Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/31/7115c6dd5025fe46a5564a030208c15aede001d63213fbcf72dbeafc5525/pyromark-0.9.10-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:630a087aea4ba2c40338cc8f95e068d9e598f3ac4b7d1c1c0f2ed9b6c2d2a8dd", size = 369593, upload-time = "2026-03-22T12:47:40.736Z" },
+    { url = "https://files.pythonhosted.org/packages/62/81/5b212f8423d1eaf8fafc2f5ad4e9251fbc9e8da6f06e140f716637d1da8e/pyromark-0.9.10-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:839b31fe481074b51c7fdd77616b278012930fc04bb2c482606274a1b82a39e8", size = 370347, upload-time = "2026-03-22T12:47:10.939Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/c8/1fa079a851d8bfe5ec1bbcdd8e03d30145f1bc5506cf45591da0430d8c65/pyromark-0.9.10-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:b4a5cbd6a0642043a2feff0bb1ab34ef482a29ec1a230d21d018ee1a1c968068", size = 539137, upload-time = "2026-03-22T12:42:43.873Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ec/897782e2b6ca3c7ff5e28f3aca6627a2da7bc8e87295c967d3bd3e95691a/pyromark-0.9.10-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:0c4edb54565fab084d9ee6aa7605d2eb514b68abc544aac11a765761cd0bed96", size = 635706, upload-time = "2026-03-22T12:43:26.453Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/4a/a18c696c903ed69f57c3ab2c8e603ecbfaf263589dea72e7efaa3e27f779/pyromark-0.9.10-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:1a977273745da365b86befaa78e1eda51c028ba8d2ad249563a75d065d6beb69", size = 602739, upload-time = "2026-03-22T12:44:37.004Z" },
+    { url = "https://files.pythonhosted.org/packages/88/5e/173f025ba8752f74cddb544de7d3f4578a5bf2f3a2373b9361def469b8cc/pyromark-0.9.10-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:56a79a1ae00470125a8d0eb42cbea45c88834c11337198a75fd70cb14077192b", size = 537874, upload-time = "2026-03-22T12:46:54.483Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/cd/3740b4fd194d512a9d1f9d04d4b11acd63be59018186aecdf3f9e55650c4/pyromark-0.9.10-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:2afb6169b7f1f75f42bdc8cc07d0bf3b2312d291d6a68a1b24929cc43a4cf831", size = 544041, upload-time = "2026-03-22T12:44:13.488Z" },
+    { url = "https://files.pythonhosted.org/packages/09/50/348ea5f1b6ea36777170286de52edbc8db02824f0a0adb557d96f57934f0/pyromark-0.9.10-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c447322247f9ec4830523944ce6093377e421100bf13e5f8e6b556bcb29145e8", size = 589022, upload-time = "2026-03-22T12:43:22.297Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/3c/7981b73bf2899174141e0c89cce40b3cb5d9e2106dda77422dcc935d1496/pyromark-0.9.10-cp313-cp313t-win32.whl", hash = "sha256:ea58e51d4e0da74338575b0438d9ad68e85a373221ea3f7dd80fdbcf8ac3924d", size = 260449, upload-time = "2026-03-22T12:43:09.912Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/98/da2844c54e64448bb6817cb99fad7db368d7b04d21ce985a26ab86c389f1/pyromark-0.9.10-cp313-cp313t-win_amd64.whl", hash = "sha256:4228500fe57507f696701d1d11d9ca967fe051b62007dcdee5ae3163eda53acd", size = 273134, upload-time = "2026-03-22T12:46:34.852Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c8/77739a1e32a3636fa29fdd131bdccd6ac2af60f8de4fbe40a69c3d55c3bb/pyromark-0.9.10-cp313-cp313t-win_arm64.whl", hash = "sha256:df7c3ae5ea73cccc49d5e59dca20eb6c83fca510dd38012f3027ab856e1bf667", size = 258115, upload-time = "2026-03-22T12:45:11.959Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/70/13a06c4fc45665e6dde0b248f8564bb203825e08cfbc0478014b5b8ebe17/pyromark-0.9.10-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:94d01f562ff8a54fc406bc29979d2b11189998eb76e174328ca8cfa4a9b90e94", size = 346541, upload-time = "2026-03-22T12:45:10.105Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/ccb70805ec1fe2cfeb558154b7b85be812e32af8b65ea9e6f83590abb3dc/pyromark-0.9.10-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5cc2c96def6e49b3cb0677dffc744f6f3a24b42726cafa80bb8b072265ffa97b", size = 329370, upload-time = "2026-03-22T12:45:56.913Z" },
+    { url = "https://files.pythonhosted.org/packages/23/3b/104d5d8f75717be901587ca9df55ad9b08a5b42aa1dcce492b608e65f8cb/pyromark-0.9.10-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c00265b0d5196dfdf89a744dc9a3602d0dff3cf4ee231a07b00e9ffc615b089", size = 362589, upload-time = "2026-03-22T12:43:48.789Z" },
+    { url = "https://files.pythonhosted.org/packages/79/36/bb5232f3c5368f26c03f5ea9b906f35550a6c2c2c06526e1b06e27f1bba0/pyromark-0.9.10-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:09b14ce543da03fe3a5f4466a5fe2c456a1f59b3834e350de7b2dc16bc7e5440", size = 361138, upload-time = "2026-03-22T12:43:56.886Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/ec/2791c257ef50cc51755b7aea73c1a71f5132e5d8e9629e64207a6a03229b/pyromark-0.9.10-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:53fc86c5089e5f62585a5262eec86d7006d1fa4b36211e8f7456d8853aa73622", size = 386461, upload-time = "2026-03-22T12:43:00.301Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/93/d77635523eedba395e35ba3fb84ad32bd030a868b2d5027cb3dac1d6c8bf/pyromark-0.9.10-cp314-cp314-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:f4608eed63b0a490366f9197a4c518eb852c8084a43b0762de3603d8b687f055", size = 418428, upload-time = "2026-03-22T12:44:38.495Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/c6/84524aaf65d33e43df2be97e37e22b170772e3ba1f48744982c9923b90e0/pyromark-0.9.10-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6613e8321523e60f1427ea29061dede8333f77631bd6978898f69eac80ec3e29", size = 408915, upload-time = "2026-03-22T12:47:38.341Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d3/e5a79b7127fbefa8fdce1a4b3095fb95b5cb61a6f621a60965fe07d8a93f/pyromark-0.9.10-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8f08e75cb1286476c4c67a691a4140d4022fdd4758158dfaf280eb7eefdc5edd", size = 450282, upload-time = "2026-03-22T12:43:52.915Z" },
+    { url = "https://files.pythonhosted.org/packages/69/f5/d626c2c27a1d09979b1e5228525e4d6d0b83e7c24641d0d7a477165e46e8/pyromark-0.9.10-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:60555b9bddc10f519854396dfa20922376fe90104cab9360608c13524aab641d", size = 370879, upload-time = "2026-03-22T12:43:28.999Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/2c/46f2be6f3021018a2e1199c02495b9d45f023b4874aac385ca229269e981/pyromark-0.9.10-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:a999f18b6d2c7aaf2b810444226f1929c6165af63e540cc10cfb45427712d25c", size = 363263, upload-time = "2026-03-22T12:45:13.703Z" },
+    { url = "https://files.pythonhosted.org/packages/44/0d/155555a3773eedc45839042221d9be7ee9fa689d053c83237f802d1fe038/pyromark-0.9.10-cp314-cp314-manylinux_2_28_armv7l.whl", hash = "sha256:3356dcf0f926edea50400ba906493923551e64fb3ad60bfa464e570affe8eced", size = 361156, upload-time = "2026-03-22T12:44:33.977Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/cc/fbafd7adeeaac1bfa0f223e19094a9dfc22981bbb513404d2eab0d41fffb/pyromark-0.9.10-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:7166158bf9f6e9887c7d78ca15d0ba5d467198c36460b3067f8d04c05e46a7bb", size = 386852, upload-time = "2026-03-22T12:43:07.417Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/7a/3dad5173e56ab627b842a164640702352ddd72fed44f680e470ac3685a1b/pyromark-0.9.10-cp314-cp314-manylinux_2_28_ppc64le.whl", hash = "sha256:5f6667f5f6eb271a60f7e33afceb352b949cd914dfcd36ac409bc2bb54a4733e", size = 409029, upload-time = "2026-03-22T12:45:46.748Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/4a/c821cd96796f084b4be97e3bd3235c7b5e6ec4de6344db90dc73e97fbce3/pyromark-0.9.10-cp314-cp314-manylinux_2_28_s390x.whl", hash = "sha256:4f7d5907733b08fb1c37ac2188a99e7576b4ff833865da9032463935a3715b4e", size = 450565, upload-time = "2026-03-22T12:47:59.265Z" },
+    { url = "https://files.pythonhosted.org/packages/df/92/e80ffbda699f761bec5fd0c58043ddbbe7bdbec35a199a471b97e9192695/pyromark-0.9.10-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:a446ee22bc5430e667ec4abbc8daf7a6811ed5d61f0a87215af417c4ab2cd328", size = 371130, upload-time = "2026-03-22T12:46:49.769Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/69/4a7ea487efc4734951286df570bcd6316152d64cdbdce7a0d32348f32579/pyromark-0.9.10-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:47d70ec0405bc47e661b151104c2ebab5455c1b93326ef4756a782bd84aa41db", size = 371905, upload-time = "2026-03-22T12:43:24.938Z" },
+    { url = "https://files.pythonhosted.org/packages/02/54/52720922cd0c9f98b3e52585d440f50288fbcafee133a508a29ca595b68b/pyromark-0.9.10-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:706a11371fd5eabbe78c7eaade837868c070d0bb20be216ecd27dcb832ccbc47", size = 540391, upload-time = "2026-03-22T12:43:46.344Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/37/c4554802798edde50e8364c63182832b198abec9d97720fd36ca87cae5ca/pyromark-0.9.10-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:838841ff13ea93742318b4e2396dc0f445ad295e0aca62404b4e2a801645fefc", size = 637637, upload-time = "2026-03-22T12:43:18.24Z" },
+    { url = "https://files.pythonhosted.org/packages/43/dd/99eaa1eee23c2dbf7ab475c7f44e9cb70586f2373a9727f6e75e451e7bbf/pyromark-0.9.10-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:b8bed724baef6ee5adf2fadf9226a598749882254337a9ea769b44b00a18725c", size = 604527, upload-time = "2026-03-22T12:47:01.763Z" },
+    { url = "https://files.pythonhosted.org/packages/67/3e/e930312b3c18ea02dc10691e1156b130d7bf03afffb1ca57384d4f9d944e/pyromark-0.9.10-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:dbb1566788a2e5d53ca21e00fe6cf69b70b9ed2c8f690b0c389d6c67e7398fe5", size = 539457, upload-time = "2026-03-22T12:45:02.895Z" },
+    { url = "https://files.pythonhosted.org/packages/69/b6/5f22b048e2aa9adb7afd2431fb4b6e561e3a9912812c348798c1515f1bf3/pyromark-0.9.10-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:88aba6fedac5b9f4f44240a10321a937fdd374ee7197a78c231eadb694ceaab5", size = 546052, upload-time = "2026-03-22T12:43:51.441Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/6f/6670aa0f861c51df6cae4322658fc90d307d54043ce0b53b8f24018c2a0e/pyromark-0.9.10-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:369a20d208acb7b5dde8c7512e4464d0bc6a8e53ef07dc9007ac885404cb85d7", size = 590284, upload-time = "2026-03-22T12:46:00.898Z" },
+    { url = "https://files.pythonhosted.org/packages/23/f7/d7bfb15d0e95c33f0b95caa9b349b99b479a5cbbdb54f4d1d70d6fc1ed3c/pyromark-0.9.10-cp314-cp314-win32.whl", hash = "sha256:d63eec43df5a436c252dd8aafbb939f22fe3d5fadb62c43c34c33544576de730", size = 260700, upload-time = "2026-03-22T12:43:14.571Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/13/5a7f2a43776c06e89479580f2239eff39d76ae811dbabe7123e16454cb3d/pyromark-0.9.10-cp314-cp314-win_amd64.whl", hash = "sha256:8cff3c5394127e4b89928b3c38a5a27fc28bf45a28cfd94554e0eae4aab9d949", size = 273208, upload-time = "2026-03-22T12:44:29.41Z" },
+    { url = "https://files.pythonhosted.org/packages/30/9d/36bfd3da4ac10287c6112d259f1c34a5fc6fb3da53b1bf392440608e414d/pyromark-0.9.10-cp314-cp314-win_arm64.whl", hash = "sha256:00c92b76ef117e7b78f966a5607748990e2fd168a71bb0509df0270fad106204", size = 258954, upload-time = "2026-03-22T12:46:41.169Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/bb/5a9136f50748656bf53391df524157d5e3cca7188fd00ca3f7aec1f011b7/pyromark-0.9.10-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:e994e6b010d62293130c30fb8fa25415a6e7a5940052f92b675d1b4e3334c968", size = 345113, upload-time = "2026-03-22T12:45:31.615Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/9b/7c484479541b978f76f5547598f7cf741aa918508bc7d2d4aa795fa56bcd/pyromark-0.9.10-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:339140de786303d0703f114b4a575d837b52df62bff927a03763d38aaeae93c2", size = 328128, upload-time = "2026-03-22T12:43:30.427Z" },
+    { url = "https://files.pythonhosted.org/packages/89/2a/1683c462a8308fdb0f88cb17f0e7f5f8cad7eda8235df8bf4ffc77bd7ff2/pyromark-0.9.10-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:898d705905056159d63a10355bbc20e60e4f2a595f6aca3eaeebdecad533f15e", size = 361106, upload-time = "2026-03-22T12:44:02.486Z" },
+    { url = "https://files.pythonhosted.org/packages/14/b8/44c1d373a4ac682cf08f5346636fcd5810d438d03de1f24a9ea636b41441/pyromark-0.9.10-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e3f32f704c185489329c5f8b374ea3e0cfbf5a130b66450a4a2369d028bab674", size = 359208, upload-time = "2026-03-22T12:44:16.195Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/8b/8c82e2cb52a4f0855fe72c3defa9ffb7656bf2b29e031fd50b11b1c12127/pyromark-0.9.10-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b5015d8b169e0039959c39d5715d1fc419b9800dc544e60d50b04e8cd19c8623", size = 384654, upload-time = "2026-03-22T12:42:39.493Z" },
+    { url = "https://files.pythonhosted.org/packages/86/44/c212870714378038be8a2284eeaf6f402e49fc66b6e66145ab0811b17df3/pyromark-0.9.10-cp314-cp314t-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:27fa2a36bfcc2a16d6b28a5839be471f18c5e780f70642e5cf8a2ffa8985d1a0", size = 416113, upload-time = "2026-03-22T12:42:58.993Z" },
+    { url = "https://files.pythonhosted.org/packages/41/97/8f3015c15f14dcda13026410d847db6e845afef297aee6f4e97f9ba9a17b/pyromark-0.9.10-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b3e92bdfb9ac46a829fe605ebc8516ca0b2af30cd6f55710bc1840dcd904abba", size = 406520, upload-time = "2026-03-22T12:47:13.468Z" },
+    { url = "https://files.pythonhosted.org/packages/af/37/0f576a466b4ea5d4b6c351686ecb9737130cbf17a9ffcab181a0c043581f/pyromark-0.9.10-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dc7761df494e42444de2720398d511e69200c69dee4825717b34084a3438f407", size = 447975, upload-time = "2026-03-22T12:45:33.327Z" },
+    { url = "https://files.pythonhosted.org/packages/84/c5/e8dd51d416dbbca5c69338dea70622aa38d24b23e4b6b1296f67c4663ed8/pyromark-0.9.10-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:88554879a603c1b12451507e80133ee7496aa31bb91e32a4c203df7a75e77d01", size = 369190, upload-time = "2026-03-22T12:43:47.557Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/3f/4791c4aab3f25552be92437df1dc29805740abafe8c0b4010a3ae59bf5df/pyromark-0.9.10-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:3565ad65a60ea637558d1a11c69a3aa1f0e089f4c74cc8da3466154a77513a32", size = 361852, upload-time = "2026-03-22T12:47:23.156Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ca/22d3ae1e7553425652c18459922182cdb465e4a68e2211f2a10f3597c00b/pyromark-0.9.10-cp314-cp314t-manylinux_2_28_armv7l.whl", hash = "sha256:3e9e5b451432d019a5301f91d16916c434bd9a178bb3b19367bd57fc9208de3f", size = 359112, upload-time = "2026-03-22T12:42:38.59Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/86/2ad78b301a6661000f05714b435b3412cdba073151aa9fb375c544b83f31/pyromark-0.9.10-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:27c403034795367ccc318f723cec3d1c63d26fd1b0c4d6b7d5867f5d42520138", size = 385027, upload-time = "2026-03-22T12:46:09.345Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/e7/6ca82f55c55799cc6b13b2f129318fb7d6abcf39d15d9be88b793bbe9afe/pyromark-0.9.10-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:8c84d1dba7abd6404f35655a676172bc5ae1f1f97f6e39c5eb9bf0c864e5b1a8", size = 406499, upload-time = "2026-03-22T12:44:41.55Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/52/d81dd65198b7a6bd952e5187d391d4837a5dbfda834938c16933809efea8/pyromark-0.9.10-cp314-cp314t-manylinux_2_28_s390x.whl", hash = "sha256:582150c7bc05e5df8ef962614c36e1321f9a3d7c07ed3c410ecd65aed74e96d4", size = 448287, upload-time = "2026-03-22T12:44:59.464Z" },
+    { url = "https://files.pythonhosted.org/packages/10/ad/71c4b8e41b7a27ab2e21de453145cc7ed9e5f869d532683669c85e991169/pyromark-0.9.10-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:b9e90ac2e18aa6feacdd3e92647e47ed0a433d4d1f918466b9f4b9aa7f95b46f", size = 369471, upload-time = "2026-03-22T12:47:35.881Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/bb/6f82599d4407a671f7f797d98ebb53c9184c802e1d58111d5a71be77ef71/pyromark-0.9.10-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f58de15053efc81d55757316191aad53128d52b47e2399d1f71aa4a773d3b23b", size = 370239, upload-time = "2026-03-22T12:44:11.823Z" },
+    { url = "https://files.pythonhosted.org/packages/12/b0/6a49b2af6568c11e0e4ee9203a76e010ab35b510a78a6b0efa4c7a1d022b/pyromark-0.9.10-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c7af63a1d56981aebff37fc075573346c252b5f78d0091b01ddd0478068a4b18", size = 539108, upload-time = "2026-03-22T12:44:35.504Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/3e/f635c494a15f2bb5c944366c0199d101ccf77eedbdc1fce7a6838a301a11/pyromark-0.9.10-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:770836297d0cca34e2c85b083fb4e7b8314cbe4588f313bb61838d02bb879656", size = 635605, upload-time = "2026-03-22T12:46:39.01Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d2/2648d624c8c666986aa3b15cd1f3d6089e443e13ce2d06781e5ffa844909/pyromark-0.9.10-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:6ee98e2a1a71f7482ca76fc0ee82d188de49d4aeb38134bfb618eb4ff897c5f0", size = 602635, upload-time = "2026-03-22T12:44:52.847Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/76/7bfa77613f9928cfc729571e1289af10e946f493afa2193b9cab32ecef77/pyromark-0.9.10-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:fc8e5727eb1f25053f63cb811c4df080e44855b9f9ae0c0353f57ab3eaec8673", size = 537854, upload-time = "2026-03-22T12:43:01.408Z" },
+    { url = "https://files.pythonhosted.org/packages/94/3e/b651e682b618d03136eaf226938926f19c289bcf3301b5598d0ee5cbcd52/pyromark-0.9.10-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:44a4d21becf02bbc9663284e33a393f7fdbc460ef98dda451406f4342027f774", size = 543902, upload-time = "2026-03-22T12:42:28.363Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/8b/885f4c7b1581cd9850a7913fdcc46da89926caa5b72effa6aaa80cc76da5/pyromark-0.9.10-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:274b2c785e4a33b66646b6980ea3bc5fb0b3d04cda316cc6e3c3f0ea7986e14d", size = 589002, upload-time = "2026-03-22T12:47:43.172Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/8c/fd6716ce80e5c1b981ba83239e21f6a705eae4aa9036b0612c563a3cebd9/pyromark-0.9.10-cp314-cp314t-win32.whl", hash = "sha256:016fa16b4926bd4bb8e21409e3f66ab94a54e165e2b381f4217125babb82f50b", size = 260320, upload-time = "2026-03-22T12:42:50.392Z" },
+    { url = "https://files.pythonhosted.org/packages/17/06/d1d1ac2ad634bab28535d226758fa8753d76d96f225c1e662d2b55205550/pyromark-0.9.10-cp314-cp314t-win_amd64.whl", hash = "sha256:5dc38aebcb81a6d86d6e0d80ffbe194aae443d5072eff6dc65908ba608719071", size = 273015, upload-time = "2026-03-22T12:42:37.534Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/35/b28e282e79e0c3009b0e23912953d18f569982d83b11849a85d1ac6d33d5/pyromark-0.9.10-cp314-cp314t-win_arm64.whl", hash = "sha256:a92de094e7f9c0e62910d8859bef6362baa1c0f170abcee48d67d6f8f3a68308", size = 258076, upload-time = "2026-03-22T12:47:06.217Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1323,6 +1491,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "telegramify-markdown"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyromark" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/94/0b29f09c3c9d28cd7b8790c4bc8aa805b126ece87f2ddc5d0c28dc9cb922/telegramify_markdown-1.1.1.tar.gz", hash = "sha256:0fc66835b889e156ef47aa1c70a215368f9673f86cac23e539f5d9fa923a4c35", size = 58615, upload-time = "2026-03-18T04:05:12.865Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/6d/71552ae1f5e959d36c9943ec5a04063ec9db69f9d524643c41a92ba422e7/telegramify_markdown-1.1.1-py3-none-any.whl", hash = "sha256:860348bae4e4e107b3fc02333ff3f592888b1e6bd9da8291aaf210e094dbd005", size = 41506, upload-time = "2026-03-18T04:05:11.636Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 问题

大模型生成标准 Markdown 格式，但飞书卡片 markdown 有自己的语法规范。标准 markdown 表格 `| col |` 等无法渲染。

## 方案

通过 system prompt 引导大模型直接输出飞书兼容的 markdown，不做任何代码层的格式转换。

### 1. 新增 `feishu_markdown.prompt`

完整的飞书卡片 markdown 语法规范，包含：

**基础语法：**
- 加粗 / 斜体 / 删除线 / 混合样式
- 链接 / 图片
- 标题（仅 `#` `##`，不支持 `###` 及以上）
- 分割线 / 无序列表 / 有序列表（不支持缩进嵌套）
- 代码块（支持语言标记）

**高级组件：**
- `<font color="red">` — 颜色文字（red/green/grey）
- `<table columns={...} data={...} />` — 表格
- `<chart chartSpec={...} />` — 图表
- `<row><col flex=1>` — 分栏布局
- `<record fields={...} data={...} />` — 记录详情
- `<note>` — 辅助文本
- `<highlight>` — 高亮块
- `<button>` — 按钮
- `<title style="blue">` — 卡片标题
- `<at id='...'>` — @用户

**禁止使用的语法：**
- 标准 markdown 表格 `| col1 | col2 |`
- `###` 及以上标题
- 嵌套/缩进列表

### 2. 修改 `plugin.py`

添加 `system_prompt` hook：
- 通过 `state["context"]` 中的 `$feishu` 标识判断 channel 来源
- 仅飞书消息时注入 prompt，不影响 Telegram 等其他 channel
- lazy load prompt 文件

### 3. 简化 `channel.py`

- 移除所有格式转换代码（`_md_table_to_feishu_table` / `_has_markdown_table` 等约 80 行）
- 统一使用 `interactive` 卡片消息，不做任何内容修改
- 完全信任大模型在 system prompt 引导下输出正确格式

## 参考

- [飞书卡片 markdown 语法](https://waytoagi.feishu.cn/wiki/WEgMwYY4ciQSUwkQvfvcF4Ykn9d)
- [飞书消息内容结构](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/im-v1/message/create_json)