### PR TITLE
fix(feishu): use chat_type for group detection, add admin bypass in _should_skip

### DIFF
--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -333,16 +333,13 @@ class FeishuChannel(Channel):
 
     def _should_skip(self, message: FeishuInboundMessage) -> str | None:
         """Return a reason string if the message should be silently skipped, else ``None``."""
-        # For group chats (chat_id starts with "oc_"), check allow_chats
-        # For p2p chats (chat_id is user's open_id), check allow_users
-        is_group_chat = message.chat_id.startswith("oc_")
-        
-        if is_group_chat:
-            # Group chat: check allow_chats restriction
+        if is_admin_sender(message.sender_open_id):
+            return None
+
+        if message.is_group:
             if self._allow_chats and message.chat_id not in self._allow_chats:
                 return "chat_not_allowed"
         else:
-            # P2P chat: check allow_users restriction
             if self._allow_users:
                 sender_ids = {
                     t


### PR DESCRIPTION
## Summary
- `_should_skip()` 使用 `chat_id.startswith("oc_")` 判断群聊，但飞书 p2p 的 chat_id 也以 `oc_` 开头，导致所有私聊被误判为群聊，走了 `allow_chats` 检查而非 `allow_users`
- 改用 `message.is_group`（基于 `chat_type` 字段）正确区分
- 补充 admin bypass：`_should_skip()` 缺少 `is_admin_sender()` 检查，admin 用户也受 allow_chats/allow_users 限制

## Test plan
- [x] 34 existing tests pass
- [x] py_compile pass
- [ ] 验证 p2p 私聊不再被 `chat_not_allowed` 拦截
- [ ] 验证 admin 用户可绕过所有权限检查

Generated with [Claude Code](https://claude.com/claude-code)