### PR TITLE
feat: enhance feishu message handling for quoted messages, @mentions, and chat history

### DIFF
--- a/src/bub_im_bridge/feishu/api.py
+++ b/src/bub_im_bridge/feishu/api.py
@@ -1,0 +1,271 @@
+"""Feishu API helpers — thin wrappers around lark_oapi for use by tools."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import re
+import time
+from datetime import datetime
+from typing import Any
+
+import lark_oapi as lark
+from loguru import logger
+
+
+# ---------------------------------------------------------------------------
+# Public API functions (no dependency on Channel)
+# ---------------------------------------------------------------------------
+
+
+async def fetch_message_content(client: lark.Client, message_id: str) -> str | None:
+    """Fetch the text content of a single message by ID."""
+    api = _get_message_api(client)
+    if api is None or not message_id:
+        return None
+
+    try:
+        from lark_oapi.api.im.v1 import GetMessageRequest
+
+        req = GetMessageRequest.builder().message_id(message_id).build()
+        resp = api.get(req)
+
+        if not resp.success():
+            logger.warning(
+                "feishu.api.fetch_message failed message_id={} code={} msg={}",
+                message_id,
+                resp.code,
+                resp.msg,
+            )
+            return None
+
+        data = getattr(resp, "data", None)
+        if data:
+            body = getattr(data, "body", None)
+            content = getattr(body, "content", None) if body else None
+            if content:
+                msg_type = getattr(data, "msg_type", None) or "text"
+                return _normalize_text(msg_type, content)
+
+    except Exception:
+        logger.exception("feishu.api.fetch_message error message_id={}", message_id)
+
+    return None
+
+
+async def fetch_chat_history(
+    client: lark.Client,
+    chat_id: str,
+    *,
+    start_time: str | None = None,
+    end_time: str | None = None,
+    resolve_names: bool = True,
+    user_name_cache: dict[str, str] | None = None,
+) -> list[dict[str, str]]:
+    """Fetch chat messages, optionally filtered by time range.
+
+    Returns all pages of results.  Uses :func:`parse_time_range` to convert
+    human-friendly strings like ``"1d"`` or ``"3h"`` into timestamps.
+    """
+    api = _get_message_api(client)
+    if api is None or not chat_id:
+        return []
+
+    start_ts = parse_time_range(start_time)
+    end_ts = parse_time_range(end_time)
+    history: list[dict[str, str]] = []
+    page_token: str | None = None
+    cache = user_name_cache if user_name_cache is not None else {}
+
+    try:
+        from lark_oapi.api.im.v1 import ListMessageRequest
+
+        while True:
+            builder = (
+                ListMessageRequest.builder()
+                .container_id_type("chat")
+                .container_id(chat_id)
+                .page_size(50)
+            )
+            if start_ts:
+                builder.start_time(str(int(start_ts)))
+            if end_ts:
+                builder.end_time(str(int(end_ts)))
+            if page_token:
+                builder.page_token(page_token)
+
+            resp = api.list(builder.build())
+
+            if not resp.success():
+                logger.warning(
+                    "feishu.api.fetch_history failed chat_id={} code={} msg={}",
+                    chat_id,
+                    resp.code,
+                    resp.msg,
+                )
+                break
+
+            data = getattr(resp, "data", None)
+            for item in getattr(data, "items", None) or []:
+                body = getattr(item, "body", None)
+                content = getattr(body, "content", None) if body else None
+                if not content:
+                    continue
+                msg_type = getattr(item, "msg_type", None) or "text"
+                sender = getattr(item, "sender", None)
+                sender_id = (getattr(sender, "id", "") or "") if sender else ""
+                sender_name = (
+                    resolve_user_name(client, sender_id, cache=cache)
+                    if resolve_names
+                    else sender_id
+                )
+                history.append(
+                    {
+                        "message_id": getattr(item, "message_id", "") or "",
+                        "sender_id": sender_id,
+                        "sender": sender_name,
+                        "content": _normalize_text(msg_type, content),
+                        "create_time": format_feishu_timestamp(
+                            getattr(item, "create_time", None)
+                        ),
+                    }
+                )
+
+            has_more = getattr(data, "has_more", False) if data else False
+            page_token = getattr(data, "page_token", None) if data else None
+            if not has_more or not page_token:
+                break
+
+    except Exception:
+        logger.exception("feishu.api.fetch_history error chat_id={}", chat_id)
+
+    return history
+
+
+def resolve_user_name(
+    client: lark.Client,
+    open_id: str,
+    *,
+    cache: dict[str, str] | None = None,
+) -> str:
+    """Resolve an open_id to a display name (with optional cache)."""
+    if not open_id:
+        return ""
+    if cache is not None and open_id in cache:
+        return cache[open_id]
+
+    name = _fetch_user_name(client, open_id)
+    if cache is not None:
+        cache[open_id] = name
+    return name
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_message_api(client: lark.Client) -> Any | None:
+    """Return the ``im.v1.message`` API handle, or ``None``."""
+    im = getattr(client, "im", None)
+    v1 = getattr(im, "v1", None) if im else None
+    return getattr(v1, "message", None) if v1 else None
+
+
+def _fetch_user_name(client: lark.Client, open_id: str) -> str:
+    """Call Feishu contact API to get user's display name."""
+    try:
+        from lark_oapi.api.contact.v3 import GetUserRequest
+
+        req = GetUserRequest.builder().user_id(open_id).user_id_type("open_id").build()
+        resp = client.contact.v3.user.get(req)
+        if resp.success():
+            user = getattr(resp, "data", None)
+            user_obj = getattr(user, "user", None) if user else None
+            if user_obj:
+                return getattr(user_obj, "name", None) or open_id
+        else:
+            logger.debug(
+                "feishu.api.fetch_user_name failed open_id={} code={} msg={}",
+                open_id,
+                resp.code,
+                resp.msg,
+            )
+    except Exception:
+        logger.debug("feishu.api.fetch_user_name error open_id={}", open_id)
+    return open_id
+
+
+def _normalize_text(message_type: str, content: str) -> str:
+    """Extract human-readable text from the raw Feishu message content JSON."""
+    if not content:
+        return ""
+    parsed: dict[str, Any] | None = None
+    with contextlib.suppress(json.JSONDecodeError):
+        obj = json.loads(content)
+        if isinstance(obj, dict):
+            parsed = obj
+    if message_type == "text":
+        return str(parsed.get("text", "")).strip() if parsed else content.strip()
+    if parsed is None:
+        return f"[{message_type} message]"
+    return f"[{message_type} message] {json.dumps(parsed, ensure_ascii=False)}"
+
+
+def parse_time_range(time_str: str | None) -> float | None:
+    """Parse time range string to Unix timestamp (seconds).
+
+    Supports:
+    - Relative: "3h" (hours), "1d", "7d", "30d" (days)
+    - ISO format: "2024-01-01", "2024-01-01T10:00:00"
+    - Unix timestamp (seconds or milliseconds)
+    """
+    if not time_str:
+        return None
+    time_str = time_str.strip()
+
+    # Relative time: hours
+    if time_str.endswith("h"):
+        try:
+            hours = int(time_str[:-1])
+            return time.time() - (hours * 3600)
+        except ValueError:
+            pass
+
+    # Relative time: days
+    if time_str.endswith("d"):
+        try:
+            days = int(time_str[:-1])
+            return time.time() - (days * 86400)
+        except ValueError:
+            pass
+
+    # Try parsing as integer (Unix timestamp)
+    try:
+        ts = int(time_str)
+        if ts > 1e12:
+            ts = ts / 1000
+        return float(ts)
+    except ValueError:
+        pass
+
+    # Try ISO format
+    try:
+        dt = datetime.fromisoformat(time_str)
+        return dt.timestamp()
+    except ValueError:
+        pass
+
+    return None
+
+
+def format_feishu_timestamp(ts: str | int | None) -> str:
+    """Convert Feishu millisecond timestamp to local time string."""
+    if not ts:
+        return ""
+    try:
+        epoch_ms = int(ts)
+        dt = datetime.fromtimestamp(epoch_ms / 1000).astimezone()
+        return dt.strftime("%Y-%m-%d %H:%M:%S")
+    except (ValueError, OSError):
+        return str(ts) if ts else ""

--- a/src/bub_im_bridge/feishu/api.py
+++ b/src/bub_im_bridge/feishu/api.py
@@ -148,13 +148,22 @@ def resolve_user_name(
     *,
     cache: dict[str, str] | None = None,
 ) -> str:
-    """Resolve an open_id to a display name (with optional cache)."""
+    """Resolve an open_id to a display name (with optional cache).
+
+    Bot IDs (``cli_`` prefix) are returned as "bot" since they cannot
+    be resolved via the contact API.
+    """
     if not open_id:
         return ""
     if cache is not None and open_id in cache:
         return cache[open_id]
 
-    name = _fetch_user_name(client, open_id)
+    # Bot IDs start with "cli_", skip API call
+    if open_id.startswith("cli_"):
+        name = "bot"
+    else:
+        name = _fetch_user_name(client, open_id)
+
     if cache is not None:
         cache[open_id] = name
     return name

