### PR TITLE
fix: expand ~ in .env values to prevent literal tilde paths

### DIFF
--- a/src/bub_im_bridge/__init__.py
+++ b/src/bub_im_bridge/__init__.py
@@ -19,7 +19,7 @@ def _load_dotenv_to_environ() -> None:
         key = key.strip()
         value = value.strip().strip("'\"")
         if key and key not in os.environ:
-            os.environ[key] = value
+            os.environ[key] = os.path.expanduser(value)
 
 
 _load_dotenv_to_environ()

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -144,7 +144,7 @@ class FeishuChannel(Channel):
 
         # User profile store
         workspace = os.environ.get("BUB_WORKSPACE", os.getcwd())
-        self._profile_store = ProfileStore(Path(workspace) / "profiles")
+        self._profile_store = ProfileStore(Path(workspace).expanduser() / "profiles")
         self._profile_store.load()
 
     @property

--- a/src/bub_im_bridge/feishu/tools.py
+++ b/src/bub_im_bridge/feishu/tools.py
@@ -115,7 +115,7 @@ def _get_profile_store(context: ToolContext) -> ProfileStore:
         return store
     # Fallback: create a store if not injected (e.g., comma-command without channel)
     workspace = context.state.get("_runtime_workspace") or os.environ.get("BUB_WORKSPACE", os.getcwd())
-    store = ProfileStore(Path(workspace) / "profiles")
+    store = ProfileStore(Path(workspace).expanduser() / "profiles")
     store.load()
     return store
 


### PR DESCRIPTION
## Summary

- `_load_dotenv_to_environ()` in `__init__.py` loaded `.env` values without `expanduser()`, so `BUB_WORKSPACE=~/work/...` was stored as literal `~` in `os.environ`
- `feishu/channel.py` and `profiles.py` then created `Path("~/work/...")` and called `mkdir(parents=True)`, producing `/app/~/work/...` under the CWD
- Added `os.path.expanduser()` at the source (dotenv loader) and defensively at consumption sites (feishu/channel.py, feishu/tools.py)

## Root cause chain

1. `.env`: `BUB_WORKSPACE=~/work/github/system-weaver`
2. `__init__.py:22`: `os.environ[key] = value` (no expanduser)
3. `feishu/channel.py:146`: `Path(workspace) / "profiles"` (literal `~`)
4. `profiles.py:103`: `self._dir.mkdir(parents=True)` → creates `/app/~/work/...`

## Cleanup note

Existing `/app/~` directories created by previous runs need manual removal:
```bash
docker-compose exec bub sh -c 'rm -rf /app/\~'
```

## Test plan

- [ ] Start gateway with `BUB_WORKSPACE=~/...` in `.env` — verify no `/app/~` directory created
- [ ] Verify profiles are written to the correct expanded path

🤖 Generated with [Claude Code](https://claude.com/claude-code)