### PR TITLE
fix: use runtime workspace for profile storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,8 +10,11 @@ BUB_API_BASE=https://api.anthropic.com
 BUB_WORKSPACE=/path/to/your-workspace
 
 # ---------------------------------------------------------------------------
-# Docker 部署目录（docker compose 使用）
+# Docker 部署（docker compose 使用）
 # ---------------------------------------------------------------------------
+# 容器时区（默认 Asia/Shanghai）
+# TZ=Asia/Shanghai
+
 BUB_HOME=~/.bub
 BUB_BOXSH=~/work/boxsh/bub-im-bridge
 BUB_SKILLS=~/.agents/skills

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ services:
   bub:
     build: .
     env_file: .env
+    environment:
+      - TZ=${TZ:-Asia/Shanghai}
     volumes:
       - ${BUB_WORKSPACE}:/workspace-base
       - ${BUB_BOXSH}:/workspace

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -143,8 +143,8 @@ class FeishuChannel(Channel):
         self._message_start_time: dict[str, float] = {}
 
         # User profile store
-        workspace = os.environ.get("BUB_WORKSPACE", os.getcwd())
-        self._profile_store = ProfileStore(Path(workspace).expanduser() / "profiles")
+        workspace = self._framework.workspace if self._framework else Path.cwd()
+        self._profile_store = ProfileStore(Path(workspace) / "profiles")
         self._profile_store.load()
 
     @property

--- a/src/bub_im_bridge/feishu/tools.py
+++ b/src/bub_im_bridge/feishu/tools.py
@@ -114,8 +114,8 @@ def _get_profile_store(context: ToolContext) -> ProfileStore:
     if store is not None:
         return store
     # Fallback: create a store if not injected (e.g., comma-command without channel)
-    workspace = context.state.get("_runtime_workspace") or os.environ.get("BUB_WORKSPACE", os.getcwd())
-    store = ProfileStore(Path(workspace).expanduser() / "profiles")
+    workspace = context.state.get("_runtime_workspace") or os.getcwd()
+    store = ProfileStore(Path(workspace) / "profiles")
     store.load()
     return store
 


### PR DESCRIPTION
## Summary

- `feishu/channel.py` was reading `BUB_WORKSPACE` env var to determine profile storage path, but this is a host-side path for Docker volume mounting — it doesn't exist inside the container
- Changed to use `self._framework.workspace` which is set by `bub -w /workspace` at runtime
- `feishu/tools.py` fallback also updated: uses `_runtime_workspace` from context state (set by BubFramework), falls back to `os.getcwd()` — no longer reads `BUB_WORKSPACE`

## Before/After

| | Before | After |
|---|---|---|
| channel.py | `os.environ.get("BUB_WORKSPACE")` → host path | `self._framework.workspace` → runtime path |
| tools.py | `_runtime_workspace` or `BUB_WORKSPACE` | `_runtime_workspace` or `os.getcwd()` |
| Profile location | `/app/~/work/github/system-weaver/profiles/` | `/workspace/profiles/` |

## Test plan

- [ ] Start gateway with `bub -w /workspace` — verify profiles created under `/workspace/profiles/`
- [ ] Verify no more `/app/~` directory created on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)