### PR TITLE
fix(docker): install fuse-overlayfs for boxsh COW mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.12-slim
 
 # git: required for weixin-agent-sdk install from GitHub
 # boxsh: sandboxed shell for agent command execution
-RUN apt-get update && apt-get install -y --no-install-recommends git curl libncurses6 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends git curl libncurses6 fuse-overlayfs && rm -rf /var/lib/apt/lists/*
 
 # Install boxsh (sandboxed shell for agent command execution)
 ARG BOXSH_VERSION=v2.1.0


### PR DESCRIPTION
## Summary
- Dockerfile 加装 `fuse-overlayfs`，修复 boxsh COW 模式启动失败
- 原因：Docker 容器内 kernel overlayfs 挂载失败（Invalid argument），boxsh fallback 到 fuse-overlayfs 但未安装

## Test plan
- [ ] `docker-compose build && docker-compose up` 正常启动，不再报 `fuse-overlayfs not found`
- [ ] COW 写入 `/workspace` 正常工作

🤖 Generated with [Claude Code](https://claude.com/claude-code)