### PR TITLE
fix(feishu): only respond to exact bot_id mentions in group chats

### DIFF
--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -315,13 +315,9 @@ class FeishuChannel(Channel):
         ):
             return True, "bot_mentioned"
 
-        # Mention whose display-name contains "bub"
-        if any("bub" in (m.name or "").lower() for m in message.mentions):
-            return True, "bub_name_mentioned"
-
-        # Any @-mention in a group chat
+        # Any @-mention in a group chat - return False to allow future customization
         if message.mentions:
-            return True, "has_mentions"
+            return False, "has_mentions_but_not_me"
 
         return False, "no_mention_in_group"
 


### PR DESCRIPTION
## Summary

修复飞书群聊中机器人响应逻辑，防止在 @ 其他机器人时当前机器人也错误响应。

## 问题描述

在群聊中 @ 其他机器人时，当前机器人也会响应消息。这是因为代码中有一个兜底逻辑，只要消息中包含任意 @mention，机器人就会被触发。

## 根本原因

`src/bub_im_bridge/feishu/channel.py:322-324` 中的逻辑：
```python
# Any @-mention in a group chat
if message.mentions:
    return True, "has_mentions"
```

## 解决方案

删除了两个宽松的触发条件：
1. ❌ 名称包含 "bub" 的 mention
2. ❌ 任意 @mention

现在只保留精确的 bot_id 匹配逻辑。

## 修改后的行为

群聊中机器人只在以下情况响应：
- ✅ 精确匹配 `BUB_FEISHU_BOT_OPEN_ID` 的 @mention
- ✅ 命令（以 `,` 或 `/` 开头）
- ✅ 引用消息（回复机器人的消息）

## 注意事项

需要确保在 `.env` 中配置了 `BUB_FEISHU_BOT_OPEN_ID` 环境变量，否则机器人将无法响应 @mention。

获取 bot_id 的方式参考：`.env.example:62-72`

## 测试

- [ ] 在群聊中 @ 当前机器人，应正常响应
- [ ] 在群聊中 @ 其他机器人，当前机器人不应响应
- [ ] 命令和回复功能仍正常工作