### PR TITLE
fix(feishu): quoted messages should not activate bot without @mention

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,6 +71,10 @@ BUB_MAX_TOKENS=16384
 #
 # BUB_FEISHU_BOT_OPEN_ID=ou_xxxxxxxxxxxxxxxx
 #
+# 机器人显示名称（用于群聊中通过 @名称 匹配，大小写不敏感）
+# 当未配置 BOT_OPEN_ID 或 open_id 匹配失败时，作为 fallback 匹配
+# BUB_FEISHU_BOT_NAME=bub
+#
 # 消息队列配置（飞书 channel 优先级队列）
 # BUB_FEISHU_QUEUE_MAX_LENGTH=100        # 队列最大长度，0=不限制（默认 0）
 #                                        # 超出时丢弃普通消息，管理员消息不受限制

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -120,6 +120,7 @@ class FeishuChannel(Channel):
             os.environ.get("BUB_FEISHU_ALLOW_CHATS", "")
         )
         self._bot_open_id = os.environ.get("BUB_FEISHU_BOT_OPEN_ID", "")
+        self._bot_name = os.environ.get("BUB_FEISHU_BOT_NAME", "").lower()
 
         # Runtime state
         self._api_client: lark.Client | None = None
@@ -363,9 +364,11 @@ class FeishuChannel(Channel):
         ):
             return True, "bot_mentioned"
 
-        # Mention whose display-name contains "bub"
-        if any("bub" in (m.name or "").lower() for m in message.mentions):
-            return True, "bub_name_mentioned"
+        # Mention whose display-name matches configured bot name
+        if self._bot_name and any(
+            self._bot_name in (m.name or "").lower() for m in message.mentions
+        ):
+            return True, "bot_name_mentioned"
 
         if message.mentions:
             return False, "has_mentions_but_not_me"

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -344,7 +344,8 @@ class FeishuChannel(Channel):
         Returns ``(is_active, reason)`` – *reason* is always populated for logging.
 
         For p2p (single chat): always active.
-        For group chat: only active if @mentioned or has quoted message (parent_id).
+        For group chat: only active if @mentioned.
+        Quoted messages (parent_id) provide context but do not activate on their own.
         """
         if message.chat_type == "p2p":
             return True, "p2p"
@@ -356,17 +357,16 @@ class FeishuChannel(Channel):
         if text.startswith(",") or text.startswith("/"):
             return True, "command"
 
-        # Quoted messages in group chat should be processed (reply to bot's message)
-        if message.parent_id:
-            return True, "quoted_message"
-
-        # Exact bot open_id match
+        # Exact bot open_id match (with or without quoted message)
         if self._bot_open_id and any(
             m.open_id == self._bot_open_id for m in message.mentions
         ):
             return True, "bot_mentioned"
 
-        # Any @-mention in a group chat - return False to allow future customization
+        # Mention whose display-name contains "bub"
+        if any("bub" in (m.name or "").lower() for m in message.mentions):
+            return True, "bub_name_mentioned"
+
         if message.mentions:
             return False, "has_mentions_but_not_me"
 


### PR DESCRIPTION
Closes #17

## 问题

群聊中用户引用别人的消息回复（没有 @agent），bot 也会响应。

例：用户 A 引用用户 B 的消息回复 → bot 插话回复"没有 @ 我，我不插话"。

## 根因

`_check_active` 中 `parent_id`（引用消息）判断在 mentions 检查之前，且无条件返回 `True`：

```python
if message.parent_id:
    return True, "quoted_message"  # ← 不检查是否 @agent
```

只要是引用回复，不管引用谁、有没有 @agent，都会激活 bot。

## 修复

移除 `parent_id` 的无条件激活。群聊中 bot 只在被 @mention 时激活：

```
p2p          → 激活
命令(,/)      → 激活
@bot_open_id → 激活
@名字含"bub"  → 激活
其他          → 不激活
```

`parent_id` 仍然被 `_build_channel_message` 使用——当 bot 被 @mention 激活后，如果消息有引用，会通过 `fetch_message_content` 获取被引用消息的内容作为上下文。