### PR TITLE
feat: restore COW mode for /workspace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM python:3.12-slim
 
 # git: required for weixin-agent-sdk install from GitHub
 # boxsh: sandboxed shell for agent command execution
-RUN apt-get update && apt-get install -y --no-install-recommends git curl libncurses6 fuse-overlayfs && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends git curl libncurses6 fuse-overlayfs && rm -rf /var/lib/apt/lists/* \
+    && echo "user_allow_other" >> /etc/fuse.conf
 
 # Install boxsh (sandboxed shell for agent command execution)
 ARG BOXSH_VERSION=v2.1.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,13 +34,13 @@ COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 # Volumes:
-#   /workspace                       - agent workspace (read-only base, COW via boxsh)
-#   /boxsh                           - COW write layer for /workspace (persists agent writes)
+#   /workspace-base                  - agent workspace read-only base (COW lower layer)
+#   /workspace                       - COW upper layer (persists agent writes via $BUB_BOXSH)
 #   /root/.agents/skills             - bub skills directory (read-only in boxsh)
 #   /root/.openclaw/openclaw-weixin  - weixin credentials (read-only in boxsh)
 #   /root/.bub                       - bub home (read-write in boxsh for tapes, config)
+VOLUME /workspace-base
 VOLUME /workspace
-VOLUME /boxsh
 VOLUME /root/.agents/skills
 VOLUME /root/.openclaw/openclaw-weixin
 VOLUME /root/.bub

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM python:3.12-slim
 
 # git: required for weixin-agent-sdk install from GitHub
 # boxsh: sandboxed shell for agent command execution
-RUN apt-get update && apt-get install -y --no-install-recommends git curl libncurses6 fuse-overlayfs && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends git curl libncurses6 fuse-overlayfs && rm -rf /var/lib/apt/lists/* && \
+    echo "user_allow_other" >> /etc/fuse.conf
 
 # Install boxsh (sandboxed shell for agent command execution)
 ARG BOXSH_VERSION=v2.1.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ FROM python:3.12-slim
 
 # git: required for weixin-agent-sdk install from GitHub
 # boxsh: sandboxed shell for agent command execution
-RUN apt-get update && apt-get install -y --no-install-recommends git curl libncurses6 fuse-overlayfs && rm -rf /var/lib/apt/lists/* \
-    && echo "user_allow_other" >> /etc/fuse.conf
+RUN apt-get update && apt-get install -y --no-install-recommends git curl libncurses6 fuse-overlayfs && rm -rf /var/lib/apt/lists/*
 
 # Install boxsh (sandboxed shell for agent command execution)
 ARG BOXSH_VERSION=v2.1.0

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ uv run bub gateway
 
 ## Docker 部署
 
-容器内通过 [boxsh](https://github.com/xicilion/boxsh) 沙箱运行，工作空间以只读方式挂载，防止 Agent 意外修改原始文件。
+容器内通过 [boxsh](https://github.com/xicilion/boxsh) 沙箱运行，Agent 对工作空间的写入通过 COW（写时复制）隔离到独立目录，原始工作空间不受影响。
 
 ### 快速开始
 
@@ -116,7 +116,8 @@ docker-compose logs -f
 
 | 目录 | 权限 | 说明 |
 |------|------|------|
-| `/workspace` | 🔒 只读 | Agent 工作空间 |
+| `/workspace` | 🐄 COW | Agent 工作空间（只读基座，写入落到 /boxsh） |
+| `/boxsh` | ✏️ 可写 | COW 写层，持久化 agent 对 workspace 的修改 |
 | `/root/.agents/skills` | 🔒 只读 | Bub 技能目录 |
 | `/root/.openclaw/openclaw-weixin` | 🔒 只读 | 微信登录凭据 |
 | `/root/.bub` | ✏️ 可写 | Bub 运行数据（tapes、配置） |

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ docker-compose logs -f
 
 | 目录 | 权限 | 说明 |
 |------|------|------|
-| `/workspace` | 🐄 COW | Agent 工作空间（fuse-overlayfs merged view，写入落到 $BUB_BOXSH） |
+| `/boxsh` | 🐄 COW | Agent 工作空间（boxsh COW merged view，基座来自 $BUB_WORKSPACE） |
 | `/root/.agents/skills` | 🔒 只读 | Bub 技能目录 |
 | `/root/.openclaw/openclaw-weixin` | 🔒 只读 | 微信登录凭据 |
 | `/root/.bub` | ✏️ 可写 | Bub 运行数据（tapes、配置） |

--- a/README.md
+++ b/README.md
@@ -116,8 +116,7 @@ docker-compose logs -f
 
 | 目录 | 权限 | 说明 |
 |------|------|------|
-| `/workspace` | 🐄 COW | Agent 工作空间（只读基座，写入落到 /boxsh） |
-| `/boxsh` | ✏️ 可写 | COW 写层，持久化 agent 对 workspace 的修改 |
+| `/workspace` | 🐄 COW | Agent 工作空间（fuse-overlayfs merged view，写入落到 $BUB_BOXSH） |
 | `/root/.agents/skills` | 🔒 只读 | Bub 技能目录 |
 | `/root/.openclaw/openclaw-weixin` | 🔒 只读 | 微信登录凭据 |
 | `/root/.bub` | ✏️ 可写 | Bub 运行数据（tapes、配置） |

--- a/README.md
+++ b/README.md
@@ -124,11 +124,11 @@ docker-compose logs -f
 ### 调试
 
 ```bash
-# 进入沙箱视图的调试 shell（与 agent 运行时视角一致）
-docker-compose exec bub /entrypoint.sh shell
+# 启动与 bub 同配置的 boxsh 调试实例（/workspace 可读写）
+docker-compose run --rm bub /entrypoint.sh shell
 
-# 进入容器运行环境（查看进程、环境变量、挂载状态）
-docker-compose exec bub bash
+# 查看当前运行态（继承服务视图，/workspace 受限）
+docker-compose exec bub /entrypoint.sh shell
 
 # 进入原始镜像环境（绕过 boxsh，排查镜像内容）
 docker-compose run --rm --entrypoint sh bub

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ docker-compose logs -f
 ### 调试
 
 ```bash
-# 进入 boxsh 沙箱（与 agent 运行时视角一致）
+# 进入沙箱视图的调试 shell（与 agent 运行时视角一致）
 docker-compose exec bub /entrypoint.sh shell
 
 # 进入容器运行环境（查看进程、环境变量、挂载状态）

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ docker-compose logs -f
 
 | 目录 | 权限 | 说明 |
 |------|------|------|
-| `/boxsh` | 🐄 COW | Agent 工作空间（boxsh COW merged view，基座来自 $BUB_WORKSPACE） |
+| `/workspace` | 🐄 COW | Agent 工作空间（boxsh COW merged view，基座来自 $BUB_WORKSPACE） |
 | `/root/.agents/skills` | 🔒 只读 | Bub 技能目录 |
 | `/root/.openclaw/openclaw-weixin` | 🔒 只读 | 微信登录凭据 |
 | `/root/.bub` | ✏️ 可写 | Bub 运行数据（tapes、配置） |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,8 @@ services:
     build: .
     env_file: .env
     volumes:
-      - ${BUB_WORKSPACE}:/workspace
-      - ${BUB_BOXSH}:/boxsh
+      - ${BUB_WORKSPACE}:/workspace-base
+      - ${BUB_BOXSH}:/workspace
       - ${BUB_SKILLS}:/root/.agents/skills
       - ${BUB_WEIXIN_DATA}:/root/.openclaw/openclaw-weixin
       - ${BUB_HOME}:/root/.bub

--- a/docs/DOCKER_USAGE.md
+++ b/docs/DOCKER_USAGE.md
@@ -66,11 +66,11 @@ docker-compose logs -f
 容器内有两层环境：**容器原始环境**和 **boxsh 沙箱环境**。entrypoint 通过 `exec boxsh --sandbox ...` 启动服务，boxsh 会为其命令树创建独立的 mount namespace（沙箱视图）。`docker-compose exec` 新起的进程会进入该 namespace，但不会自动经过 boxsh 初始化。
 
 ```bash
-# 1. 进入 boxsh 沙箱（与 agent 运行时视角一致）
-#    适合验证 agent 在沙箱中的行为
+# 1. 进入沙箱视图的调试 shell（与 agent 运行时视角一致）
+#    继承 PID 1 的 boxsh 沙箱保护（COW、只读挂载等）
 docker-compose exec bub /entrypoint.sh shell
 
-# 2. 进入容器运行环境（boxsh 的 mount namespace，但未经沙箱初始化）
+# 2. 进入容器运行环境（同样在 boxsh 的 mount namespace 内）
 #    适合看进程、环境变量、运行中挂载状态
 docker-compose exec bub bash
 
@@ -222,13 +222,13 @@ mount | grep -E "bind|overlay" | grep -v "lowerdir=/var/lib/docker"
 /entrypoint.sh
 # → 在 boxsh 沙箱内启动 bub gateway
 
-# 2. 进入交互式 shell
+# 2. 进入交互式 shell（继承沙箱保护）
 /entrypoint.sh shell
-# → 在 boxsh 沙箱内启动交互式 shell
+# → 在沙箱视图下启动交互式 shell
 
-# 3. 执行单个命令
+# 3. 执行单个命令（继承沙箱保护）
 /entrypoint.sh <command>
-# → 在 boxsh 沙箱内执行命令
+# → 在沙箱视图下执行命令
 ```
 
 ## 常见问题

--- a/docs/DOCKER_USAGE.md
+++ b/docs/DOCKER_USAGE.md
@@ -42,7 +42,8 @@ docker-compose logs -f
 
 | 容器内路径 | 环境变量 | 默认值 | 沙箱权限 | 说明 |
 |-----------|---------|-------|---------|------|
-| `/workspace` | `BUB_WORKSPACE` | (必需) | 🔒 只读 | Agent 工作空间 |
+| `/workspace` | `BUB_WORKSPACE` | (必需) | 🐄 COW | Agent 工作空间（只读基座，写入落到 /boxsh） |
+| `/boxsh` | `BUB_BOXSH` | `~/work/boxsh/bub-im-bridge` | ✏️ 可写 | COW 写层，持久化 agent 对 /workspace 的修改 |
 | `/root/.agents/skills` | `BUB_SKILLS` | `~/.agents/skills` | 🔒 只读 | Bub 技能目录 |
 | `/root/.openclaw/openclaw-weixin` | `BUB_WEIXIN_DATA` | `~/.openclaw/openclaw-weixin` | 🔒 只读 | 微信登录凭据 |
 | `/root/.bub` | `BUB_HOME` | `~/.bub` | ✏️ 可写 | Bub 运行数据（tapes、配置） |
@@ -53,10 +54,10 @@ docker-compose logs -f
 
 - ✅ Agent 可以读取 workspace、skills、weixin 配置
 - ✅ Agent 可以在 `/root/.bub` 中写入 tapes 和配置
-- ❌ Agent **无法**修改 workspace（只读）
+- ✅ Agent 对 `/workspace` 的写操作通过 COW 落到 `/boxsh`，原始 workspace 不受影响
 - ❌ Agent **无法**修改 skills 和 weixin 配置（防止意外覆盖）
 
-即使 AI agent 生成了 `rm -rf /workspace` 这样的危险命令，也不会对宿主机的原始 workspace 造成影响。
+即使 AI agent 生成了 `rm -rf /workspace` 这样的危险命令，也不会对宿主机的原始 workspace 造成影响。所有写入、删除、覆盖都沉淀到宿主机 `$BUB_BOXSH` 目录。
 
 ## 调试和运维
 
@@ -78,12 +79,17 @@ docker-compose exec bub bash
 docker-compose run --rm --entrypoint sh bub
 ```
 
-在沙箱内，你可以验证只读保护：
+在沙箱内，你可以验证 COW 和只读保护：
 
 ```bash
-# 测试 workspace 只读（应该失败）
+# 测试 COW 写入（应该成功，但不修改原始 workspace）
 echo "test" > /workspace/test.txt
-# 输出：Read-only file system
+cat /workspace/test.txt
+# 输出：test（通过 COW 层读取）
+
+# 在宿主机验证原始 workspace 未被修改
+# ls ~/work/github/bub-im-bridge/test.txt → 不存在
+# ls ~/work/boxsh/bub-im-bridge/test.txt → 存在（COW 写层）
 
 # 测试 skills 目录只读（应该失败）
 touch /root/.agents/skills/test.txt  
@@ -145,6 +151,7 @@ BUB_API_KEY=sk-ant-xxxxx
 
 ```bash
 # Bub 相关目录（使用默认值即可）
+BUB_BOXSH=~/work/boxsh/bub-im-bridge
 BUB_SKILLS=~/.agents/skills
 BUB_WEIXIN_DATA=~/.openclaw/openclaw-weixin
 BUB_HOME=~/.bub
@@ -172,9 +179,10 @@ docker-compose exec bub /entrypoint.sh shell
 
 # 在沙箱内执行：
 
-# 1. 测试 workspace 只读
+# 1. 测试 COW 写入（成功，但原始 workspace 不变）
 echo test > /workspace/test.txt
-# 预期输出：Read-only file system
+cat /workspace/test.txt
+# 预期输出：test
 
 # 2. 测试可写目录
 touch /root/.bub/test.txt
@@ -197,9 +205,11 @@ mount | grep -E "bind|overlay" | grep -v "lowerdir=/var/lib/docker"
 ```
 宿主机
  ├── $BUB_WORKSPACE (原始工作区，不被修改)
+ ├── $BUB_BOXSH (COW 写层，持久化 agent 写入)
  └── Docker 容器
       ├── /workspace ← $BUB_WORKSPACE
-      └── boxsh 沙箱 (ro:/workspace)
+      ├── /boxsh ← $BUB_BOXSH
+      └── boxsh 沙箱 (cow:/workspace:/boxsh)
            └── bub gateway 进程
 ```
 
@@ -262,6 +272,7 @@ docker-compose up -d
 A: 不会。所有重要数据都通过 volume 挂载，存储在宿主机上：
 - `/root/.bub` → `$BUB_HOME`（tapes、配置）
 - `/root/.openclaw/openclaw-weixin` → `$BUB_WEIXIN_DATA`（微信凭据）
+- `/boxsh` → `$BUB_BOXSH`（agent 对 workspace 的 COW 写入）
 
 容器删除重建后，这些数据仍然存在。
 
@@ -288,7 +299,7 @@ BOXSH_ARGS="--sandbox \
   --bind wr:/app \
   --bind wr:/root \
   --bind ro:/entrypoint.sh \
-  --bind ro:/workspace \
+  --bind cow:$WORKSPACE:/boxsh \
   --bind ro:/root/.agents/skills \
   --bind ro:/root/.openclaw/openclaw-weixin \
   --bind wr:/root/.bub"
@@ -306,7 +317,7 @@ BOXSH_ARGS="--sandbox \
 ```bash
 BOXSH_ARGS="--sandbox \
   --new-net-ns \
-  --bind ro:/workspace \
+  --bind cow:$WORKSPACE:/boxsh \
   ..."
 ```
 
@@ -323,6 +334,7 @@ services:
     env_file: .env.bub1
     volumes:
       - ${BUB_WORKSPACE_1}:/workspace
+      - ${BUB_BOXSH_1}:/boxsh
       - ${BUB_HOME_1}:/root/.bub
     container_name: bub-1
 
@@ -331,9 +343,12 @@ services:
     env_file: .env.bub2
     volumes:
       - ${BUB_WORKSPACE_2}:/workspace
+      - ${BUB_BOXSH_2}:/boxsh
       - ${BUB_HOME_2}:/root/.bub
     container_name: bub-2
 ```
+
+每个实例的 `BUB_BOXSH` 必须指向不同的项目专属目录（如 `~/work/boxsh/project-1`、`~/work/boxsh/project-2`），避免 COW 写层互相污染。
 
 ## 技术细节
 

--- a/docs/DOCKER_USAGE.md
+++ b/docs/DOCKER_USAGE.md
@@ -42,8 +42,8 @@ docker-compose logs -f
 
 | 容器内路径 | 环境变量 | 默认值 | 沙箱权限 | 说明 |
 |-----------|---------|-------|---------|------|
-| `/workspace` | `BUB_WORKSPACE` | (必需) | (基座) | COW 只读基座（不在沙箱内直接暴露） |
-| `/boxsh` | `BUB_BOXSH` | `~/work/boxsh/bub-im-bridge` | 🐄 COW | Agent 工作空间（boxsh COW merged view），写入持久化到宿主机 |
+| `/workspace-base` | `BUB_WORKSPACE` | (必需) | (基座) | COW 只读基座（Docker volume，不在沙箱内直接暴露） |
+| `/workspace` | `BUB_BOXSH` | `~/work/boxsh/bub-im-bridge` | 🐄 COW | Agent 工作空间（boxsh COW merged view），写入持久化到宿主机 |
 | `/root/.agents/skills` | `BUB_SKILLS` | `~/.agents/skills` | 🔒 只读 | Bub 技能目录 |
 | `/root/.openclaw/openclaw-weixin` | `BUB_WEIXIN_DATA` | `~/.openclaw/openclaw-weixin` | 🔒 只读 | 微信登录凭据 |
 | `/root/.bub` | `BUB_HOME` | `~/.bub` | ✏️ 可写 | Bub 运行数据（tapes、配置） |
@@ -52,22 +52,22 @@ docker-compose logs -f
 
 容器内使用 [boxsh](https://github.com/xicilion/boxsh) 沙箱运行 bub 服务，提供进程级别的文件系统隔离：
 
-- ✅ Agent 可以读写 `/boxsh`（COW merged view，基座来自 $BUB_WORKSPACE）
+- ✅ Agent 可以读写 `/workspace`（COW merged view，基座来自 $BUB_WORKSPACE）
 - ✅ Agent 可以在 `/root/.bub` 中写入 tapes 和配置
-- ✅ Agent 对 `/boxsh` 的写操作通过 COW 持久化到宿主机 `$BUB_BOXSH`，原始 workspace 不受影响
+- ✅ Agent 对 `/workspace` 的写操作通过 COW 持久化到宿主机 `$BUB_BOXSH`，原始 workspace 不受影响
 - ❌ Agent **无法**修改 skills 和 weixin 配置（防止意外覆盖）
 
-即使 AI agent 生成了 `rm -rf /boxsh` 这样的危险命令，也不会对宿主机的原始 workspace 造成影响。所有写入、删除、覆盖都沉淀到宿主机 `$BUB_BOXSH` 目录。
+即使 AI agent 生成了 `rm -rf /workspace` 这样的危险命令，也不会对宿主机的原始 workspace 造成影响。所有写入、删除、覆盖都沉淀到宿主机 `$BUB_BOXSH` 目录。
 
 ## 调试和运维
 
 ### 进入容器调试
 
-entrypoint 通过 `exec boxsh --sandbox ...` 启动服务，boxsh 使用 `cow:/workspace:/boxsh` 建立 COW overlay 并创建独立的 mount namespace（沙箱视图）。`docker-compose exec` 新起的进程会进入该 namespace。
+entrypoint 通过 `exec boxsh --sandbox ...` 启动服务，boxsh 使用 `cow:/workspace-base:/workspace` 建立 COW overlay 并创建独立的 mount namespace（沙箱视图）。`docker-compose exec` 新起的进程会进入该 namespace。
 
 ```bash
 # 1. 进入沙箱视图的调试 shell（与 agent 运行时视角一致）
-#    /boxsh 可读写（COW merged view），skills/weixin 只读
+#    /workspace 可读写（COW merged view），skills/weixin 只读
 docker-compose exec bub /entrypoint.sh shell
 
 # 2. 进入容器运行环境（同样在 boxsh 的 mount namespace 内）
@@ -83,13 +83,12 @@ docker-compose run --rm --entrypoint sh bub
 
 ```bash
 # 测试 COW 写入（应该成功，但不修改原始 workspace）
-echo "test" > /boxsh/test.txt
-cat /boxsh/test.txt
+echo "test" > /workspace/test.txt
+cat /workspace/test.txt
 # 输出：test（通过 COW 层读取）
 
 # 在宿主机验证原始 workspace 未被修改
 # ls $BUB_WORKSPACE/test.txt → 不存在
-# ls $BUB_BOXSH/test.txt → 存在（COW 写层）
 
 # 测试 skills 目录只读（应该失败）
 touch /root/.agents/skills/test.txt  
@@ -104,7 +103,7 @@ echo "success" > /root/.bub/test.txt
 
 ```bash
 # 在沙箱内查看文件（通过 entrypoint）
-docker-compose exec bub /entrypoint.sh ls -la /boxsh
+docker-compose exec bub /entrypoint.sh ls -la /workspace
 
 # 在沙箱内查看 bub 配置
 docker-compose exec bub /entrypoint.sh cat /root/.bub/config.yaml
@@ -180,8 +179,8 @@ docker-compose exec bub /entrypoint.sh shell
 # 在沙箱内执行：
 
 # 1. 测试 COW 写入（成功，但原始 workspace 不变）
-echo test > /boxsh/test.txt
-cat /boxsh/test.txt
+echo test > /workspace/test.txt
+cat /workspace/test.txt
 # 预期输出：test
 
 # 2. 测试可写目录
@@ -207,11 +206,11 @@ mount | grep -E "bind|overlay" | grep -v "lowerdir=/var/lib/docker"
  ├── $BUB_WORKSPACE (原始工作区，不被修改)
  ├── $BUB_BOXSH (COW 写层，持久化 agent 写入)
  └── Docker 容器
-      ├── /workspace ← $BUB_WORKSPACE (只读基座)
-      ├── /boxsh     ← $BUB_BOXSH (COW upper layer)
-      └── boxsh 沙箱 (cow:/workspace:/boxsh)
-           ├── /boxsh = COW merged view (agent workspace)
-           └── bub gateway 进程 (bub -w /boxsh)
+      ├── /workspace-base ← $BUB_WORKSPACE (只读基座)
+      ├── /workspace      ← $BUB_BOXSH (COW upper layer)
+      └── boxsh 沙箱 (cow:/workspace-base:/workspace)
+           ├── /workspace = COW merged view (agent workspace)
+           └── bub gateway 进程 (bub -w /workspace)
 ```
 
 ### entrypoint.sh 用法
@@ -236,7 +235,7 @@ mount | grep -E "bind|overlay" | grep -v "lowerdir=/var/lib/docker"
 
 ### Q: 为什么要使用 boxsh 沙箱？
 
-A: boxsh 提供进程级别的文件系统隔离，防止 AI agent 执行的命令意外修改重要文件。即使 agent 生成了 `rm -rf /boxsh` 这样的危险命令，也不会对宿主机的原始 workspace 造成影响。
+A: boxsh 提供进程级别的文件系统隔离，防止 AI agent 执行的命令意外修改重要文件。即使 agent 生成了 `rm -rf /workspace` 这样的危险命令，也不会对宿主机的原始 workspace 造成影响。
 
 ### Q: 沙箱会影响性能吗？
 
@@ -273,7 +272,7 @@ docker-compose up -d
 A: 不会。所有重要数据都通过 volume 挂载，存储在宿主机上：
 - `/root/.bub` → `$BUB_HOME`（tapes、配置）
 - `/root/.openclaw/openclaw-weixin` → `$BUB_WEIXIN_DATA`（微信凭据）
-- `/boxsh` → `$BUB_BOXSH`（agent 对 workspace 的 COW 写入）
+- `/workspace` → `$BUB_BOXSH`（agent 对 workspace 的 COW 写入）
 
 容器删除重建后，这些数据仍然存在。
 
@@ -300,7 +299,7 @@ BOXSH_ARGS="--sandbox \
   --bind wr:/app \
   --bind wr:/root \
   --bind ro:/entrypoint.sh \
-  --bind cow:/workspace:/boxsh \
+  --bind cow:/workspace-base:/workspace \
   --bind ro:/root/.agents/skills \
   --bind ro:/root/.openclaw/openclaw-weixin \
   --bind wr:/root/.bub"
@@ -318,7 +317,7 @@ BOXSH_ARGS="--sandbox \
 ```bash
 BOXSH_ARGS="--sandbox \
   --new-net-ns \
-  --bind cow:$WORKSPACE:/boxsh \
+  --bind cow:/workspace-base:/workspace \
   ..."
 ```
 
@@ -334,8 +333,8 @@ services:
     build: .
     env_file: .env.bub1
     volumes:
-      - ${BUB_WORKSPACE_1}:/workspace
-      - ${BUB_BOXSH_1}:/boxsh
+      - ${BUB_WORKSPACE_1}:/workspace-base
+      - ${BUB_BOXSH_1}:/workspace
       - ${BUB_HOME_1}:/root/.bub
     container_name: bub-1
 
@@ -343,8 +342,8 @@ services:
     build: .
     env_file: .env.bub2
     volumes:
-      - ${BUB_WORKSPACE_2}:/workspace
-      - ${BUB_BOXSH_2}:/boxsh
+      - ${BUB_WORKSPACE_2}:/workspace-base
+      - ${BUB_BOXSH_2}:/workspace
       - ${BUB_HOME_2}:/root/.bub
     container_name: bub-2
 ```

--- a/docs/DOCKER_USAGE.md
+++ b/docs/DOCKER_USAGE.md
@@ -42,8 +42,8 @@ docker-compose logs -f
 
 | 容器内路径 | 环境变量 | 默认值 | 沙箱权限 | 说明 |
 |-----------|---------|-------|---------|------|
-| `/workspace` | `BUB_WORKSPACE` | (必需) | 🐄 COW | Agent 工作空间（只读基座，写入落到 /boxsh） |
-| `/boxsh` | `BUB_BOXSH` | `~/work/boxsh/bub-im-bridge` | ✏️ 可写 | COW 写层，持久化 agent 对 /workspace 的修改 |
+| `/workspace` | `BUB_WORKSPACE` | (必需) | 🐄 COW | Agent 工作空间（fuse-overlayfs merged view，写入落到 /boxsh） |
+| `/boxsh` | `BUB_BOXSH` | `~/work/boxsh/bub-im-bridge` | (内部) | COW upper layer，持久化 agent 对 /workspace 的修改 |
 | `/root/.agents/skills` | `BUB_SKILLS` | `~/.agents/skills` | 🔒 只读 | Bub 技能目录 |
 | `/root/.openclaw/openclaw-weixin` | `BUB_WEIXIN_DATA` | `~/.openclaw/openclaw-weixin` | 🔒 只读 | 微信登录凭据 |
 | `/root/.bub` | `BUB_HOME` | `~/.bub` | ✏️ 可写 | Bub 运行数据（tapes、配置） |
@@ -63,11 +63,11 @@ docker-compose logs -f
 
 ### 进入容器调试
 
-容器内有两层环境：**容器原始环境**和 **boxsh 沙箱环境**。entrypoint 通过 `exec boxsh --sandbox ...` 启动服务，boxsh 会为其命令树创建独立的 mount namespace（沙箱视图）。`docker-compose exec` 新起的进程会进入该 namespace，但不会自动经过 boxsh 初始化。
+容器启动时先用 fuse-overlayfs 在 `/workspace` 上建立 COW overlay（allow_other），再通过 `exec boxsh --sandbox ...` 启动服务。boxsh 为其命令树创建独立的 mount namespace（沙箱视图），`docker-compose exec` 新起的进程会进入该 namespace。
 
 ```bash
 # 1. 进入沙箱视图的调试 shell（与 agent 运行时视角一致）
-#    继承 PID 1 的 boxsh 沙箱保护（COW、只读挂载等）
+#    /workspace 可读写（COW overlay），skills/weixin 只读
 docker-compose exec bub /entrypoint.sh shell
 
 # 2. 进入容器运行环境（同样在 boxsh 的 mount namespace 内）
@@ -207,9 +207,8 @@ mount | grep -E "bind|overlay" | grep -v "lowerdir=/var/lib/docker"
  ├── $BUB_WORKSPACE (原始工作区，不被修改)
  ├── $BUB_BOXSH (COW 写层，持久化 agent 写入)
  └── Docker 容器
-      ├── /workspace ← $BUB_WORKSPACE
-      ├── /boxsh ← $BUB_BOXSH
-      └── boxsh 沙箱 (cow:/workspace:/boxsh)
+      ├── /workspace ← fuse-overlayfs(lower=$BUB_WORKSPACE, upper=$BUB_BOXSH)
+      └── boxsh 沙箱 (bind wr:/workspace)
            └── bub gateway 进程
 ```
 
@@ -299,16 +298,17 @@ BOXSH_ARGS="--sandbox \
   --bind wr:/app \
   --bind wr:/root \
   --bind ro:/entrypoint.sh \
-  --bind cow:$WORKSPACE:/boxsh \
+  --bind wr:$WORKSPACE \
   --bind ro:/root/.agents/skills \
   --bind ro:/root/.openclaw/openclaw-weixin \
   --bind wr:/root/.bub"
 ```
 
-支持的挂载模式：
+COW overlay 在 boxsh 之前由 `fuse-overlayfs` 建立（见 `entrypoint.sh` 顶部），boxsh 只需以 `wr` 绑定 `/workspace`。
+
+支持的 boxsh 挂载模式：
 - `ro:PATH` - 只读挂载
 - `wr:PATH` - 读写挂载
-- `cow:SRC:DST` - 写时复制（COW）挂载
 
 ### 隔离网络访问
 

--- a/docs/DOCKER_USAGE.md
+++ b/docs/DOCKER_USAGE.md
@@ -63,16 +63,17 @@ docker-compose logs -f
 
 ### 进入容器调试
 
-entrypoint 通过 `exec boxsh --sandbox ...` 启动服务，boxsh 使用 `cow:/workspace-base:/workspace` 建立 COW overlay 并创建独立的 mount namespace（沙箱视图）。`docker-compose exec` 新起的进程会进入该 namespace。
+entrypoint 通过 `exec boxsh --sandbox ...` 启动服务，boxsh 使用 `cow:/workspace-base:/workspace` 建立 COW overlay 并创建独立的 mount namespace（沙箱视图）。
 
 ```bash
-# 1. 进入沙箱视图的调试 shell（与 agent 运行时视角一致）
-#    /workspace 可读写（COW merged view），skills/weixin 只读
-docker-compose exec bub /entrypoint.sh shell
+# 1. 启动与 bub 同配置的新 boxsh 调试实例（推荐）
+#    /workspace 可读写（独立的 COW merged view），skills/weixin 只读
+#    适合验证 agent 在沙箱中的行为、测试文件读写
+docker-compose run --rm bub /entrypoint.sh shell
 
-# 2. 进入容器运行环境（同样在 boxsh 的 mount namespace 内）
-#    适合看进程、环境变量、运行中挂载状态
-docker-compose exec bub bash
+# 2. 查看当前运行态（继承服务的沙箱视图）
+#    可查看进程、环境变量、/root/.bub 等，但 /workspace 受 fuse 限制不可访问
+docker-compose exec bub /entrypoint.sh shell
 
 # 3. 进入原始镜像环境（绕过 boxsh，启动新容器）
 #    适合排查镜像内容、确认文件是否被正确打包

--- a/docs/DOCKER_USAGE.md
+++ b/docs/DOCKER_USAGE.md
@@ -42,8 +42,8 @@ docker-compose logs -f
 
 | 容器内路径 | 环境变量 | 默认值 | 沙箱权限 | 说明 |
 |-----------|---------|-------|---------|------|
-| `/workspace` | `BUB_WORKSPACE` | (必需) | 🐄 COW | Agent 工作空间（fuse-overlayfs merged view，写入落到 /boxsh） |
-| `/boxsh` | `BUB_BOXSH` | `~/work/boxsh/bub-im-bridge` | (内部) | COW upper layer，持久化 agent 对 /workspace 的修改 |
+| `/workspace` | `BUB_WORKSPACE` | (必需) | (基座) | COW 只读基座（不在沙箱内直接暴露） |
+| `/boxsh` | `BUB_BOXSH` | `~/work/boxsh/bub-im-bridge` | 🐄 COW | Agent 工作空间（boxsh COW merged view），写入持久化到宿主机 |
 | `/root/.agents/skills` | `BUB_SKILLS` | `~/.agents/skills` | 🔒 只读 | Bub 技能目录 |
 | `/root/.openclaw/openclaw-weixin` | `BUB_WEIXIN_DATA` | `~/.openclaw/openclaw-weixin` | 🔒 只读 | 微信登录凭据 |
 | `/root/.bub` | `BUB_HOME` | `~/.bub` | ✏️ 可写 | Bub 运行数据（tapes、配置） |
@@ -52,22 +52,22 @@ docker-compose logs -f
 
 容器内使用 [boxsh](https://github.com/xicilion/boxsh) 沙箱运行 bub 服务，提供进程级别的文件系统隔离：
 
-- ✅ Agent 可以读取 workspace、skills、weixin 配置
+- ✅ Agent 可以读写 `/boxsh`（COW merged view，基座来自 $BUB_WORKSPACE）
 - ✅ Agent 可以在 `/root/.bub` 中写入 tapes 和配置
-- ✅ Agent 对 `/workspace` 的写操作通过 COW 落到 `/boxsh`，原始 workspace 不受影响
+- ✅ Agent 对 `/boxsh` 的写操作通过 COW 持久化到宿主机 `$BUB_BOXSH`，原始 workspace 不受影响
 - ❌ Agent **无法**修改 skills 和 weixin 配置（防止意外覆盖）
 
-即使 AI agent 生成了 `rm -rf /workspace` 这样的危险命令，也不会对宿主机的原始 workspace 造成影响。所有写入、删除、覆盖都沉淀到宿主机 `$BUB_BOXSH` 目录。
+即使 AI agent 生成了 `rm -rf /boxsh` 这样的危险命令，也不会对宿主机的原始 workspace 造成影响。所有写入、删除、覆盖都沉淀到宿主机 `$BUB_BOXSH` 目录。
 
 ## 调试和运维
 
 ### 进入容器调试
 
-容器启动时先用 fuse-overlayfs 在 `/workspace` 上建立 COW overlay（allow_other），再通过 `exec boxsh --sandbox ...` 启动服务。boxsh 为其命令树创建独立的 mount namespace（沙箱视图），`docker-compose exec` 新起的进程会进入该 namespace。
+entrypoint 通过 `exec boxsh --sandbox ...` 启动服务，boxsh 使用 `cow:/workspace:/boxsh` 建立 COW overlay 并创建独立的 mount namespace（沙箱视图）。`docker-compose exec` 新起的进程会进入该 namespace。
 
 ```bash
 # 1. 进入沙箱视图的调试 shell（与 agent 运行时视角一致）
-#    /workspace 可读写（COW overlay），skills/weixin 只读
+#    /boxsh 可读写（COW merged view），skills/weixin 只读
 docker-compose exec bub /entrypoint.sh shell
 
 # 2. 进入容器运行环境（同样在 boxsh 的 mount namespace 内）
@@ -83,13 +83,13 @@ docker-compose run --rm --entrypoint sh bub
 
 ```bash
 # 测试 COW 写入（应该成功，但不修改原始 workspace）
-echo "test" > /workspace/test.txt
-cat /workspace/test.txt
+echo "test" > /boxsh/test.txt
+cat /boxsh/test.txt
 # 输出：test（通过 COW 层读取）
 
 # 在宿主机验证原始 workspace 未被修改
-# ls ~/work/github/bub-im-bridge/test.txt → 不存在
-# ls ~/work/boxsh/bub-im-bridge/test.txt → 存在（COW 写层）
+# ls $BUB_WORKSPACE/test.txt → 不存在
+# ls $BUB_BOXSH/test.txt → 存在（COW 写层）
 
 # 测试 skills 目录只读（应该失败）
 touch /root/.agents/skills/test.txt  
@@ -104,7 +104,7 @@ echo "success" > /root/.bub/test.txt
 
 ```bash
 # 在沙箱内查看文件（通过 entrypoint）
-docker-compose exec bub /entrypoint.sh ls -la /workspace
+docker-compose exec bub /entrypoint.sh ls -la /boxsh
 
 # 在沙箱内查看 bub 配置
 docker-compose exec bub /entrypoint.sh cat /root/.bub/config.yaml
@@ -180,8 +180,8 @@ docker-compose exec bub /entrypoint.sh shell
 # 在沙箱内执行：
 
 # 1. 测试 COW 写入（成功，但原始 workspace 不变）
-echo test > /workspace/test.txt
-cat /workspace/test.txt
+echo test > /boxsh/test.txt
+cat /boxsh/test.txt
 # 预期输出：test
 
 # 2. 测试可写目录
@@ -207,9 +207,11 @@ mount | grep -E "bind|overlay" | grep -v "lowerdir=/var/lib/docker"
  ├── $BUB_WORKSPACE (原始工作区，不被修改)
  ├── $BUB_BOXSH (COW 写层，持久化 agent 写入)
  └── Docker 容器
-      ├── /workspace ← fuse-overlayfs(lower=$BUB_WORKSPACE, upper=$BUB_BOXSH)
-      └── boxsh 沙箱 (bind wr:/workspace)
-           └── bub gateway 进程
+      ├── /workspace ← $BUB_WORKSPACE (只读基座)
+      ├── /boxsh     ← $BUB_BOXSH (COW upper layer)
+      └── boxsh 沙箱 (cow:/workspace:/boxsh)
+           ├── /boxsh = COW merged view (agent workspace)
+           └── bub gateway 进程 (bub -w /boxsh)
 ```
 
 ### entrypoint.sh 用法
@@ -234,7 +236,7 @@ mount | grep -E "bind|overlay" | grep -v "lowerdir=/var/lib/docker"
 
 ### Q: 为什么要使用 boxsh 沙箱？
 
-A: boxsh 提供进程级别的文件系统隔离，防止 AI agent 执行的命令意外修改重要文件。即使 agent 生成了 `rm -rf /workspace` 这样的危险命令，也不会对宿主机造成影响。
+A: boxsh 提供进程级别的文件系统隔离，防止 AI agent 执行的命令意外修改重要文件。即使 agent 生成了 `rm -rf /boxsh` 这样的危险命令，也不会对宿主机的原始 workspace 造成影响。
 
 ### Q: 沙箱会影响性能吗？
 
@@ -298,17 +300,16 @@ BOXSH_ARGS="--sandbox \
   --bind wr:/app \
   --bind wr:/root \
   --bind ro:/entrypoint.sh \
-  --bind wr:$WORKSPACE \
+  --bind cow:/workspace:/boxsh \
   --bind ro:/root/.agents/skills \
   --bind ro:/root/.openclaw/openclaw-weixin \
   --bind wr:/root/.bub"
 ```
 
-COW overlay 在 boxsh 之前由 `fuse-overlayfs` 建立（见 `entrypoint.sh` 顶部），boxsh 只需以 `wr` 绑定 `/workspace`。
-
 支持的 boxsh 挂载模式：
 - `ro:PATH` - 只读挂载
 - `wr:PATH` - 读写挂载
+- `cow:SRC:DST` - 写时复制（SRC 为只读基座，DST 为沙箱内 merged view）
 
 ### 隔离网络访问
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,26 +22,38 @@ set -e
 # Fixed paths inside container (mounted via docker-compose volumes)
 WORKSPACE="/workspace"
 
-BOXSH_ARGS="--sandbox \
+# Service mode: COW overlay for /workspace (writes go to /boxsh)
+SERVICE_ARGS="--sandbox \
   --bind wr:/app \
   --bind wr:/root \
   --bind ro:/entrypoint.sh \
-  --bind wr:/boxsh \
   --bind cow:$WORKSPACE:/boxsh \
   --bind ro:/root/.agents/skills \
   --bind ro:/root/.openclaw/openclaw-weixin \
   --bind wr:/root/.bub"
 
-# 如果没有参数，启动服务
+# Debug mode: when called via `docker exec`, /workspace is already the COW
+# merged view from the service's boxsh. No need for nested COW — just bind
+# the existing view as writable.
+DEBUG_ARGS="--sandbox \
+  --bind wr:/app \
+  --bind wr:/root \
+  --bind ro:/entrypoint.sh \
+  --bind wr:$WORKSPACE \
+  --bind ro:/root/.agents/skills \
+  --bind ro:/root/.openclaw/openclaw-weixin \
+  --bind wr:/root/.bub"
+
+# 如果没有参数，启动服务（COW 模式）
 if [ $# -eq 0 ]; then
-  exec boxsh $BOXSH_ARGS -c "cd /app && uv run bub -w '$WORKSPACE' gateway"
+  exec boxsh $SERVICE_ARGS -c "cd /app && uv run bub -w '$WORKSPACE' gateway"
 fi
 
-# 如果第一个参数是 "shell" 或 "sh"，启动交互式 shell
+# 如果第一个参数是 "shell" 或 "sh"，启动交互式调试 shell
 if [ "$1" = "shell" ] || [ "$1" = "sh" ]; then
   shift
-  exec boxsh $BOXSH_ARGS "$@"
+  exec boxsh $DEBUG_ARGS "$@"
 fi
 
-# 否则，在 boxsh 中执行传入的命令
-exec boxsh $BOXSH_ARGS -c "$*"
+# 否则，在沙箱中执行传入的命令（调试模式）
+exec boxsh $DEBUG_ARGS -c "$*"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,18 +28,30 @@ set -e
 
 WORKSPACE="/workspace"
 
-# --- COW overlay setup ---
-# Set up fuse-overlayfs manually (not via boxsh cow:) so that:
-# 1. The merged view is at /workspace (natural path)
-# 2. allow_other lets docker exec processes access the overlay
-mkdir -p /tmp/overlay-lower /tmp/overlay-work
+# --- Debug modes (via docker exec) ---
+# docker exec enters PID 1's sandbox namespace where the COW overlay
+# is already set up. Just exec a shell — no overlay init needed.
+if [ "$1" = "shell" ] || [ "$1" = "sh" ]; then
+  shift
+  exec sh "$@"
+fi
+
+if [ $# -gt 0 ]; then
+  exec sh -c "$*"
+fi
+
+# --- Service startup (no args) ---
+
+# COW overlay: set up fuse-overlayfs so /workspace becomes the merged view.
+# allow_other lets docker exec processes access the overlay.
+# workdir must be on the same filesystem as upperdir (/boxsh).
+mkdir -p /tmp/overlay-lower /boxsh/.overlay-work
 mount --bind $WORKSPACE /tmp/overlay-lower
 fuse-overlayfs \
-  -o "lowerdir=/tmp/overlay-lower,upperdir=/boxsh,workdir=/tmp/overlay-work,allow_other" \
+  -o "lowerdir=/tmp/overlay-lower,upperdir=/boxsh,workdir=/boxsh/.overlay-work,allow_other" \
   $WORKSPACE
 
-# --- boxsh sandbox ---
-# /workspace is now the COW overlay; boxsh just binds it as writable.
+# boxsh sandbox: /workspace is now the COW overlay, bind it as writable.
 BOXSH_ARGS="--sandbox \
   --bind wr:/app \
   --bind wr:/root \
@@ -49,16 +61,4 @@ BOXSH_ARGS="--sandbox \
   --bind ro:/root/.openclaw/openclaw-weixin \
   --bind wr:/root/.bub"
 
-# 如果没有参数，启动服务
-if [ $# -eq 0 ]; then
-  exec boxsh $BOXSH_ARGS -c "cd /app && uv run bub -w '$WORKSPACE' gateway"
-fi
-
-# Debug modes: docker exec enters PID 1's sandbox namespace.
-# /workspace is accessible (allow_other on fuse-overlayfs).
-if [ "$1" = "shell" ] || [ "$1" = "sh" ]; then
-  shift
-  exec sh "$@"
-fi
-
-exec sh -c "$*"
+exec boxsh $BOXSH_ARGS -c "cd /app && uv run bub -w '$WORKSPACE' gateway"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,28 +9,23 @@
 # Directory layout inside the sandbox:
 #   /app                             (rw) application code
 #   /root                            (rw) home directory
-#   /workspace                       (cow) agent workspace (COW merged view)
+#   /boxsh                           (cow) agent workspace (COW merged view)
 #   /root/.agents/skills             (ro) bub skills
 #   /root/.openclaw/openclaw-weixin  (ro) weixin credentials
 #   /root/.bub                       (rw) bub home (tapes, config)
 #
-# COW setup:
-#   fuse-overlayfs is set up BEFORE boxsh, with allow_other, so the
-#   merged view at /workspace is accessible to all processes (including
-#   docker exec). boxsh then binds /workspace as writable — it's already
-#   the overlay.
+# COW via boxsh native cow:SRC:DST:
+#   SRC (/workspace) = read-only base (Docker volume from host workspace)
+#   DST (/boxsh)     = overlay mount point / merged view in sandbox
+#   Writes persist to host's $BUB_BOXSH via Docker volume at /boxsh.
 #
-# Docker volumes:
-#   /workspace ← $BUB_WORKSPACE (original data, becomes overlay lower layer)
-#   /boxsh     ← $BUB_BOXSH (persistent write layer, becomes overlay upper)
+# Note: /workspace is NOT visible inside the sandbox. The agent workspace
+# is at /boxsh (the COW merged view).
 
 set -e
 
-WORKSPACE="/workspace"
-
 # --- Debug modes (via docker exec) ---
-# docker exec enters PID 1's sandbox namespace where the COW overlay
-# is already set up. Just exec a shell — no overlay init needed.
+# docker exec enters PID 1's sandbox namespace. Just exec a shell.
 if [ "$1" = "shell" ] || [ "$1" = "sh" ]; then
   shift
   exec sh "$@"
@@ -41,24 +36,13 @@ if [ $# -gt 0 ]; then
 fi
 
 # --- Service startup (no args) ---
-
-# COW overlay: set up fuse-overlayfs so /workspace becomes the merged view.
-# allow_other lets docker exec processes access the overlay.
-# workdir must be on the same filesystem as upperdir (/boxsh).
-mkdir -p /tmp/overlay-lower /boxsh/.overlay-work
-mount --bind $WORKSPACE /tmp/overlay-lower
-fuse-overlayfs \
-  -o "lowerdir=/tmp/overlay-lower,upperdir=/boxsh,workdir=/boxsh/.overlay-work,allow_other" \
-  $WORKSPACE
-
-# boxsh sandbox: /workspace is now the COW overlay, bind it as writable.
 BOXSH_ARGS="--sandbox \
   --bind wr:/app \
   --bind wr:/root \
   --bind ro:/entrypoint.sh \
-  --bind wr:$WORKSPACE \
+  --bind cow:/workspace:/boxsh \
   --bind ro:/root/.agents/skills \
   --bind ro:/root/.openclaw/openclaw-weixin \
   --bind wr:/root/.bub"
 
-exec boxsh $BOXSH_ARGS -c "cd /app && uv run bub -w '$WORKSPACE' gateway"
+exec boxsh $BOXSH_ARGS -c "cd /app && uv run bub -w /boxsh gateway"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,10 +3,10 @@
 #
 # Usage:
 #   entrypoint.sh              - Start bub gateway (default)
-#   entrypoint.sh shell        - Interactive shell (sandbox view)
-#   entrypoint.sh <command>    - Run command (sandbox view)
+#   entrypoint.sh shell        - Interactive shell in boxsh sandbox
+#   entrypoint.sh <command>    - Run command in boxsh sandbox
 #
-# Directory layout inside the sandbox:
+# Directory layout inside the container:
 #   /app                             (rw) application code
 #   /root                            (rw) home directory
 #   /workspace                       (cow) agent workspace (COW merged view)
@@ -21,18 +21,6 @@
 
 set -e
 
-# --- Debug modes (via docker exec) ---
-# docker exec enters PID 1's sandbox namespace. Just exec a shell.
-if [ "$1" = "shell" ] || [ "$1" = "sh" ]; then
-  shift
-  exec sh "$@"
-fi
-
-if [ $# -gt 0 ]; then
-  exec sh -c "$*"
-fi
-
-# --- Service startup (no args) ---
 BOXSH_ARGS="--sandbox \
   --bind wr:/app \
   --bind wr:/root \
@@ -42,4 +30,16 @@ BOXSH_ARGS="--sandbox \
   --bind ro:/root/.openclaw/openclaw-weixin \
   --bind wr:/root/.bub"
 
-exec boxsh $BOXSH_ARGS -c "cd /app && uv run bub -w /workspace gateway"
+# 如果没有参数，启动服务
+if [ $# -eq 0 ]; then
+  exec boxsh $BOXSH_ARGS -c "cd /app && uv run bub -w /workspace gateway"
+fi
+
+# 如果第一个参数是 "shell" 或 "sh"，启动交互式 shell
+if [ "$1" = "shell" ] || [ "$1" = "sh" ]; then
+  shift
+  exec boxsh $BOXSH_ARGS "$@"
+fi
+
+# 否则，在 boxsh 中执行传入的命令
+exec boxsh $BOXSH_ARGS -c "$*"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,6 +21,20 @@
 
 set -e
 
+# --- Debug modes (via docker exec) ---
+# docker exec enters PID 1's sandbox namespace, so /workspace-base is not
+# visible (only sandbox-bound paths exist). Just exec a shell directly —
+# it already inherits the sandbox's COW view of /workspace.
+if [ "$1" = "shell" ] || [ "$1" = "sh" ]; then
+  shift
+  exec sh "$@"
+fi
+
+if [ $# -gt 0 ]; then
+  exec sh -c "$*"
+fi
+
+# --- Service startup (no args) ---
 BOXSH_ARGS="--sandbox \
   --bind wr:/app \
   --bind wr:/root \
@@ -30,16 +44,4 @@ BOXSH_ARGS="--sandbox \
   --bind ro:/root/.openclaw/openclaw-weixin \
   --bind wr:/root/.bub"
 
-# 如果没有参数，启动服务
-if [ $# -eq 0 ]; then
-  exec boxsh $BOXSH_ARGS -c "cd /app && uv run bub -w /workspace gateway"
-fi
-
-# 如果第一个参数是 "shell" 或 "sh"，启动交互式 shell
-if [ "$1" = "shell" ] || [ "$1" = "sh" ]; then
-  shift
-  exec boxsh $BOXSH_ARGS "$@"
-fi
-
-# 否则，在 boxsh 中执行传入的命令
-exec boxsh $BOXSH_ARGS -c "$*"
+exec boxsh $BOXSH_ARGS -c "cd /app && uv run bub -w /workspace gateway"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,46 +6,59 @@
 #   entrypoint.sh shell        - Interactive shell (sandbox view)
 #   entrypoint.sh <command>    - Run command (sandbox view)
 #
-# Directory layout inside the container:
+# Directory layout inside the sandbox:
 #   /app                             (rw) application code
 #   /root                            (rw) home directory
-#   /workspace                       (cow) agent workspace (read-only base, writes go to /boxsh)
-#   /boxsh                           (rw) COW write layer for /workspace
+#   /workspace                       (cow) agent workspace (COW merged view)
 #   /root/.agents/skills             (ro) bub skills
 #   /root/.openclaw/openclaw-weixin  (ro) weixin credentials
 #   /root/.bub                       (rw) bub home (tapes, config)
 #
-# Note: Bind order matters! Later binds override earlier ones.
+# COW setup:
+#   fuse-overlayfs is set up BEFORE boxsh, with allow_other, so the
+#   merged view at /workspace is accessible to all processes (including
+#   docker exec). boxsh then binds /workspace as writable — it's already
+#   the overlay.
+#
+# Docker volumes:
+#   /workspace ← $BUB_WORKSPACE (original data, becomes overlay lower layer)
+#   /boxsh     ← $BUB_BOXSH (persistent write layer, becomes overlay upper)
 
 set -e
 
-# Fixed paths inside container (mounted via docker-compose volumes)
 WORKSPACE="/workspace"
 
-# Service mode: boxsh sandbox with COW overlay for /workspace
+# --- COW overlay setup ---
+# Set up fuse-overlayfs manually (not via boxsh cow:) so that:
+# 1. The merged view is at /workspace (natural path)
+# 2. allow_other lets docker exec processes access the overlay
+mkdir -p /tmp/overlay-lower /tmp/overlay-work
+mount --bind $WORKSPACE /tmp/overlay-lower
+fuse-overlayfs \
+  -o "lowerdir=/tmp/overlay-lower,upperdir=/boxsh,workdir=/tmp/overlay-work,allow_other" \
+  $WORKSPACE
+
+# --- boxsh sandbox ---
+# /workspace is now the COW overlay; boxsh just binds it as writable.
 BOXSH_ARGS="--sandbox \
   --bind wr:/app \
   --bind wr:/root \
   --bind ro:/entrypoint.sh \
-  --bind cow:$WORKSPACE:/boxsh \
+  --bind wr:$WORKSPACE \
   --bind ro:/root/.agents/skills \
   --bind ro:/root/.openclaw/openclaw-weixin \
   --bind wr:/root/.bub"
 
-# 如果没有参数，启动服务（COW 模式）
+# 如果没有参数，启动服务
 if [ $# -eq 0 ]; then
   exec boxsh $BOXSH_ARGS -c "cd /app && uv run bub -w '$WORKSPACE' gateway"
 fi
 
-# Debug modes: when called via `docker exec`, the process already runs
-# inside PID 1's boxsh sandbox namespace (COW overlay, ro/wr binds all
-# in effect). Nesting a second boxsh fails because fuse-overlayfs mounts
-# cannot be used as bind sources for a new namespace. Just exec a shell
-# directly — the sandbox protections are already inherited.
+# Debug modes: docker exec enters PID 1's sandbox namespace.
+# /workspace is accessible (allow_other on fuse-overlayfs).
 if [ "$1" = "shell" ] || [ "$1" = "sh" ]; then
   shift
   exec sh "$@"
 fi
 
-# 在沙箱中执行传入的命令
 exec sh -c "$*"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,6 +26,7 @@ BOXSH_ARGS="--sandbox \
   --bind wr:/app \
   --bind wr:/root \
   --bind ro:/entrypoint.sh \
+  --bind wr:/boxsh \
   --bind cow:$WORKSPACE:/boxsh \
   --bind ro:/root/.agents/skills \
   --bind ro:/root/.openclaw/openclaw-weixin \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,8 +3,8 @@
 #
 # Usage:
 #   entrypoint.sh              - Start bub gateway (default)
-#   entrypoint.sh shell        - Interactive shell in boxsh sandbox
-#   entrypoint.sh <command>    - Run command in boxsh sandbox
+#   entrypoint.sh shell        - Interactive shell (sandbox view)
+#   entrypoint.sh <command>    - Run command (sandbox view)
 #
 # Directory layout inside the container:
 #   /app                             (rw) application code
@@ -22,8 +22,8 @@ set -e
 # Fixed paths inside container (mounted via docker-compose volumes)
 WORKSPACE="/workspace"
 
-# Service mode: COW overlay for /workspace (writes go to /boxsh)
-SERVICE_ARGS="--sandbox \
+# Service mode: boxsh sandbox with COW overlay for /workspace
+BOXSH_ARGS="--sandbox \
   --bind wr:/app \
   --bind wr:/root \
   --bind ro:/entrypoint.sh \
@@ -32,28 +32,20 @@ SERVICE_ARGS="--sandbox \
   --bind ro:/root/.openclaw/openclaw-weixin \
   --bind wr:/root/.bub"
 
-# Debug mode: when called via `docker exec`, /workspace is already the COW
-# merged view from the service's boxsh. No need for nested COW — just bind
-# the existing view as writable.
-DEBUG_ARGS="--sandbox \
-  --bind wr:/app \
-  --bind wr:/root \
-  --bind ro:/entrypoint.sh \
-  --bind wr:$WORKSPACE \
-  --bind ro:/root/.agents/skills \
-  --bind ro:/root/.openclaw/openclaw-weixin \
-  --bind wr:/root/.bub"
-
 # 如果没有参数，启动服务（COW 模式）
 if [ $# -eq 0 ]; then
-  exec boxsh $SERVICE_ARGS -c "cd /app && uv run bub -w '$WORKSPACE' gateway"
+  exec boxsh $BOXSH_ARGS -c "cd /app && uv run bub -w '$WORKSPACE' gateway"
 fi
 
-# 如果第一个参数是 "shell" 或 "sh"，启动交互式调试 shell
+# Debug modes: when called via `docker exec`, the process already runs
+# inside PID 1's boxsh sandbox namespace (COW overlay, ro/wr binds all
+# in effect). Nesting a second boxsh fails because fuse-overlayfs mounts
+# cannot be used as bind sources for a new namespace. Just exec a shell
+# directly — the sandbox protections are already inherited.
 if [ "$1" = "shell" ] || [ "$1" = "sh" ]; then
   shift
-  exec boxsh $DEBUG_ARGS "$@"
+  exec sh "$@"
 fi
 
-# 否则，在沙箱中执行传入的命令（调试模式）
-exec boxsh $DEBUG_ARGS -c "$*"
+# 在沙箱中执行传入的命令
+exec sh -c "$*"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,8 @@
 # Directory layout inside the container:
 #   /app                             (rw) application code
 #   /root                            (rw) home directory
-#   /workspace                       (ro) agent workspace
+#   /workspace                       (cow) agent workspace (read-only base, writes go to /boxsh)
+#   /boxsh                           (rw) COW write layer for /workspace
 #   /root/.agents/skills             (ro) bub skills
 #   /root/.openclaw/openclaw-weixin  (ro) weixin credentials
 #   /root/.bub                       (rw) bub home (tapes, config)
@@ -25,7 +26,7 @@ BOXSH_ARGS="--sandbox \
   --bind wr:/app \
   --bind wr:/root \
   --bind ro:/entrypoint.sh \
-  --bind ro:/workspace \
+  --bind cow:$WORKSPACE:/boxsh \
   --bind ro:/root/.agents/skills \
   --bind ro:/root/.openclaw/openclaw-weixin \
   --bind wr:/root/.bub"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,18 +9,15 @@
 # Directory layout inside the sandbox:
 #   /app                             (rw) application code
 #   /root                            (rw) home directory
-#   /boxsh                           (cow) agent workspace (COW merged view)
+#   /workspace                       (cow) agent workspace (COW merged view)
 #   /root/.agents/skills             (ro) bub skills
 #   /root/.openclaw/openclaw-weixin  (ro) weixin credentials
 #   /root/.bub                       (rw) bub home (tapes, config)
 #
 # COW via boxsh native cow:SRC:DST:
-#   SRC (/workspace) = read-only base (Docker volume from host workspace)
-#   DST (/boxsh)     = overlay mount point / merged view in sandbox
-#   Writes persist to host's $BUB_BOXSH via Docker volume at /boxsh.
-#
-# Note: /workspace is NOT visible inside the sandbox. The agent workspace
-# is at /boxsh (the COW merged view).
+#   SRC (/workspace-base) = read-only base (Docker volume from host workspace)
+#   DST (/workspace)      = overlay mount point / merged view in sandbox
+#   Writes persist to host's $BUB_BOXSH via Docker volume at /workspace (COW upper layer).
 
 set -e
 
@@ -40,9 +37,9 @@ BOXSH_ARGS="--sandbox \
   --bind wr:/app \
   --bind wr:/root \
   --bind ro:/entrypoint.sh \
-  --bind cow:/workspace:/boxsh \
+  --bind cow:/workspace-base:/workspace \
   --bind ro:/root/.agents/skills \
   --bind ro:/root/.openclaw/openclaw-weixin \
   --bind wr:/root/.bub"
 
-exec boxsh $BOXSH_ARGS -c "cd /app && uv run bub -w /boxsh gateway"
+exec boxsh $BOXSH_ARGS -c "cd /app && uv run bub -w /workspace gateway"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@
 #   entrypoint.sh shell        - Interactive shell in boxsh sandbox
 #   entrypoint.sh <command>    - Run command in boxsh sandbox
 #
-# Directory layout inside the container:
+# Directory layout inside the sandbox:
 #   /app                             (rw) application code
 #   /root                            (rw) home directory
 #   /workspace                       (cow) agent workspace (COW merged view)
@@ -21,20 +21,6 @@
 
 set -e
 
-# --- Debug modes (via docker exec) ---
-# docker exec enters PID 1's sandbox namespace, so /workspace-base is not
-# visible (only sandbox-bound paths exist). Just exec a shell directly —
-# it already inherits the sandbox's COW view of /workspace.
-if [ "$1" = "shell" ] || [ "$1" = "sh" ]; then
-  shift
-  exec sh "$@"
-fi
-
-if [ $# -gt 0 ]; then
-  exec sh -c "$*"
-fi
-
-# --- Service startup (no args) ---
 BOXSH_ARGS="--sandbox \
   --bind wr:/app \
   --bind wr:/root \
@@ -44,4 +30,27 @@ BOXSH_ARGS="--sandbox \
   --bind ro:/root/.openclaw/openclaw-weixin \
   --bind wr:/root/.bub"
 
-exec boxsh $BOXSH_ARGS -c "cd /app && uv run bub -w /workspace gateway"
+# 如果没有参数，启动服务
+if [ $# -eq 0 ]; then
+  exec boxsh $BOXSH_ARGS -c "cd /app && uv run bub -w /workspace gateway"
+fi
+
+# 如果第一个参数是 "shell" 或 "sh"，启动交互式 shell
+if [ "$1" = "shell" ] || [ "$1" = "sh" ]; then
+  shift
+  if [ -d /workspace-base ]; then
+    # Fresh container (docker-compose run --rm): start new boxsh sandbox
+    exec boxsh $BOXSH_ARGS "$@"
+  else
+    # Inside existing sandbox (docker exec): /workspace-base not visible,
+    # just exec sh — it inherits the sandbox's mount namespace
+    exec sh "$@"
+  fi
+fi
+
+# 否则，在 boxsh 中执行传入的命令
+if [ -d /workspace-base ]; then
+  exec boxsh $BOXSH_ARGS -c "$*"
+else
+  exec sh -c "$*"
+fi


### PR DESCRIPTION
## Summary
- Restore `--bind cow:$WORKSPACE:/boxsh` in entrypoint.sh (was temporarily changed to `ro:/workspace`)
- Keep `--bind ro:/entrypoint.sh` for debug access via `docker-compose exec bub /entrypoint.sh shell`
- Update all docs (README.md, DOCKER_USAGE.md) to reflect COW mode

## Verification
After rebuild, enter sandbox and test:
```bash
docker-compose exec bub /entrypoint.sh shell
echo test > /workspace/xxx.txt
cat /workspace/xxx.txt           # should output: test
```
On host: original workspace should be untouched, `$BUB_BOXSH` should contain the write.

## Test plan
- [ ] `docker-compose build --no-cache && docker-compose up -d`
- [ ] `docker-compose exec bub /entrypoint.sh shell` enters sandbox
- [ ] COW write to `/workspace` succeeds in sandbox
- [ ] Original workspace on host is unmodified
- [ ] `$BUB_BOXSH` directory contains COW upper layer files

🤖 Generated with [Claude Code](https://claude.com/claude-code)