### PR TITLE
feat(docker): switch workspace to COW mode with persistent write layer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,7 @@ BUB_WORKSPACE=/path/to/your-workspace
 # Docker 部署目录（docker compose 使用）
 # ---------------------------------------------------------------------------
 BUB_HOME=~/.bub
+BUB_BOXSH=~/work/boxsh
 BUB_SKILLS=~/.agents/skills
 BUB_WEIXIN_DATA=~/.openclaw/openclaw-weixin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,11 +34,13 @@ COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 # Volumes:
-#   /workspace                       - agent workspace (system-weaver, read-only in boxsh)
+#   /workspace                       - agent workspace (read-only base, COW via boxsh)
+#   /boxsh                           - COW write layer for /workspace (persists agent writes)
 #   /root/.agents/skills             - bub skills directory (read-only in boxsh)
 #   /root/.openclaw/openclaw-weixin  - weixin credentials (read-only in boxsh)
 #   /root/.bub                       - bub home (read-write in boxsh for tapes, config)
 VOLUME /workspace
+VOLUME /boxsh
 VOLUME /root/.agents/skills
 VOLUME /root/.openclaw/openclaw-weixin
 VOLUME /root/.bub

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ uv run bub gateway
 
 ## Docker 部署
 
-容器内通过 [boxsh](https://github.com/xicilion/boxsh) 沙箱运行，Agent 执行的命令只能写入 `~/.bub`，无法修改工作空间和凭据。
+容器内通过 [boxsh](https://github.com/xicilion/boxsh) 沙箱运行，Agent 对工作空间的写入通过 COW（写时复制）隔离到独立目录，原始工作空间不受影响。
 
 ### 快速开始
 
@@ -100,7 +100,7 @@ cp .env.example .env
 # 编辑 .env，填入 BUB_WORKSPACE 等配置
 
 # 2. 创建必要目录
-mkdir -p ~/.bub ~/.agents/skills
+mkdir -p ~/.bub ~/.agents/skills ~/work/boxsh
 
 # 3. 微信渠道需要先登录
 uv run -m bub_im_bridge login
@@ -116,7 +116,8 @@ docker-compose logs -f
 
 | 目录 | 权限 | 说明 |
 |------|------|------|
-| `/workspace` | 🔒 只读 | Agent 工作空间（防止意外修改） |
+| `/workspace` | 🐄 COW | Agent 工作空间（只读基座，写入落到 /boxsh） |
+| `/boxsh` | ✏️ 可写 | COW 写层，持久化 agent 对 workspace 的修改 |
 | `/root/.agents/skills` | 🔒 只读 | Bub 技能目录 |
 | `/root/.openclaw/openclaw-weixin` | 🔒 只读 | 微信登录凭据 |
 | `/root/.bub` | ✏️ 可写 | Bub 运行数据（tapes、配置） |
@@ -127,9 +128,9 @@ docker-compose logs -f
 # 进入容器调试（已在沙箱内）
 docker-compose exec bub sh
 
-# 验证只读保护
-touch /workspace/test.txt  # 应该失败
-touch /root/.bub/test.txt  # 应该成功
+# 验证 COW 写入（成功，但原始 workspace 不变）
+echo test > /workspace/test.txt  # COW 写入到 /boxsh
+touch /root/.bub/test.txt  # 直接可写
 ```
 
 📖 **详细文档**：[docs/DOCKER_USAGE.md](docs/DOCKER_USAGE.md)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     env_file: .env
     volumes:
       - ${BUB_WORKSPACE}:/workspace
+      - ${BUB_BOXSH}:/boxsh
       - ${BUB_SKILLS}:/root/.agents/skills
       - ${BUB_WEIXIN_DATA}:/root/.openclaw/openclaw-weixin
       - ${BUB_HOME}:/root/.bub

--- a/docs/DOCKER_USAGE.md
+++ b/docs/DOCKER_USAGE.md
@@ -15,7 +15,7 @@ cp .env.example .env
 ### 2. 创建必要目录
 
 ```bash
-mkdir -p ~/.bub ~/.agents/skills
+mkdir -p ~/.bub ~/.agents/skills ~/work/boxsh
 ```
 
 ### 3. 微信渠道登录（可选）
@@ -42,7 +42,8 @@ docker-compose logs -f
 
 | 容器内路径 | 环境变量 | 默认值 | 沙箱权限 | 说明 |
 |-----------|---------|-------|---------|------|
-| `/workspace` | `BUB_WORKSPACE` | (必需) | 🔒 只读 | Agent 工作空间 |
+| `/workspace` | `BUB_WORKSPACE` | (必需) | 🐄 COW | Agent 工作空间（只读基座，写入落到 /boxsh） |
+| `/boxsh` | `BUB_BOXSH` | `~/work/boxsh` | ✏️ 可写 | COW 写层，持久化 agent 对 /workspace 的修改 |
 | `/root/.agents/skills` | `BUB_SKILLS` | `~/.agents/skills` | 🔒 只读 | Bub 技能目录 |
 | `/root/.openclaw/openclaw-weixin` | `BUB_WEIXIN_DATA` | `~/.openclaw/openclaw-weixin` | 🔒 只读 | 微信登录凭据 |
 | `/root/.bub` | `BUB_HOME` | `~/.bub` | ✏️ 可写 | Bub 运行数据（tapes、配置） |
@@ -53,10 +54,10 @@ docker-compose logs -f
 
 - ✅ Agent 可以读取 workspace、skills、weixin 配置
 - ✅ Agent 可以在 `/root/.bub` 中写入 tapes 和配置
-- ❌ Agent **无法**修改 workspace（防止意外破坏）
+- ✅ Agent 对 `/workspace` 的写操作通过 COW 落到 `/boxsh`，原始 workspace 不受影响
 - ❌ Agent **无法**修改 skills 和 weixin 配置（防止意外覆盖）
 
-即使 AI agent 生成了 `rm -rf /workspace` 这样的危险命令，也不会对宿主机造成影响。
+即使 AI agent 生成了 `rm -rf /workspace` 这样的危险命令，也不会对宿主机的原始 workspace 造成影响。所有写入、删除、覆盖都沉淀到宿主机 `$BUB_BOXSH` 目录。
 
 ## 调试和运维
 
@@ -72,12 +73,17 @@ docker-compose exec bub sh
 docker-compose exec bub bash
 ```
 
-在沙箱内，你可以验证只读保护：
+在沙箱内，你可以验证 COW 和只读保护：
 
 ```bash
-# 测试只读约束（应该失败）
-touch /workspace/test.txt
-# 输出：Read-only file system
+# 测试 COW 写入（应该成功，但不修改原始 workspace）
+echo "test" > /workspace/test.txt
+cat /workspace/test.txt
+# 输出：test（通过 COW 层读取）
+
+# 在宿主机验证原始 workspace 未被修改
+# ls ~/work/github/bub-im-bridge/test.txt → 不存在
+# ls ~/work/boxsh/test.txt → 存在（COW 写层）
 
 # 测试 skills 目录只读（应该失败）
 touch /root/.agents/skills/test.txt  
@@ -97,9 +103,9 @@ docker-compose exec bub ls -la /workspace
 # 查看 bub 配置
 docker-compose exec bub cat /root/.bub/config.yaml
 
-# 测试只读保护
-docker-compose exec bub touch /workspace/test.txt
-# 输出：Read-only file system
+# 测试 COW 写入（成功，但不影响原始 workspace）
+docker-compose exec bub sh -c "echo test > /workspace/test.txt && cat /workspace/test.txt"
+# 输出：test
 ```
 
 ### 查看日志
@@ -143,6 +149,7 @@ BUB_API_KEY=sk-ant-xxxxx
 
 ```bash
 # Bub 相关目录（使用默认值即可）
+BUB_BOXSH=~/work/boxsh
 BUB_SKILLS=~/.agents/skills
 BUB_WEIXIN_DATA=~/.openclaw/openclaw-weixin
 BUB_HOME=~/.bub
@@ -194,8 +201,12 @@ mount | grep -E "bind|overlay" | grep -v "lowerdir=/var/lib/docker"
 
 ```
 宿主机
+ ├── $BUB_WORKSPACE (原始工作区，不被修改)
+ ├── $BUB_BOXSH (COW 写层，持久化 agent 写入)
  └── Docker 容器
-      └── boxsh 沙箱
+      ├── /workspace ← $BUB_WORKSPACE
+      ├── /boxsh ← $BUB_BOXSH
+      └── boxsh 沙箱 (cow:/workspace:/boxsh)
            └── bub gateway 进程
 ```
 
@@ -258,6 +269,7 @@ docker-compose up -d
 A: 不会。所有重要数据都通过 volume 挂载，存储在宿主机上：
 - `/root/.bub` → `$BUB_HOME`（tapes、配置）
 - `/root/.openclaw/openclaw-weixin` → `$BUB_WEIXIN_DATA`（微信凭据）
+- `/boxsh` → `$BUB_BOXSH`（agent 对 workspace 的 COW 写入）
 
 容器删除重建后，这些数据仍然存在。
 
@@ -281,7 +293,7 @@ docker exec -it bub /entrypoint.sh ls -la /root/.bub/tapes/
 
 ```bash
 BOXSH_ARGS="--sandbox \
-  --bind ro:$WORKSPACE \
+  --bind cow:$WORKSPACE:/boxsh \
   --bind ro:/root/.agents/skills \
   --bind ro:/root/.openclaw/openclaw-weixin \
   --bind wr:/root/.bub"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,8 @@
 # Directory layout inside the container:
 #   /app                             (rw) application code
 #   /root                            (rw) home directory
-#   /workspace                       (ro) agent workspace
+#   /workspace                       (cow) agent workspace (read-only base, writes go to /boxsh)
+#   /boxsh                           (rw) COW write layer for /workspace
 #   /root/.agents/skills             (ro) bub skills
 #   /root/.openclaw/openclaw-weixin  (ro) weixin credentials
 #   /root/.bub                       (rw) bub home (tapes, config)
@@ -24,7 +25,7 @@ WORKSPACE="/workspace"
 BOXSH_ARGS="--sandbox \
   --bind wr:/app \
   --bind wr:/root \
-  --bind ro:$WORKSPACE \
+  --bind cow:$WORKSPACE:/boxsh \
   --bind ro:/root/.agents/skills \
   --bind ro:/root/.openclaw/openclaw-weixin \
   --bind wr:/root/.bub"


### PR DESCRIPTION
## Summary
- `entrypoint.sh`: `--bind ro:/workspace` → `--bind cow:/workspace:/boxsh`，agent 对 workspace 的写入通过 COW 隔离
- `docker-compose.yml`: 新增 `${BUB_BOXSH}:/boxsh` volume，COW 写层持久化到宿主机
- `Dockerfile`: 新增 `VOLUME /boxsh`
- `.env.example`: 新增 `BUB_BOXSH=~/work/boxsh`
- `README.md` + `docs/DOCKER_USAGE.md`: 同步更新文档

## Architecture
```
宿主机
 ├── $BUB_WORKSPACE (原始工作区，不被修改)
 ├── $BUB_BOXSH (COW 写层，持久化 agent 写入)
 └── Docker 容器
      ├── /workspace ← $BUB_WORKSPACE
      ├── /boxsh ← $BUB_BOXSH
      └── boxsh 沙箱 (cow:/workspace:/boxsh)
           └── bub gateway 进程
```

## Test plan
- [ ] `docker-compose up -d` 正常启动
- [ ] 容器内 `echo test > /workspace/test.txt` 成功（COW 写入）
- [ ] 宿主机原始 workspace 目录无 test.txt（未被污染）
- [ ] 宿主机 `$BUB_BOXSH` 目录下有 test.txt（COW 层持久化）
- [ ] 容器内 `/root/.agents/skills` 仍为只读

🤖 Generated with [Claude Code](https://claude.com/claude-code)