### PR TITLE
fix(feishu): fix quoted message content not fetched in group chat

### DIFF
--- a/src/bub_im_bridge/feishu/api.py
+++ b/src/bub_im_bridge/feishu/api.py
@@ -19,7 +19,11 @@ from loguru import logger
 
 
 async def fetch_message_content(client: lark.Client, message_id: str) -> str | None:
-    """Fetch the text content of a single message by ID."""
+    """Fetch the text content of a single message by ID.
+
+    Uses ``GET /open-apis/im/v1/messages/:message_id``.
+    Requires ``im:message`` or ``im:message:readonly`` permission.
+    """
     api = _get_message_api(client)
     if api is None or not message_id:
         return None
@@ -40,22 +44,36 @@ async def fetch_message_content(client: lark.Client, message_id: str) -> str | N
             return None
 
         data = getattr(resp, "data", None)
-        if data:
-            # GetMessage returns items list; take the first item
-            items = getattr(data, "items", None) or []
-            item = items[0] if items else data
-            body = getattr(item, "body", None)
-            content = getattr(body, "content", None) if body else None
-            if content:
-                msg_type = getattr(item, "msg_type", None) or "text"
-                text = _normalize_text(msg_type, content)
-                # Replace @_user_N mention placeholders with display names
-                for mention in getattr(item, "mentions", None) or []:
-                    key = getattr(mention, "key", None)
-                    name = getattr(mention, "name", None)
-                    if key and name:
-                        text = text.replace(key, f"@{name}")
-                return text
+        if not data:
+            logger.warning("feishu.api.fetch_message no data message_id={}", message_id)
+            return None
+
+        items = getattr(data, "items", None) or []
+        if not items:
+            logger.warning(
+                "feishu.api.fetch_message empty items message_id={}", message_id
+            )
+            return None
+
+        item = items[0]
+        body = getattr(item, "body", None)
+        content = getattr(body, "content", None) if body else None
+        if not content:
+            logger.debug(
+                "feishu.api.fetch_message no body/content message_id={} msg_type={}",
+                message_id,
+                getattr(item, "msg_type", None),
+            )
+            return None
+
+        msg_type = getattr(item, "msg_type", None) or "text"
+        text = _normalize_text(msg_type, content)
+        for mention in getattr(item, "mentions", None) or []:
+            key = getattr(mention, "key", None)
+            name = getattr(mention, "name", None)
+            if key and name:
+                text = text.replace(key, f"@{name}")
+        return text
 
     except Exception:
         logger.exception("feishu.api.fetch_message error message_id={}", message_id)

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -273,16 +273,15 @@ class FeishuChannel(Channel):
             if message is None:
                 return
 
-            if message.is_group:
-                logger.info(
-                    "feishu.incoming chat_type={} chat_id={} sender={}({}) mentions={} text={}",
-                    message.chat_type,
-                    message.chat_id,
-                    message.sender_display,
-                    message.sender_open_id,
-                    len(message.mentions),
-                    message.text[:80],
-                )
+            logger.info(
+                "feishu.incoming chat_type={} chat_id={} sender={}({}) mentions={} text={}",
+                message.chat_type,
+                message.chat_id,
+                message.sender_display,
+                message.sender_open_id,
+                len(message.mentions),
+                message.text[:80],
+            )
 
             skip_reason = self._should_skip(message)
             if skip_reason:

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -404,7 +404,7 @@ class FeishuChannel(Channel):
             logger.info(
                 "feishu.dispatch admin immediate session_id={} content={}",
                 session_id,
-                channel_msg.content[:80],
+                channel_msg.content,
             )
             fq = self._get_framework_queue()
             if fq is not None:

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -402,6 +402,11 @@ class FeishuChannel(Channel):
 
         # Admin → bypass queue + debounce, execute immediately
         if is_admin:
+            logger.info(
+                "feishu.dispatch admin immediate session_id={} content={}",
+                session_id,
+                channel_msg.content[:80],
+            )
             fq = self._get_framework_queue()
             if fq is not None:
                 await fq.put(channel_msg)
@@ -411,8 +416,19 @@ class FeishuChannel(Channel):
 
         # Normal flow: enqueue message with priority
         enqueued = await self._queue.put(channel_msg)
-
-        if not enqueued:
+        if enqueued:
+            logger.info(
+                "feishu.dispatch enqueued session_id={} queue_size={} content={}",
+                session_id,
+                self._queue.size,
+                channel_msg.content[:80],
+            )
+        else:
+            logger.warning(
+                "feishu.dispatch dropped (queue full) session_id={} content={}",
+                session_id,
+                channel_msg.content[:80],
+            )
             self._send_queue_full_notification(message)
 
     async def _build_channel_message(

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -436,6 +436,11 @@ class FeishuChannel(Channel):
             quoted_message = await fetch_message_content(
                 self._api_client, message.parent_id
             )
+            if not quoted_message:
+                logger.warning(
+                    "feishu.dispatch quoted message fetch returned empty parent_id={}",
+                    message.parent_id,
+                )
 
         history_hint = (
             FEISHU_HISTORY_HINT_GROUP if message.is_group else FEISHU_HISTORY_HINT_P2P


### PR DESCRIPTION
Closes #17

## 问题

群聊中引用消息 @agent 时，agent 拿不到被引用的消息内容。

## 根因

`fetch_message_content` 中 `GetMessage` API 返回的 `items` 列表为空时，代码 fallback 到用 `data`（`GetMessageResponseBody`）本身作为 message item：

```python
items = getattr(data, "items", None) or []
item = items[0] if items else data   # ← data 没有 body 属性
body = getattr(item, "body", None)   # ← None
content = getattr(body, "content", None) if body else None  # ← None
# 静默返回 None，无任何日志
```

`GetMessageResponseBody` 没有 `body` 属性，导致静默返回 `None`。调用方 `_build_channel_message` 检查 `if quoted_message:` 也是静默跳过，最终 payload 中没有 `quoted_message` 字段。

## 修复

- `items` 为空时视为明确失败，记录 warning 日志并返回 `None`
- 在 `fetch_message_content` 的每个失败路径增加日志：`data` 为空、`items` 为空、`body/content` 为空
- 在 `_build_channel_message` 中增加 warning：quoted message fetch 返回空时记录 `parent_id`

## 排查结论

| 检查点 | 结果 |
|--------|------|
| `parent_id` 解析 | 正确（`_parse_event` line 702） |
| `_check_active` 引用消息判断 | 正确（`parent_id` 分支在 mentions 之前，line 361） |
| `fetch_message_content` API 调用 | **有 bug**：`items` 为空时 fallback 到错误对象 |
| 静默失败 | **有问题**：多个路径无日志 |