--- a/src/bub_im_bridge/feishu/api.py
+++ b/src/bub_im_bridge/feishu/api.py
@@ -77,6 +77,10 @@ async def fetch_chat_history(
     page_token: str | None = None
     cache = user_name_cache if user_name_cache is not None else {}
 
+    # Bulk-load member names before iterating messages
+    if resolve_names and not cache:
+        preload_chat_members(client, chat_id, cache)
+
     try:
         from lark_oapi.api.im.v1 import ListMessageRequest
 
@@ -162,11 +166,63 @@ def resolve_user_name(
     if open_id.startswith("cli_"):
         name = "bot"
     else:
+        # Not in cache — try contact API as fallback
         name = _fetch_user_name(client, open_id)
 
     if cache is not None:
         cache[open_id] = name
     return name
+
+
+def preload_chat_members(
+    client: lark.Client,
+    chat_id: str,
+    cache: dict[str, str],
+) -> None:
+    """Bulk-load chat member names into cache via the chat members API.
+
+    This only requires ``im:chat:readonly`` permission (available to any
+    bot that has joined the chat), unlike the contact API which needs
+    ``contact:user.base:readonly``.
+    """
+    try:
+        from lark_oapi.api.im.v1 import GetChatMembersRequest
+
+        page_token: str | None = None
+        while True:
+            builder = (
+                GetChatMembersRequest.builder()
+                .chat_id(chat_id)
+                .member_id_type("open_id")
+                .page_size(100)
+            )
+            if page_token:
+                builder.page_token(page_token)
+
+            resp = client.im.v1.chat_members.get(builder.build())
+            if not resp.success():
+                logger.debug(
+                    "feishu.api.preload_members failed chat_id={} code={} msg={}",
+                    chat_id,
+                    resp.code,
+                    resp.msg,
+                )
+                break
+
+            data = getattr(resp, "data", None)
+            for member in getattr(data, "items", None) or []:
+                member_id = getattr(member, "member_id", None) or ""
+                name = getattr(member, "name", None) or ""
+                if member_id and name:
+                    cache[member_id] = name
+
+            has_more = getattr(data, "has_more", False) if data else False
+            page_token = getattr(data, "page_token", None) if data else None
+            if not has_more or not page_token:
+                break
+
+    except Exception:
+        logger.debug("feishu.api.preload_members error chat_id={}", chat_id)
 
 
 # ---------------------------------------------------------------------------
@@ -182,7 +238,11 @@ def _get_message_api(client: lark.Client) -> Any | None:
 
 
 def _fetch_user_name(client: lark.Client, open_id: str) -> str:
-    """Call Feishu contact API to get user's display name."""
+    """Call Feishu contact API to get user's display name.
+
+    Requires ``contact:user.base:readonly`` permission. Falls back to
+    *open_id* if the app lacks permission (error 41050).
+    """
     try:
         from lark_oapi.api.contact.v3 import GetUserRequest
 

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -161,6 +161,11 @@ class FeishuChannel(Channel):
             .build()
         )
 
+        # Register client for tool access
+        from bub_im_bridge.feishu.tools import set_client
+
+        set_client(self._api_client)
+
         event_handler = (
             lark.EventDispatcherHandler.builder(
                 self._verification_token,

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -154,6 +154,11 @@ class FeishuChannel(Channel):
 
         self._loop = asyncio.get_running_loop()
 
+        # Register this channel instance globally for tool access
+        from bub_im_bridge.feishu import tools as feishu_tools
+
+        feishu_tools._channel_instance = self
+
         logger.info(
             "feishu.start app_id={}... allow_users={} allow_chats={} bot_open_id={}",
             self._app_id[:8],
@@ -445,17 +450,17 @@ class FeishuChannel(Channel):
     async def _fetch_chat_history(
         self,
         chat_id: str,
-        limit: int = 20,
         start_time: str | None = None,
         end_time: str | None = None,
     ) -> list[dict[str, str]] | None:
         """Fetch chat history with optional time range.
 
+        Uses pagination to retrieve all messages within the time range.
+
         Args:
             chat_id: The chat ID to fetch history from.
-            limit: Maximum number of messages to return (max 50).
-            start_time: Start time in ISO format or relative like "1d", "7d".
-            end_time: End time in ISO format (defaults to now).
+            start_time: Relative like "1d", "7d" or ISO format.
+            end_time: End time (defaults to now).
         """
         if self._api_client is None or not chat_id:
             return None
@@ -463,22 +468,6 @@ class FeishuChannel(Channel):
         try:
             from lark_oapi.api.im.v1 import ListMessageRequest
 
-            builder = (
-                ListMessageRequest.builder()
-                .container_id_type("chat")
-                .container_id(chat_id)
-                .page_size(min(limit, 50))
-            )
-
-            # Add time range filters if provided
-            start_ts = _parse_time_range(start_time)
-            end_ts = _parse_time_range(end_time)
-            if start_ts:
-                builder.start_time(str(int(start_ts)))
-            if end_ts:
-                builder.end_time(str(int(end_ts)))
-
-            req = builder.build()
             im_api = getattr(self._api_client, "im", None)
             if not im_api:
                 return None
@@ -488,41 +477,70 @@ class FeishuChannel(Channel):
             message_api = getattr(v1_api, "message", None)
             if not message_api:
                 return None
-            resp = message_api.list(req)
 
-            if not resp.success():
-                logger.warning(
-                    "feishu.fetch_history failed chat_id={} code={} msg={}",
-                    chat_id,
-                    resp.code,
-                    resp.msg,
-                )
-                return None
+            # Add time range filters if provided
+            start_ts = _parse_time_range(start_time)
+            end_ts = _parse_time_range(end_time)
 
             history: list[dict[str, str]] = []
-            data = getattr(resp, "data", None)
-            items = getattr(data, "items", None) if data else None
-            if items:
-                for item in items:
-                    body = getattr(item, "body", None)
-                    if body:
-                        content = getattr(body, "content", None)
-                        if content:
-                            msg_type = getattr(item, "msg_type", None) or "text"
-                            normalized = _normalize_text(msg_type, content)
-                            sender = getattr(item, "sender", None)
-                            sender_id = getattr(sender, "id", "") if sender else ""
-                            create_time = getattr(item, "create_time", None)
-                            history.append(
-                                {
-                                    "message_id": getattr(item, "message_id", "") or "",
-                                    "sender": sender_id or "",
-                                    "content": normalized,
-                                    "create_time": _format_feishu_timestamp(
-                                        create_time
-                                    ),
-                                }
-                            )
+            page_token: str | None = None
+
+            while True:
+                builder = (
+                    ListMessageRequest.builder()
+                    .container_id_type("chat")
+                    .container_id(chat_id)
+                    .page_size(50)
+                )
+                if start_ts:
+                    builder.start_time(str(int(start_ts)))
+                if end_ts:
+                    builder.end_time(str(int(end_ts)))
+                if page_token:
+                    builder.page_token(page_token)
+
+                req = builder.build()
+                resp = message_api.list(req)
+
+                if not resp.success():
+                    logger.warning(
+                        "feishu.fetch_history failed chat_id={} code={} msg={}",
+                        chat_id,
+                        resp.code,
+                        resp.msg,
+                    )
+                    break
+
+                data = getattr(resp, "data", None)
+                items = getattr(data, "items", None) if data else None
+                if items:
+                    for item in items:
+                        body = getattr(item, "body", None)
+                        if body:
+                            content = getattr(body, "content", None)
+                            if content:
+                                msg_type = getattr(item, "msg_type", None) or "text"
+                                normalized = _normalize_text(msg_type, content)
+                                sender = getattr(item, "sender", None)
+                                sender_id = getattr(sender, "id", "") if sender else ""
+                                create_time = getattr(item, "create_time", None)
+                                history.append(
+                                    {
+                                        "message_id": getattr(item, "message_id", "")
+                                        or "",
+                                        "sender": sender_id or "",
+                                        "content": normalized,
+                                        "create_time": _format_feishu_timestamp(
+                                            create_time
+                                        ),
+                                    }
+                                )
+
+                # Check for next page
+                has_more = getattr(data, "has_more", False) if data else False
+                page_token = getattr(data, "page_token", None) if data else None
+                if not has_more or not page_token:
+                    break
 
             return history if history else None
 

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -300,16 +300,23 @@ class FeishuChannel(Channel):
         """Decide whether the message should trigger the bot.
 
         Returns ``(is_active, reason)`` – *reason* is always populated for logging.
+
+        For p2p (single chat): always active.
+        For group chat: only active if @mentioned or has quoted message (parent_id).
         """
         if message.chat_type == "p2p":
             return True, "p2p"
 
+        # Group chat: check for @mentions or quoted message
         text = message.text.strip()
 
+        # Commands always trigger
         if text.startswith(",") or text.startswith("/"):
             return True, "command"
-        if "bub" in text.lower():
-            return True, "bub_keyword"
+
+        # Quoted messages in group chat should be processed (reply to bot's message)
+        if message.parent_id:
+            return True, "quoted_message"
 
         # Exact bot open_id match
         if self._bot_open_id and any(
@@ -321,7 +328,7 @@ class FeishuChannel(Channel):
         if any("bub" in (m.name or "").lower() for m in message.mentions):
             return True, "bub_name_mentioned"
 
-        # Any @-mention in a group chat (permissive fallback)
+        # Any @-mention in a group chat
         if message.mentions:
             return True, "has_mentions"
 
@@ -353,7 +360,15 @@ class FeishuChannel(Channel):
             )
             return
 
-        payload = {
+        # Fetch quoted message content if this is a reply
+        quoted_message = None
+        if message.parent_id:
+            quoted_message = await self._fetch_message_content(message.parent_id)
+
+        # Fetch recent chat history for context
+        chat_history = await self._fetch_chat_history(message.chat_id, limit=10)
+
+        payload: dict[str, Any] = {
             "message": message.text + FEISHU_OUTPUT_INSTRUCTION,
             "message_id": message.message_id,
             "chat_type": message.chat_type,
@@ -361,6 +376,13 @@ class FeishuChannel(Channel):
             "sender_name": message.sender_display,
             "create_time": _format_feishu_timestamp(message.create_time),
         }
+
+        if quoted_message:
+            payload["quoted_message"] = quoted_message
+
+        if chat_history:
+            payload["chat_history"] = chat_history
+
         local_time = _format_feishu_timestamp(message.create_time)
         await self._on_receive(
             ChannelMessage(
@@ -372,6 +394,120 @@ class FeishuChannel(Channel):
                 context={"date": local_time} if local_time else {},
             )
         )
+
+    # -- message fetching ----------------------------------------------------
+
+    async def _fetch_message_content(self, message_id: str) -> str | None:
+        """Fetch the content of a message by its ID."""
+        if self._api_client is None or not message_id:
+            return None
+
+        try:
+            from lark_oapi.api.im.v1 import GetMessageRequest
+
+            req = GetMessageRequest.builder().message_id(message_id).build()
+            im_api = getattr(self._api_client, "im", None)
+            if not im_api:
+                return None
+            v1_api = getattr(im_api, "v1", None)
+            if not v1_api:
+                return None
+            message_api = getattr(v1_api, "message", None)
+            if not message_api:
+                return None
+            resp = message_api.get(req)
+
+            if not resp.success():
+                logger.warning(
+                    "feishu.fetch_message failed message_id={} code={} msg={}",
+                    message_id,
+                    resp.code,
+                    resp.msg,
+                )
+                return None
+
+            msg = getattr(resp, "data", None)
+            if msg:
+                body = getattr(msg, "body", None)
+                if body:
+                    content = getattr(body, "content", None)
+                    if content:
+                        msg_type = getattr(msg, "msg_type", None) or "text"
+                        return _normalize_text(msg_type, content)
+
+        except Exception:
+            logger.exception("feishu.fetch_message error message_id={}", message_id)
+
+        return None
+
+    async def _fetch_chat_history(
+        self, chat_id: str, limit: int = 10
+    ) -> list[dict[str, str]] | None:
+        """Fetch recent chat history for context."""
+        if self._api_client is None or not chat_id:
+            return None
+
+        try:
+            from lark_oapi.api.im.v1 import ListMessageRequest
+
+            req = (
+                ListMessageRequest.builder()
+                .container_id_type("chat")
+                .container_id(chat_id)
+                .page_size(min(limit, 50))
+                .build()
+            )
+            im_api = getattr(self._api_client, "im", None)
+            if not im_api:
+                return None
+            v1_api = getattr(im_api, "v1", None)
+            if not v1_api:
+                return None
+            message_api = getattr(v1_api, "message", None)
+            if not message_api:
+                return None
+            resp = message_api.list(req)
+
+            if not resp.success():
+                logger.warning(
+                    "feishu.fetch_history failed chat_id={} code={} msg={}",
+                    chat_id,
+                    resp.code,
+                    resp.msg,
+                )
+                return None
+
+            history: list[dict[str, str]] = []
+            data = getattr(resp, "data", None)
+            items = getattr(data, "items", None) if data else None
+            if items:
+                for item in items:
+                    body = getattr(item, "body", None)
+                    if body:
+                        content = getattr(body, "content", None)
+                        if content:
+                            msg_type = getattr(item, "msg_type", None) or "text"
+                            normalized = _normalize_text(msg_type, content)
+                            sender = getattr(item, "sender", None)
+                            sender_id = getattr(sender, "id", "") if sender else ""
+                            create_time = getattr(item, "create_time", None)
+                            history.append(
+                                {
+                                    "message_id": getattr(item, "message_id", "") or "",
+                                    "sender": sender_id or "",
+                                    "content": normalized,
+                                    "create_time": _format_feishu_timestamp(
+                                        create_time
+                                    ),
+                                }
+                            )
+
+            return history if history else None
+
+        except Exception:
+            logger.exception("feishu.fetch_history error chat_id={}", chat_id)
+
+        return None
 
     # -- outbound ------------------------------------------------------------
 
@@ -560,7 +696,7 @@ def _extract_outbound_text(message: ChannelMessage) -> str:
 import re
 
 
-def _format_feishu_timestamp(ts: str | None) -> str:
+def _format_feishu_timestamp(ts: str | int | None) -> str:
     """Convert Feishu millisecond timestamp to local time string."""
     if not ts:
         return ""
@@ -569,7 +705,7 @@ def _format_feishu_timestamp(ts: str | None) -> str:
         dt = datetime.fromtimestamp(epoch_ms / 1000).astimezone()
         return dt.strftime("%Y-%m-%d %H:%M:%S")
     except (ValueError, OSError):
-        return ts or ""
+        return str(ts) if ts else ""
 
 
 # Patterns that indicate rich content needing card rendering

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -8,9 +8,7 @@ import json
 import os
 import re
 import threading
-import time
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
 from typing import Any, ClassVar
 
 import lark_oapi as lark
@@ -26,6 +24,11 @@ from bub.channels.base import Channel
 from bub.channels.message import ChannelMessage
 from bub.types import MessageHandler
 
+from bub_im_bridge.feishu.api import (
+    fetch_message_content,
+    format_feishu_timestamp,
+    _normalize_text,
+)
 from bub_im_bridge.feishu.feishu_prompts import (
     FEISHU_HISTORY_HINT_GROUP,
     FEISHU_HISTORY_HINT_P2P,
@@ -46,24 +49,6 @@ def _parse_collection(raw: str) -> set[str]:
         if isinstance(parsed, list):
             return {str(item).strip() for item in parsed if str(item).strip()}
     return {item.strip() for item in raw.split(",") if item.strip()}
-
-
-def _normalize_text(message_type: str, content: str) -> str:
-    """Extract human-readable text from the raw Feishu message content JSON."""
-    if not content:
-        return ""
-
-    parsed: dict[str, Any] | None = None
-    with contextlib.suppress(json.JSONDecodeError):
-        obj = json.loads(content)
-        if isinstance(obj, dict):
-            parsed = obj
-
-    if message_type == "text":
-        return str(parsed.get("text", "")).strip() if parsed else content.strip()
-    if parsed is None:
-        return f"[{message_type} message]"
-    return f"[{message_type} message] {json.dumps(parsed, ensure_ascii=False)}"
 
 
 # ---------------------------------------------------------------------------
@@ -148,9 +133,6 @@ class FeishuChannel(Channel):
         # (The bub framework does not forward ``context`` to outbound messages.)
         self._last_message_id: dict[str, str] = {}
 
-        # Cache: open_id -> display name (avoids repeated API calls)
-        self._user_name_cache: dict[str, str] = {}
-
     @property
     def needs_debounce(self) -> bool:
         return True
@@ -162,11 +144,6 @@ class FeishuChannel(Channel):
             )
 
         self._loop = asyncio.get_running_loop()
-
-        # Register this channel instance for tool access
-        from bub_im_bridge.feishu.tools import registry
-
-        registry.set(self)
 
         logger.info(
             "feishu.start app_id={}... allow_users={} allow_chats={} bot_open_id={}",
@@ -376,8 +353,10 @@ class FeishuChannel(Channel):
 
         # Fetch quoted message content if this is a reply
         quoted_message = None
-        if message.parent_id:
-            quoted_message = await self.fetch_message_content(message.parent_id)
+        if message.parent_id and self._api_client is not None:
+            quoted_message = await fetch_message_content(
+                self._api_client, message.parent_id
+            )
 
         history_hint = (
             FEISHU_HISTORY_HINT_GROUP if message.is_group else FEISHU_HISTORY_HINT_P2P
@@ -389,20 +368,20 @@ class FeishuChannel(Channel):
             "chat_type": message.chat_type,
             "sender_id": message.sender_open_id or "",
             "sender_name": message.sender_display,
-            "create_time": _format_feishu_timestamp(message.create_time),
+            "create_time": format_feishu_timestamp(message.create_time),
         }
 
         if quoted_message:
             payload["quoted_message"] = quoted_message
 
-        local_time = _format_feishu_timestamp(message.create_time)
+        local_time = format_feishu_timestamp(message.create_time)
 
-        # Register channel instance and chat_id in context for tool access
+        # Inject API client into context for tool access (like schedule injects scheduler)
         context: dict[str, Any] = {}
         if local_time:
             context["date"] = local_time
-        context["_feishu_channel"] = self
-        context["_feishu_chat_id"] = message.chat_id
+        if self._api_client is not None:
+            context["_feishu_api_client"] = self._api_client
 
         await self._on_receive(
             ChannelMessage(
@@ -414,170 +393,6 @@ class FeishuChannel(Channel):
                 context=context,
             )
         )
-
-    # -- message fetching ----------------------------------------------------
-
-    def _get_message_api(self) -> Any | None:
-        """Return the ``im.v1.message`` API handle, or ``None``."""
-        if self._api_client is None:
-            return None
-        im = getattr(self._api_client, "im", None)
-        v1 = getattr(im, "v1", None) if im else None
-        return getattr(v1, "message", None) if v1 else None
-
-    async def fetch_message_content(self, message_id: str) -> str | None:
-        """Fetch the text content of a single message by ID."""
-        api = self._get_message_api()
-        if api is None or not message_id:
-            return None
-
-        try:
-            from lark_oapi.api.im.v1 import GetMessageRequest
-
-            req = GetMessageRequest.builder().message_id(message_id).build()
-            resp = api.get(req)
-
-            if not resp.success():
-                logger.warning(
-                    "feishu.fetch_message failed message_id={} code={} msg={}",
-                    message_id,
-                    resp.code,
-                    resp.msg,
-                )
-                return None
-
-            data = getattr(resp, "data", None)
-            if data:
-                body = getattr(data, "body", None)
-                content = getattr(body, "content", None) if body else None
-                if content:
-                    msg_type = getattr(data, "msg_type", None) or "text"
-                    return _normalize_text(msg_type, content)
-
-        except Exception:
-            logger.exception("feishu.fetch_message error message_id={}", message_id)
-
-        return None
-
-    async def fetch_chat_history(
-        self,
-        chat_id: str,
-        start_time: str | None = None,
-        end_time: str | None = None,
-    ) -> list[dict[str, str]]:
-        """Fetch chat messages, optionally filtered by time range.
-
-        Returns all pages of results. Uses ``_parse_time_range`` to convert
-        human-friendly strings like ``"1d"`` or ``"7d"`` into timestamps.
-        """
-        api = self._get_message_api()
-        if api is None or not chat_id:
-            return []
-
-        start_ts = _parse_time_range(start_time)
-        end_ts = _parse_time_range(end_time)
-        history: list[dict[str, str]] = []
-        page_token: str | None = None
-
-        try:
-            from lark_oapi.api.im.v1 import ListMessageRequest
-
-            while True:
-                builder = (
-                    ListMessageRequest.builder()
-                    .container_id_type("chat")
-                    .container_id(chat_id)
-                    .page_size(50)
-                )
-                if start_ts:
-                    builder.start_time(str(int(start_ts)))
-                if end_ts:
-                    builder.end_time(str(int(end_ts)))
-                if page_token:
-                    builder.page_token(page_token)
-
-                resp = api.list(builder.build())
-
-                if not resp.success():
-                    logger.warning(
-                        "feishu.fetch_history failed chat_id={} code={} msg={}",
-                        chat_id,
-                        resp.code,
-                        resp.msg,
-                    )
-                    break
-
-                data = getattr(resp, "data", None)
-                for item in getattr(data, "items", None) or []:
-                    body = getattr(item, "body", None)
-                    content = getattr(body, "content", None) if body else None
-                    if not content:
-                        continue
-                    msg_type = getattr(item, "msg_type", None) or "text"
-                    sender = getattr(item, "sender", None)
-                    sender_id = (getattr(sender, "id", "") or "") if sender else ""
-                    history.append(
-                        {
-                            "message_id": getattr(item, "message_id", "") or "",
-                            "sender_id": sender_id,
-                            "sender": self._resolve_user_name(sender_id),
-                            "content": _normalize_text(msg_type, content),
-                            "create_time": _format_feishu_timestamp(
-                                getattr(item, "create_time", None)
-                            ),
-                        }
-                    )
-
-                has_more = getattr(data, "has_more", False) if data else False
-                page_token = getattr(data, "page_token", None) if data else None
-                if not has_more or not page_token:
-                    break
-
-        except Exception:
-            logger.exception("feishu.fetch_history error chat_id={}", chat_id)
-
-        return history
-
-    def _resolve_user_name(self, open_id: str) -> str:
-        """Resolve an open_id to a display name, with caching."""
-        if not open_id:
-            return ""
-        if open_id in self._user_name_cache:
-            return self._user_name_cache[open_id]
-
-        name = self._fetch_user_name(open_id)
-        self._user_name_cache[open_id] = name
-        return name
-
-    def _fetch_user_name(self, open_id: str) -> str:
-        """Call Feishu contact API to get user's display name."""
-        if self._api_client is None:
-            return open_id
-        try:
-            from lark_oapi.api.contact.v3 import GetUserRequest
-
-            req = (
-                GetUserRequest.builder()
-                .user_id(open_id)
-                .user_id_type("open_id")
-                .build()
-            )
-            resp = self._api_client.contact.v3.user.get(req)
-            if resp.success():
-                user = getattr(resp, "data", None)
-                user_obj = getattr(user, "user", None) if user else None
-                if user_obj:
-                    return getattr(user_obj, "name", None) or open_id
-            else:
-                logger.debug(
-                    "feishu.fetch_user_name failed open_id={} code={} msg={}",
-                    open_id,
-                    resp.code,
-                    resp.msg,
-                )
-        except Exception:
-            logger.debug("feishu.fetch_user_name error open_id={}", open_id)
-        return open_id
 
     # -- outbound ------------------------------------------------------------
 
@@ -761,67 +576,6 @@ def _extract_outbound_text(message: ChannelMessage) -> str:
             if isinstance(text, str) and text.strip():
                 return text
     return content.strip() if isinstance(content, str) else ""
-
-
-def _parse_time_range(time_str: str | None) -> float | None:
-    """Parse time range string to Unix timestamp (seconds).
-
-    Supports:
-    - Relative: "3h" (hours), "1d", "7d", "30d" (days)
-    - ISO format: "2024-01-01", "2024-01-01T10:00:00"
-    - Unix timestamp (seconds or milliseconds)
-    """
-    if not time_str:
-        return None
-
-    time_str = time_str.strip()
-
-    # Relative time: hours
-    if time_str.endswith("h"):
-        try:
-            hours = int(time_str[:-1])
-            return time.time() - (hours * 3600)
-        except ValueError:
-            pass
-
-    # Relative time: days
-    if time_str.endswith("d"):
-        try:
-            days = int(time_str[:-1])
-            return time.time() - (days * 86400)
-        except ValueError:
-            pass
-
-    # Try parsing as integer (Unix timestamp)
-    try:
-        ts = int(time_str)
-        # Detect milliseconds (13 digits) vs seconds (10 digits)
-        if ts > 1e12:
-            ts = ts / 1000
-        return float(ts)
-    except ValueError:
-        pass
-
-    # Try ISO format
-    try:
-        dt = datetime.fromisoformat(time_str)
-        return dt.timestamp()
-    except ValueError:
-        pass
-
-    return None
-
-
-def _format_feishu_timestamp(ts: str | int | None) -> str:
-    """Convert Feishu millisecond timestamp to local time string."""
-    if not ts:
-        return ""
-    try:
-        epoch_ms = int(ts)
-        dt = datetime.fromtimestamp(epoch_ms / 1000).astimezone()
-        return dt.strftime("%Y-%m-%d %H:%M:%S")
-    except (ValueError, OSError):
-        return str(ts) if ts else ""
 
 
 # Patterns that indicate rich content needing card rendering

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -6,7 +6,9 @@ import asyncio
 import contextlib
 import json
 import os
+import re
 import threading
+import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, ClassVar
@@ -154,10 +156,10 @@ class FeishuChannel(Channel):
 
         self._loop = asyncio.get_running_loop()
 
-        # Register this channel instance globally for tool access
-        from bub_im_bridge.feishu import tools as feishu_tools
+        # Register this channel instance for tool access
+        from bub_im_bridge.feishu.tools import registry
 
-        feishu_tools._channel_instance = self
+        registry.set(self)
 
         logger.info(
             "feishu.start app_id={}... allow_users={} allow_chats={} bot_open_id={}",
@@ -368,7 +370,7 @@ class FeishuChannel(Channel):
         # Fetch quoted message content if this is a reply
         quoted_message = None
         if message.parent_id:
-            quoted_message = await self._fetch_message_content(message.parent_id)
+            quoted_message = await self.fetch_message_content(message.parent_id)
 
         payload: dict[str, Any] = {
             "message": message.text + FEISHU_OUTPUT_INSTRUCTION,
@@ -404,25 +406,25 @@ class FeishuChannel(Channel):
 
     # -- message fetching ----------------------------------------------------
 
-    async def _fetch_message_content(self, message_id: str) -> str | None:
-        """Fetch the content of a message by its ID."""
-        if self._api_client is None or not message_id:
+    def _get_message_api(self) -> Any | None:
+        """Return the ``im.v1.message`` API handle, or ``None``."""
+        if self._api_client is None:
+            return None
+        im = getattr(self._api_client, "im", None)
+        v1 = getattr(im, "v1", None) if im else None
+        return getattr(v1, "message", None) if v1 else None
+
+    async def fetch_message_content(self, message_id: str) -> str | None:
+        """Fetch the text content of a single message by ID."""
+        api = self._get_message_api()
+        if api is None or not message_id:
             return None
 
         try:
             from lark_oapi.api.im.v1 import GetMessageRequest
 
             req = GetMessageRequest.builder().message_id(message_id).build()
-            im_api = getattr(self._api_client, "im", None)
-            if not im_api:
-                return None
-            v1_api = getattr(im_api, "v1", None)
-            if not v1_api:
-                return None
-            message_api = getattr(v1_api, "message", None)
-            if not message_api:
-                return None
-            resp = message_api.get(req)
+            resp = api.get(req)
 
             if not resp.success():
                 logger.warning(
@@ -433,57 +435,41 @@ class FeishuChannel(Channel):
                 )
                 return None
 
-            msg = getattr(resp, "data", None)
-            if msg:
-                body = getattr(msg, "body", None)
-                if body:
-                    content = getattr(body, "content", None)
-                    if content:
-                        msg_type = getattr(msg, "msg_type", None) or "text"
-                        return _normalize_text(msg_type, content)
+            data = getattr(resp, "data", None)
+            if data:
+                body = getattr(data, "body", None)
+                content = getattr(body, "content", None) if body else None
+                if content:
+                    msg_type = getattr(data, "msg_type", None) or "text"
+                    return _normalize_text(msg_type, content)
 
         except Exception:
             logger.exception("feishu.fetch_message error message_id={}", message_id)
 
         return None
 
-    async def _fetch_chat_history(
+    async def fetch_chat_history(
         self,
         chat_id: str,
         start_time: str | None = None,
         end_time: str | None = None,
-    ) -> list[dict[str, str]] | None:
-        """Fetch chat history with optional time range.
+    ) -> list[dict[str, str]]:
+        """Fetch chat messages, optionally filtered by time range.
 
-        Uses pagination to retrieve all messages within the time range.
-
-        Args:
-            chat_id: The chat ID to fetch history from.
-            start_time: Relative like "1d", "7d" or ISO format.
-            end_time: End time (defaults to now).
+        Returns all pages of results. Uses ``_parse_time_range`` to convert
+        human-friendly strings like ``"1d"`` or ``"7d"`` into timestamps.
         """
-        if self._api_client is None or not chat_id:
-            return None
+        api = self._get_message_api()
+        if api is None or not chat_id:
+            return []
+
+        start_ts = _parse_time_range(start_time)
+        end_ts = _parse_time_range(end_time)
+        history: list[dict[str, str]] = []
+        page_token: str | None = None
 
         try:
             from lark_oapi.api.im.v1 import ListMessageRequest
-
-            im_api = getattr(self._api_client, "im", None)
-            if not im_api:
-                return None
-            v1_api = getattr(im_api, "v1", None)
-            if not v1_api:
-                return None
-            message_api = getattr(v1_api, "message", None)
-            if not message_api:
-                return None
-
-            # Add time range filters if provided
-            start_ts = _parse_time_range(start_time)
-            end_ts = _parse_time_range(end_time)
-
-            history: list[dict[str, str]] = []
-            page_token: str | None = None
 
             while True:
                 builder = (
@@ -499,8 +485,7 @@ class FeishuChannel(Channel):
                 if page_token:
                     builder.page_token(page_token)
 
-                req = builder.build()
-                resp = message_api.list(req)
+                resp = api.list(builder.build())
 
                 if not resp.success():
                     logger.warning(
@@ -512,42 +497,35 @@ class FeishuChannel(Channel):
                     break
 
                 data = getattr(resp, "data", None)
-                items = getattr(data, "items", None) if data else None
-                if items:
-                    for item in items:
-                        body = getattr(item, "body", None)
-                        if body:
-                            content = getattr(body, "content", None)
-                            if content:
-                                msg_type = getattr(item, "msg_type", None) or "text"
-                                normalized = _normalize_text(msg_type, content)
-                                sender = getattr(item, "sender", None)
-                                sender_id = getattr(sender, "id", "") if sender else ""
-                                create_time = getattr(item, "create_time", None)
-                                history.append(
-                                    {
-                                        "message_id": getattr(item, "message_id", "")
-                                        or "",
-                                        "sender": sender_id or "",
-                                        "content": normalized,
-                                        "create_time": _format_feishu_timestamp(
-                                            create_time
-                                        ),
-                                    }
-                                )
+                for item in getattr(data, "items", None) or []:
+                    body = getattr(item, "body", None)
+                    content = getattr(body, "content", None) if body else None
+                    if not content:
+                        continue
+                    msg_type = getattr(item, "msg_type", None) or "text"
+                    sender = getattr(item, "sender", None)
+                    history.append(
+                        {
+                            "message_id": getattr(item, "message_id", "") or "",
+                            "sender": (getattr(sender, "id", "") or "")
+                            if sender
+                            else "",
+                            "content": _normalize_text(msg_type, content),
+                            "create_time": _format_feishu_timestamp(
+                                getattr(item, "create_time", None)
+                            ),
+                        }
+                    )
 
-                # Check for next page
                 has_more = getattr(data, "has_more", False) if data else False
                 page_token = getattr(data, "page_token", None) if data else None
                 if not has_more or not page_token:
                     break
 
-            return history if history else None
-
         except Exception:
             logger.exception("feishu.fetch_history error chat_id={}", chat_id)
 
-        return None
+        return history
 
     # -- outbound ------------------------------------------------------------
 
@@ -733,15 +711,11 @@ def _extract_outbound_text(message: ChannelMessage) -> str:
     return content.strip() if isinstance(content, str) else ""
 
 
-import re
-import time
-
-
 def _parse_time_range(time_str: str | None) -> float | None:
     """Parse time range string to Unix timestamp (seconds).
 
     Supports:
-    - Relative: "1d", "7d", "30d" (days)
+    - Relative: "3h" (hours), "1d", "7d", "30d" (days)
     - ISO format: "2024-01-01", "2024-01-01T10:00:00"
     - Unix timestamp (seconds or milliseconds)
     """
@@ -750,7 +724,15 @@ def _parse_time_range(time_str: str | None) -> float | None:
 
     time_str = time_str.strip()
 
-    # Relative time (e.g., "1d", "7d", "30d")
+    # Relative time: hours
+    if time_str.endswith("h"):
+        try:
+            hours = int(time_str[:-1])
+            return time.time() - (hours * 3600)
+        except ValueError:
+            pass
+
+    # Relative time: days
     if time_str.endswith("d"):
         try:
             days = int(time_str[:-1])

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -347,11 +347,6 @@ class FeishuChannel(Channel):
         if text.startswith("/"):
             text = "," + text[1:]
 
-        # Handle history command: ,history 1d or /history 7d
-        if text.startswith(",history"):
-            await self._handle_history_command(message, text)
-            return
-
         if text.startswith(","):
             await self._on_receive(
                 ChannelMessage(
@@ -383,6 +378,14 @@ class FeishuChannel(Channel):
             payload["quoted_message"] = quoted_message
 
         local_time = _format_feishu_timestamp(message.create_time)
+
+        # Register channel instance and chat_id in context for tool access
+        context: dict[str, Any] = {}
+        if local_time:
+            context["date"] = local_time
+        context["_feishu_channel"] = self
+        context["_feishu_chat_id"] = message.chat_id
+
         await self._on_receive(
             ChannelMessage(
                 session_id=session_id,
@@ -390,52 +393,7 @@ class FeishuChannel(Channel):
                 chat_id=message.chat_id,
                 content=json.dumps(payload, ensure_ascii=False),
                 is_active=True,
-                context={"date": local_time} if local_time else {},
-            )
-        )
-
-    async def _handle_history_command(
-        self, message: FeishuInboundMessage, text: str
-    ) -> None:
-        """Handle ,history [time_range] command to fetch chat history.
-
-        Examples:
-            ,history         - fetch last 20 messages
-            ,history 1d      - fetch messages from last 1 day
-            ,history 7d      - fetch messages from last 7 days
-        """
-        session_id = f"feishu:{message.chat_id}"
-        self._last_message_id[message.chat_id] = message.message_id
-
-        # Parse time range from command
-        parts = text.split()
-        time_range = parts[1] if len(parts) > 1 else None
-
-        # Fetch history
-        history = await self._fetch_chat_history(
-            message.chat_id, limit=20, start_time=time_range
-        )
-
-        if not history:
-            response_text = "No messages found for the specified time range."
-        else:
-            # Format history for display
-            lines = [f"Chat history ({len(history)} messages):\n"]
-            for msg in history:
-                sender = msg.get("sender", "unknown")
-                content = msg.get("content", "")
-                create_time = msg.get("create_time", "")
-                lines.append(f"[{create_time}] {sender}: {content}")
-            response_text = "\n".join(lines)
-
-        # Send response
-        await self.send(
-            ChannelMessage(
-                session_id=session_id,
-                channel=self.name,
-                chat_id=message.chat_id,
-                content=response_text,
-                is_active=True,
+                context=context,
             )
         )
 

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -161,11 +161,6 @@ class FeishuChannel(Channel):
             .build()
         )
 
-        # Register client for tool access
-        from bub_im_bridge.feishu.tools import set_client
-
-        set_client(self._api_client)
-
         event_handler = (
             lark.EventDispatcherHandler.builder(
                 self._verification_token,

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -381,6 +381,19 @@ class FeishuChannel(Channel):
             "create_time": _format_feishu_timestamp(message.create_time),
         }
 
+        # In group chats, the bot only sees messages that @mention it.
+        # Remind the LLM to use feishu.history for full chat history.
+        if message.is_group:
+            payload["message"] += (
+                "\n\n<important>"
+                "You are in a GROUP chat. You can ONLY see messages where you are @mentioned. "
+                "You CANNOT see other messages in this group. "
+                "When the user asks about chat history, previous messages, or what others said, "
+                "you MUST use the feishu_history tool to fetch the actual messages. "
+                "Do NOT guess or make up chat history."
+                "</important>"
+            )
+
         if quoted_message:
             payload["quoted_message"] = quoted_message
 

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -26,7 +26,11 @@ from bub.channels.base import Channel
 from bub.channels.message import ChannelMessage
 from bub.types import MessageHandler
 
-from bub_im_bridge.feishu.feishu_prompts import FEISHU_OUTPUT_INSTRUCTION
+from bub_im_bridge.feishu.feishu_prompts import (
+    FEISHU_HISTORY_HINT_GROUP,
+    FEISHU_HISTORY_HINT_P2P,
+    FEISHU_OUTPUT_INSTRUCTION,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -375,27 +379,18 @@ class FeishuChannel(Channel):
         if message.parent_id:
             quoted_message = await self.fetch_message_content(message.parent_id)
 
+        history_hint = (
+            FEISHU_HISTORY_HINT_GROUP if message.is_group else FEISHU_HISTORY_HINT_P2P
+        )
+
         payload: dict[str, Any] = {
-            "message": message.text + FEISHU_OUTPUT_INSTRUCTION,
+            "message": message.text + FEISHU_OUTPUT_INSTRUCTION + history_hint,
             "message_id": message.message_id,
             "chat_type": message.chat_type,
             "sender_id": message.sender_open_id or "",
             "sender_name": message.sender_display,
             "create_time": _format_feishu_timestamp(message.create_time),
         }
-
-        # In group chats, the bot only sees messages that @mention it.
-        # Remind the LLM to use feishu.history for full chat history.
-        if message.is_group:
-            payload["message"] += (
-                "\n\n<important>"
-                "You are in a GROUP chat. You can ONLY see messages where you are @mentioned. "
-                "You CANNOT see other messages in this group. "
-                "When the user asks about chat history, previous messages, or what others said, "
-                "you MUST use the feishu_history tool to fetch the actual messages. "
-                "Do NOT guess or make up chat history."
-                "</important>"
-            )
 
         if quoted_message:
             payload["quoted_message"] = quoted_message

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -347,6 +347,11 @@ class FeishuChannel(Channel):
         if text.startswith("/"):
             text = "," + text[1:]
 
+        # Handle history command: ,history 1d or /history 7d
+        if text.startswith(",history"):
+            await self._handle_history_command(message, text)
+            return
+
         if text.startswith(","):
             await self._on_receive(
                 ChannelMessage(
@@ -365,9 +370,6 @@ class FeishuChannel(Channel):
         if message.parent_id:
             quoted_message = await self._fetch_message_content(message.parent_id)
 
-        # Fetch recent chat history for context
-        chat_history = await self._fetch_chat_history(message.chat_id, limit=10)
-
         payload: dict[str, Any] = {
             "message": message.text + FEISHU_OUTPUT_INSTRUCTION,
             "message_id": message.message_id,
@@ -380,9 +382,6 @@ class FeishuChannel(Channel):
         if quoted_message:
             payload["quoted_message"] = quoted_message
 
-        if chat_history:
-            payload["chat_history"] = chat_history
-
         local_time = _format_feishu_timestamp(message.create_time)
         await self._on_receive(
             ChannelMessage(
@@ -392,6 +391,51 @@ class FeishuChannel(Channel):
                 content=json.dumps(payload, ensure_ascii=False),
                 is_active=True,
                 context={"date": local_time} if local_time else {},
+            )
+        )
+
+    async def _handle_history_command(
+        self, message: FeishuInboundMessage, text: str
+    ) -> None:
+        """Handle ,history [time_range] command to fetch chat history.
+
+        Examples:
+            ,history         - fetch last 20 messages
+            ,history 1d      - fetch messages from last 1 day
+            ,history 7d      - fetch messages from last 7 days
+        """
+        session_id = f"feishu:{message.chat_id}"
+        self._last_message_id[message.chat_id] = message.message_id
+
+        # Parse time range from command
+        parts = text.split()
+        time_range = parts[1] if len(parts) > 1 else None
+
+        # Fetch history
+        history = await self._fetch_chat_history(
+            message.chat_id, limit=20, start_time=time_range
+        )
+
+        if not history:
+            response_text = "No messages found for the specified time range."
+        else:
+            # Format history for display
+            lines = [f"Chat history ({len(history)} messages):\n"]
+            for msg in history:
+                sender = msg.get("sender", "unknown")
+                content = msg.get("content", "")
+                create_time = msg.get("create_time", "")
+                lines.append(f"[{create_time}] {sender}: {content}")
+            response_text = "\n".join(lines)
+
+        # Send response
+        await self.send(
+            ChannelMessage(
+                session_id=session_id,
+                channel=self.name,
+                chat_id=message.chat_id,
+                content=response_text,
+                is_active=True,
             )
         )
 
@@ -441,22 +485,42 @@ class FeishuChannel(Channel):
         return None
 
     async def _fetch_chat_history(
-        self, chat_id: str, limit: int = 10
+        self,
+        chat_id: str,
+        limit: int = 20,
+        start_time: str | None = None,
+        end_time: str | None = None,
     ) -> list[dict[str, str]] | None:
-        """Fetch recent chat history for context."""
+        """Fetch chat history with optional time range.
+
+        Args:
+            chat_id: The chat ID to fetch history from.
+            limit: Maximum number of messages to return (max 50).
+            start_time: Start time in ISO format or relative like "1d", "7d".
+            end_time: End time in ISO format (defaults to now).
+        """
         if self._api_client is None or not chat_id:
             return None
 
         try:
             from lark_oapi.api.im.v1 import ListMessageRequest
 
-            req = (
+            builder = (
                 ListMessageRequest.builder()
                 .container_id_type("chat")
                 .container_id(chat_id)
                 .page_size(min(limit, 50))
-                .build()
             )
+
+            # Add time range filters if provided
+            start_ts = _parse_time_range(start_time)
+            end_ts = _parse_time_range(end_time)
+            if start_ts:
+                builder.start_time(str(int(start_ts)))
+            if end_ts:
+                builder.end_time(str(int(end_ts)))
+
+            req = builder.build()
             im_api = getattr(self._api_client, "im", None)
             if not im_api:
                 return None
@@ -694,6 +758,48 @@ def _extract_outbound_text(message: ChannelMessage) -> str:
 
 
 import re
+import time
+
+
+def _parse_time_range(time_str: str | None) -> float | None:
+    """Parse time range string to Unix timestamp (seconds).
+
+    Supports:
+    - Relative: "1d", "7d", "30d" (days)
+    - ISO format: "2024-01-01", "2024-01-01T10:00:00"
+    - Unix timestamp (seconds or milliseconds)
+    """
+    if not time_str:
+        return None
+
+    time_str = time_str.strip()
+
+    # Relative time (e.g., "1d", "7d", "30d")
+    if time_str.endswith("d"):
+        try:
+            days = int(time_str[:-1])
+            return time.time() - (days * 86400)
+        except ValueError:
+            pass
+
+    # Try parsing as integer (Unix timestamp)
+    try:
+        ts = int(time_str)
+        # Detect milliseconds (13 digits) vs seconds (10 digits)
+        if ts > 1e12:
+            ts = ts / 1000
+        return float(ts)
+    except ValueError:
+        pass
+
+    # Try ISO format
+    try:
+        dt = datetime.fromisoformat(time_str)
+        return dt.timestamp()
+    except ValueError:
+        pass
+
+    return None
 
 
 def _format_feishu_timestamp(ts: str | int | None) -> str:

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -144,6 +144,9 @@ class FeishuChannel(Channel):
         # (The bub framework does not forward ``context`` to outbound messages.)
         self._last_message_id: dict[str, str] = {}
 
+        # Cache: open_id -> display name (avoids repeated API calls)
+        self._user_name_cache: dict[str, str] = {}
+
     @property
     def needs_debounce(self) -> bool:
         return True
@@ -517,12 +520,12 @@ class FeishuChannel(Channel):
                         continue
                     msg_type = getattr(item, "msg_type", None) or "text"
                     sender = getattr(item, "sender", None)
+                    sender_id = (getattr(sender, "id", "") or "") if sender else ""
                     history.append(
                         {
                             "message_id": getattr(item, "message_id", "") or "",
-                            "sender": (getattr(sender, "id", "") or "")
-                            if sender
-                            else "",
+                            "sender_id": sender_id,
+                            "sender": self._resolve_user_name(sender_id),
                             "content": _normalize_text(msg_type, content),
                             "create_time": _format_feishu_timestamp(
                                 getattr(item, "create_time", None)
@@ -539,6 +542,47 @@ class FeishuChannel(Channel):
             logger.exception("feishu.fetch_history error chat_id={}", chat_id)
 
         return history
+
+    def _resolve_user_name(self, open_id: str) -> str:
+        """Resolve an open_id to a display name, with caching."""
+        if not open_id:
+            return ""
+        if open_id in self._user_name_cache:
+            return self._user_name_cache[open_id]
+
+        name = self._fetch_user_name(open_id)
+        self._user_name_cache[open_id] = name
+        return name
+
+    def _fetch_user_name(self, open_id: str) -> str:
+        """Call Feishu contact API to get user's display name."""
+        if self._api_client is None:
+            return open_id
+        try:
+            from lark_oapi.api.contact.v3 import GetUserRequest
+
+            req = (
+                GetUserRequest.builder()
+                .user_id(open_id)
+                .user_id_type("open_id")
+                .build()
+            )
+            resp = self._api_client.contact.v3.user.get(req)
+            if resp.success():
+                user = getattr(resp, "data", None)
+                user_obj = getattr(user, "user", None) if user else None
+                if user_obj:
+                    return getattr(user_obj, "name", None) or open_id
+            else:
+                logger.debug(
+                    "feishu.fetch_user_name failed open_id={} code={} msg={}",
+                    open_id,
+                    resp.code,
+                    resp.msg,
+                )
+        except Exception:
+            logger.debug("feishu.fetch_user_name error open_id={}", open_id)
+        return open_id
 
     # -- outbound ------------------------------------------------------------
 

--- a/src/bub_im_bridge/feishu/feishu_prompts.py
+++ b/src/bub_im_bridge/feishu/feishu_prompts.py
@@ -16,20 +16,4 @@ Your response will be rendered in Feishu. Use standard Markdown with these rules
 
 For simple conversational replies, respond naturally without formatting — like a normal person chatting.
 Only use rich formatting (headings, tables, lists) when the content benefits from structure.
-</output_format>
-
-<tools>
-You have access to the feishu.history tool for fetching chat history. Use it when users ask about previous messages, chat history, or what was discussed earlier.
-
-Examples of when to use feishu.history:
-- "What did we discuss yesterday?"
-- "Show me messages from the last week"
-- "What was the last thing John said?"
-- "查一下最近1天的消息"
-- "看看昨天的聊天记录"
-- "最近都聊了什么"
-
-Parameters:
-- time_range: Time range for history query (e.g., '1d', '7d', '24h'). If not specified, returns recent messages.
-- limit: Maximum number of messages to return (default 20, max 50).
-</tools>"""
+</output_format>"""

--- a/src/bub_im_bridge/feishu/feishu_prompts.py
+++ b/src/bub_im_bridge/feishu/feishu_prompts.py
@@ -16,4 +16,20 @@ Your response will be rendered in Feishu. Use standard Markdown with these rules
 
 For simple conversational replies, respond naturally without formatting — like a normal person chatting.
 Only use rich formatting (headings, tables, lists) when the content benefits from structure.
-</output_format>"""
+</output_format>
+
+<tools>
+You have access to the feishu.history tool for fetching chat history. Use it when users ask about previous messages, chat history, or what was discussed earlier.
+
+Examples of when to use feishu.history:
+- "What did we discuss yesterday?"
+- "Show me messages from the last week"
+- "What was the last thing John said?"
+- "查一下最近1天的消息"
+- "看看昨天的聊天记录"
+- "最近都聊了什么"
+
+Parameters:
+- time_range: Time range for history query (e.g., '1d', '7d', '24h'). If not specified, returns recent messages.
+- limit: Maximum number of messages to return (default 20, max 50).
+</tools>"""

--- a/src/bub_im_bridge/feishu/feishu_prompts.py
+++ b/src/bub_im_bridge/feishu/feishu_prompts.py
@@ -1,4 +1,4 @@
-"""Feishu-specific output format instructions appended to user messages."""
+"""Feishu-specific prompt instructions appended to user messages."""
 
 FEISHU_OUTPUT_INSTRUCTION = """\
 
@@ -17,3 +17,24 @@ Your response will be rendered in Feishu. Use standard Markdown with these rules
 For simple conversational replies, respond naturally without formatting — like a normal person chatting.
 Only use rich formatting (headings, tables, lists) when the content benefits from structure.
 </output_format>"""
+
+FEISHU_HISTORY_HINT_P2P = """\
+
+<important>
+Your conversation history (tape) only contains messages processed by this bot session. \
+It does NOT include the full Feishu chat history (e.g. messages before the bot started, \
+or messages outside this session). \
+When the user asks about chat history, previous messages, or past conversations, \
+you MUST use the feishu_history tool to fetch the actual messages from Feishu. \
+Do NOT rely solely on your conversation tape or guess chat history.
+</important>"""
+
+FEISHU_HISTORY_HINT_GROUP = """\
+
+<important>
+You are in a GROUP chat. You can ONLY see messages where you are @mentioned. \
+You CANNOT see other messages in this group. \
+When the user asks about chat history, previous messages, or what others said, \
+you MUST use the feishu_history tool to fetch the actual messages. \
+Do NOT guess or make up chat history.
+</important>"""

--- a/src/bub_im_bridge/feishu/plugin.py
+++ b/src/bub_im_bridge/feishu/plugin.py
@@ -9,6 +9,7 @@ from bub.hookspecs import hookimpl
 from bub.types import MessageHandler
 
 from bub_im_bridge.feishu.channel import FeishuChannel
+from bub_im_bridge.feishu import tools  # noqa: F401 - import to register tools
 
 
 class FeishPlugin:

--- a/src/bub_im_bridge/feishu/tools.py
+++ b/src/bub_im_bridge/feishu/tools.py
@@ -12,15 +12,23 @@ from bub_im_bridge.feishu.api import fetch_chat_history
 
 
 # ---------------------------------------------------------------------------
-# Helpers
+# Client registry – set once by FeishuChannel.start(), read by tools.
 # ---------------------------------------------------------------------------
 
+_api_client: lark.Client | None = None
 
-def _ensure_client(state: dict) -> lark.Client:
-    client = state.get("_feishu_api_client")
-    if client is None:
-        raise RuntimeError("Feishu API client not found in state")
-    return client
+
+def set_client(client: lark.Client) -> None:
+    """Register the Feishu API client (called by FeishuChannel.start)."""
+    global _api_client
+    _api_client = client
+
+
+def _get_client() -> lark.Client:
+    """Return the registered client or raise."""
+    if _api_client is None:
+        raise RuntimeError("Feishu API client has not been registered yet")
+    return _api_client
 
 
 def _session_to_chat_id(context: ToolContext) -> str | None:
@@ -63,7 +71,7 @@ async def feishu_history(params: HistoryInput, *, context: ToolContext) -> str:
     - "查一下最近1天的消息"
     - "看看昨天的聊天记录"
     """
-    client = _ensure_client(context.state)
+    client = _get_client()
 
     chat_id = _session_to_chat_id(context)
     if not chat_id:

--- a/src/bub_im_bridge/feishu/tools.py
+++ b/src/bub_im_bridge/feishu/tools.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import os
+from functools import lru_cache
+
 import lark_oapi as lark
 from pydantic import BaseModel, Field
 from republic import ToolContext
@@ -12,23 +15,24 @@ from bub_im_bridge.feishu.api import fetch_chat_history
 
 
 # ---------------------------------------------------------------------------
-# Client registry – set once by FeishuChannel.start(), read by tools.
+# Helpers
 # ---------------------------------------------------------------------------
 
-_api_client: lark.Client | None = None
 
-
-def set_client(client: lark.Client) -> None:
-    """Register the Feishu API client (called by FeishuChannel.start)."""
-    global _api_client
-    _api_client = client
-
-
-def _get_client() -> lark.Client:
-    """Return the registered client or raise."""
-    if _api_client is None:
-        raise RuntimeError("Feishu API client has not been registered yet")
-    return _api_client
+@lru_cache(maxsize=1)
+def _build_client() -> lark.Client:
+    """Lazily build a shared Feishu API client from environment variables."""
+    app_id = os.environ.get("BUB_FEISHU_APP_ID", "")
+    app_secret = os.environ.get("BUB_FEISHU_APP_SECRET", "")
+    if not app_id or not app_secret:
+        raise RuntimeError("BUB_FEISHU_APP_ID / BUB_FEISHU_APP_SECRET not set")
+    return (
+        lark.Client.builder()
+        .app_id(app_id)
+        .app_secret(app_secret)
+        .log_level(lark.LogLevel.WARNING)
+        .build()
+    )
 
 
 def _session_to_chat_id(context: ToolContext) -> str | None:
@@ -71,7 +75,7 @@ async def feishu_history(params: HistoryInput, *, context: ToolContext) -> str:
     - "查一下最近1天的消息"
     - "看看昨天的聊天记录"
     """
-    client = _get_client()
+    client = _build_client()
 
     chat_id = _session_to_chat_id(context)
     if not chat_id:

--- a/src/bub_im_bridge/feishu/tools.py
+++ b/src/bub_im_bridge/feishu/tools.py
@@ -91,26 +91,10 @@ async def feishu_history(params: HistoryInput, *, context: ToolContext) -> str:
         return "No messages found for the specified time range."
 
     lines = [f"Found {len(history)} messages:\n"]
-    total_len = 0
-    max_len = 8000  # Keep tool output within a reasonable size for LLM context
-    truncated = False
     for msg in history:
         sender = msg.get("sender", "unknown")
         content = msg.get("content", "")
         create_time = msg.get("create_time", "")
-        # Truncate individual long messages
-        if len(content) > 200:
-            content = content[:200] + "..."
-        line = f"[{create_time}] {sender}: {content}"
-        total_len += len(line)
-        if total_len > max_len:
-            truncated = True
-            break
-        lines.append(line)
-
-    if truncated:
-        lines.append(
-            f"\n... (truncated, showing {len(lines) - 1} of {len(history)} messages)"
-        )
+        lines.append(f"[{create_time}] {sender}: {content}")
 
     return "\n".join(lines)

--- a/src/bub_im_bridge/feishu/tools.py
+++ b/src/bub_im_bridge/feishu/tools.py
@@ -91,10 +91,26 @@ async def feishu_history(params: HistoryInput, *, context: ToolContext) -> str:
         return "No messages found for the specified time range."
 
     lines = [f"Found {len(history)} messages:\n"]
+    total_len = 0
+    max_len = 8000  # Keep tool output within a reasonable size for LLM context
+    truncated = False
     for msg in history:
         sender = msg.get("sender", "unknown")
         content = msg.get("content", "")
         create_time = msg.get("create_time", "")
-        lines.append(f"[{create_time}] {sender}: {content}")
+        # Truncate individual long messages
+        if len(content) > 200:
+            content = content[:200] + "..."
+        line = f"[{create_time}] {sender}: {content}"
+        total_len += len(line)
+        if total_len > max_len:
+            truncated = True
+            break
+        lines.append(line)
+
+    if truncated:
+        lines.append(
+            f"\n... (truncated, showing {len(lines) - 1} of {len(history)} messages)"
+        )
 
     return "\n".join(lines)

--- a/src/bub_im_bridge/feishu/tools.py
+++ b/src/bub_im_bridge/feishu/tools.py
@@ -12,13 +12,9 @@ from bub.tools import tool
 if TYPE_CHECKING:
     from bub_im_bridge.feishu.channel import FeishuChannel
 
-
-def _get_feishu_channel(context: ToolContext) -> FeishuChannel:
-    """Get FeishuChannel instance from tool context."""
-    channel = context.state.get("_feishu_channel")
-    if channel is None:
-        raise RuntimeError("Feishu channel not available in tool context")
-    return channel
+# Global reference to the active FeishuChannel instance.
+# Set by FeishuChannel.start(), read by tools at call time.
+_channel_instance: FeishuChannel | None = None
 
 
 class HistoryInput(BaseModel):
@@ -31,12 +27,6 @@ class HistoryInput(BaseModel):
             "'7d' (last 7 days), '24h' (last 24 hours). "
             "If not specified, returns the most recent messages."
         ),
-    )
-    limit: int = Field(
-        20,
-        description="Maximum number of messages to return (max 50).",
-        ge=1,
-        le=50,
     )
 
 
@@ -55,16 +45,21 @@ async def feishu_history(params: HistoryInput, *, context: ToolContext) -> str:
     - "查一下最近1天的消息"
     - "看看昨天的聊天记录"
     """
-    channel = _get_feishu_channel(context)
-    chat_id = context.state.get("_feishu_chat_id")
+    if _channel_instance is None:
+        return "Error: Feishu channel is not available."
+
+    # Resolve chat_id from session_id in state (format: "feishu:{chat_id}")
+    session_id = context.state.get("session_id", "")
+    chat_id = ""
+    if isinstance(session_id, str) and session_id.startswith("feishu:"):
+        chat_id = session_id.removeprefix("feishu:")
 
     if not chat_id:
-        return "Error: Cannot determine the current chat. Please try again."
+        return "Error: Cannot determine the current chat."
 
     # Parse time_range to start_time
     start_time = None
     if params.time_range:
-        # Convert "24h" to "1d" format if needed
         time_range = params.time_range
         if time_range.endswith("h"):
             try:
@@ -76,9 +71,8 @@ async def feishu_history(params: HistoryInput, *, context: ToolContext) -> str:
         else:
             start_time = time_range
 
-    history = await channel._fetch_chat_history(
+    history = await _channel_instance._fetch_chat_history(
         chat_id=chat_id,
-        limit=params.limit,
         start_time=start_time,
     )
 

--- a/src/bub_im_bridge/feishu/tools.py
+++ b/src/bub_im_bridge/feishu/tools.py
@@ -12,9 +12,38 @@ from bub.tools import tool
 if TYPE_CHECKING:
     from bub_im_bridge.feishu.channel import FeishuChannel
 
-# Global reference to the active FeishuChannel instance.
-# Set by FeishuChannel.start(), read by tools at call time.
-_channel_instance: FeishuChannel | None = None
+
+# ---------------------------------------------------------------------------
+# Channel registry – one writer (FeishuChannel.start), many readers (tools).
+# ---------------------------------------------------------------------------
+
+
+class _ChannelRegistry:
+    """Holds a reference to the active :class:`FeishuChannel`.
+
+    Intentionally a class rather than a bare global so that the mutation
+    surface is explicit and grep-able.
+    """
+
+    _instance: FeishuChannel | None = None
+
+    @classmethod
+    def set(cls, channel: FeishuChannel) -> None:
+        cls._instance = channel
+
+    @classmethod
+    def get(cls) -> FeishuChannel:
+        if cls._instance is None:
+            raise RuntimeError("Feishu channel has not been started yet")
+        return cls._instance
+
+
+registry = _ChannelRegistry
+
+
+# ---------------------------------------------------------------------------
+# Tool definitions
+# ---------------------------------------------------------------------------
 
 
 class HistoryInput(BaseModel):
@@ -24,10 +53,18 @@ class HistoryInput(BaseModel):
         None,
         description=(
             "Time range for history query. Examples: '1d' (last 1 day), "
-            "'7d' (last 7 days), '24h' (last 24 hours). "
+            "'7d' (last 7 days), '3h' (last 3 hours). "
             "If not specified, returns the most recent messages."
         ),
     )
+
+
+def _session_to_chat_id(context: ToolContext) -> str | None:
+    """Extract ``chat_id`` from the session id stored in tool context state."""
+    session_id = context.state.get("session_id", "")
+    if isinstance(session_id, str) and session_id.startswith("feishu:"):
+        return session_id.removeprefix("feishu:")
+    return None
 
 
 @tool(name="feishu.history", model=HistoryInput, context=True)
@@ -41,45 +78,23 @@ async def feishu_history(params: HistoryInput, *, context: ToolContext) -> str:
     Examples of when to use:
     - "What did we discuss yesterday?"
     - "Show me messages from the last week"
-    - "What was the last thing John said?"
     - "查一下最近1天的消息"
     - "看看昨天的聊天记录"
     """
-    if _channel_instance is None:
-        return "Error: Feishu channel is not available."
+    channel = registry.get()
 
-    # Resolve chat_id from session_id in state (format: "feishu:{chat_id}")
-    session_id = context.state.get("session_id", "")
-    chat_id = ""
-    if isinstance(session_id, str) and session_id.startswith("feishu:"):
-        chat_id = session_id.removeprefix("feishu:")
-
+    chat_id = _session_to_chat_id(context)
     if not chat_id:
         return "Error: Cannot determine the current chat."
 
-    # Parse time_range to start_time
-    start_time = None
-    if params.time_range:
-        time_range = params.time_range
-        if time_range.endswith("h"):
-            try:
-                hours = int(time_range[:-1])
-                days = hours / 24
-                start_time = f"{days:.1f}d"
-            except ValueError:
-                start_time = time_range
-        else:
-            start_time = time_range
-
-    history = await _channel_instance._fetch_chat_history(
+    history = await channel.fetch_chat_history(
         chat_id=chat_id,
-        start_time=start_time,
+        start_time=params.time_range,
     )
 
     if not history:
         return "No messages found for the specified time range."
 
-    # Format history for display
     lines = [f"Found {len(history)} messages:\n"]
     for msg in history:
         sender = msg.get("sender", "unknown")

--- a/src/bub_im_bridge/feishu/tools.py
+++ b/src/bub_im_bridge/feishu/tools.py
@@ -1,0 +1,96 @@
+"""Feishu-specific tools for the Bub framework."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+from republic import ToolContext
+
+from bub.tools import tool
+
+if TYPE_CHECKING:
+    from bub_im_bridge.feishu.channel import FeishuChannel
+
+
+def _get_feishu_channel(context: ToolContext) -> FeishuChannel:
+    """Get FeishuChannel instance from tool context."""
+    channel = context.state.get("_feishu_channel")
+    if channel is None:
+        raise RuntimeError("Feishu channel not available in tool context")
+    return channel
+
+
+class HistoryInput(BaseModel):
+    """Input parameters for feishu.history tool."""
+
+    time_range: str | None = Field(
+        None,
+        description=(
+            "Time range for history query. Examples: '1d' (last 1 day), "
+            "'7d' (last 7 days), '24h' (last 24 hours). "
+            "If not specified, returns the most recent messages."
+        ),
+    )
+    limit: int = Field(
+        20,
+        description="Maximum number of messages to return (max 50).",
+        ge=1,
+        le=50,
+    )
+
+
+@tool(name="feishu.history", model=HistoryInput, context=True)
+async def feishu_history(params: HistoryInput, *, context: ToolContext) -> str:
+    """Fetch chat history from the current Feishu conversation.
+
+    Use this tool when the user asks about previous messages, chat history,
+    or wants to see what was discussed earlier. Supports time range queries
+    like 'last 1 day' or 'last 7 days'.
+
+    Examples of when to use:
+    - "What did we discuss yesterday?"
+    - "Show me messages from the last week"
+    - "What was the last thing John said?"
+    - "查一下最近1天的消息"
+    - "看看昨天的聊天记录"
+    """
+    channel = _get_feishu_channel(context)
+    chat_id = context.state.get("_feishu_chat_id")
+
+    if not chat_id:
+        return "Error: Cannot determine the current chat. Please try again."
+
+    # Parse time_range to start_time
+    start_time = None
+    if params.time_range:
+        # Convert "24h" to "1d" format if needed
+        time_range = params.time_range
+        if time_range.endswith("h"):
+            try:
+                hours = int(time_range[:-1])
+                days = hours / 24
+                start_time = f"{days:.1f}d"
+            except ValueError:
+                start_time = time_range
+        else:
+            start_time = time_range
+
+    history = await channel._fetch_chat_history(
+        chat_id=chat_id,
+        limit=params.limit,
+        start_time=start_time,
+    )
+
+    if not history:
+        return "No messages found for the specified time range."
+
+    # Format history for display
+    lines = [f"Found {len(history)} messages:\n"]
+    for msg in history:
+        sender = msg.get("sender", "unknown")
+        content = msg.get("content", "")
+        create_time = msg.get("create_time", "")
+        lines.append(f"[{create_time}] {sender}: {content}")
+
+    return "\n".join(lines)

--- a/src/bub_im_bridge/feishu/tools.py
+++ b/src/bub_im_bridge/feishu/tools.py
@@ -2,43 +2,33 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
+import lark_oapi as lark
 from pydantic import BaseModel, Field
 from republic import ToolContext
 
 from bub.tools import tool
 
-if TYPE_CHECKING:
-    from bub_im_bridge.feishu.channel import FeishuChannel
+from bub_im_bridge.feishu.api import fetch_chat_history
 
 
 # ---------------------------------------------------------------------------
-# Channel registry – one writer (FeishuChannel.start), many readers (tools).
+# Helpers
 # ---------------------------------------------------------------------------
 
 
-class _ChannelRegistry:
-    """Holds a reference to the active :class:`FeishuChannel`.
-
-    Intentionally a class rather than a bare global so that the mutation
-    surface is explicit and grep-able.
-    """
-
-    _instance: FeishuChannel | None = None
-
-    @classmethod
-    def set(cls, channel: FeishuChannel) -> None:
-        cls._instance = channel
-
-    @classmethod
-    def get(cls) -> FeishuChannel:
-        if cls._instance is None:
-            raise RuntimeError("Feishu channel has not been started yet")
-        return cls._instance
+def _ensure_client(state: dict) -> lark.Client:
+    client = state.get("_feishu_api_client")
+    if client is None:
+        raise RuntimeError("Feishu API client not found in state")
+    return client
 
 
-registry = _ChannelRegistry
+def _session_to_chat_id(context: ToolContext) -> str | None:
+    """Extract ``chat_id`` from the session id stored in tool context state."""
+    session_id = context.state.get("session_id", "")
+    if isinstance(session_id, str) and session_id.startswith("feishu:"):
+        return session_id.removeprefix("feishu:")
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -59,14 +49,6 @@ class HistoryInput(BaseModel):
     )
 
 
-def _session_to_chat_id(context: ToolContext) -> str | None:
-    """Extract ``chat_id`` from the session id stored in tool context state."""
-    session_id = context.state.get("session_id", "")
-    if isinstance(session_id, str) and session_id.startswith("feishu:"):
-        return session_id.removeprefix("feishu:")
-    return None
-
-
 @tool(name="feishu.history", model=HistoryInput, context=True)
 async def feishu_history(params: HistoryInput, *, context: ToolContext) -> str:
     """Fetch chat history from the current Feishu conversation.
@@ -81,14 +63,15 @@ async def feishu_history(params: HistoryInput, *, context: ToolContext) -> str:
     - "查一下最近1天的消息"
     - "看看昨天的聊天记录"
     """
-    channel = registry.get()
+    client = _ensure_client(context.state)
 
     chat_id = _session_to_chat_id(context)
     if not chat_id:
         return "Error: Cannot determine the current chat."
 
-    history = await channel.fetch_chat_history(
-        chat_id=chat_id,
+    history = await fetch_chat_history(
+        client,
+        chat_id,
         start_time=params.time_range,
     )
 


### PR DESCRIPTION
## Summary

1. **Single chat: quoted message awareness** — When a user replies to a message, the bot fetches and includes the quoted message content in context
2. **Group chat: @mention only** — Bot only responds to @mentions, commands, or quoted messages
3. **Chat history via feishu.history tool** — LLM can fetch chat history through natural language queries, powered by Feishu API

## Architecture

```
tools.py          — feishu.history tool definition (self-contained, builds own lark.Client)
api.py            — pure Feishu API helpers (fetch_message_content, fetch_chat_history, etc.)
channel.py        — message routing, dispatch, quoted message handling
feishu_prompts.py — output format + history hints (group/p2p)
plugin.py         — tool registration via import
```

### Key Design Decisions

- **Tool builds its own client** — `lark.Client` is stateless (only needs env vars), so the tool lazily creates one via `@lru_cache` instead of requiring injection from channel
- **Chat ID from session_id** — Tool resolves `chat_id` from `context.state["session_id"]` (format: `feishu:{chat_id}`)
- **User name resolution** — Uses `GetChatMembers` API to bulk-load names (only needs `im:chat:readonly`), with contact API as fallback for edge cases
- **Group chat hint** — Explicit `<important>` prompt tells LLM it cannot see non-@mentioned messages and must use `feishu_history` tool

## Changes

### New Files
- `src/bub_im_bridge/feishu/tools.py` — `feishu.history` tool with `@lru_cache` client
- `src/bub_im_bridge/feishu/api.py` — Feishu API layer (message fetching, user resolution, time parsing)

### Modified Files
- `channel.py` — Quoted message fetching, group chat activation rules, history hints
- `feishu_prompts.py` — Output format instructions, group/p2p history hints
- `plugin.py` — Import tools module for registration

## Usage Examples

Natural language triggers:
- "查一下最近1天的消息"
- "看看昨天的聊天记录"
- "What did we discuss yesterday?"
- "Show me messages from the last week"

## Configuration

- `BUB_MAX_TOKENS` — Should be increased (e.g. 16384) for history summarization tasks. Default 1024 limits LLM output length.