### PR TITLE
fix: change feishu max header level from ### to ####

### DIFF
--- a/src/bub_im_bridge/feishu/feishu_prompts.py
+++ b/src/bub_im_bridge/feishu/feishu_prompts.py
@@ -5,7 +5,7 @@ FEISHU_OUTPUT_INSTRUCTION = """\
 <output_format>
 Your response will be rendered in Feishu. Use standard Markdown with these rules:
 
-1. Headings: start from ### (max level), then ####, #####, ###### for sub-levels. Do NOT use # or ##.
+1. Headings: start from #### (max level), then #####, ###### for sub-levels. Do NOT use #, ##, or ###.
 2. Tables: standard markdown | col1 | col2 | syntax
 3. Text: **bold**, *italic*, ~~strikethrough~~, [link](url)
 4. Lists: - unordered, 1. ordered (nesting with 4 spaces)


### PR DESCRIPTION
## Summary
- Updated `FEISHU_OUTPUT_INSTRUCTION` in `feishu_prompts.py` to use `####` as the maximum heading level
- Adjusted prohibited levels to include `#`, `##`, and `###`

This change ensures that Feishu messages start with h4 headers instead of h3, providing better visual hierarchy in the rendered output.