### PR TITLE
feat: add user.create tool + profile system hardening

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,9 +30,11 @@ BOXSH_ARGS="--sandbox \
   --bind ro:/root/.openclaw/openclaw-weixin \
   --bind wr:/root/.bub"
 
-# Ensure profiles directory exists in workspace-base before boxsh
-# creates the COW overlay (avoids EXDEV on first mkdir inside overlay)
+# Ensure profiles directory exists in BOTH lower (workspace-base) and upper
+# (workspace / BUB_BOXSH) layers before boxsh creates the COW overlay.
+# fuse-overlayfs raises EXDEV on file creation in lower-only directories.
 [ -d /workspace-base ] && mkdir -p /workspace-base/profiles
+[ -d /workspace ] && mkdir -p /workspace/profiles
 
 # 如果没有参数，启动服务
 if [ $# -eq 0 ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,6 +30,10 @@ BOXSH_ARGS="--sandbox \
   --bind ro:/root/.openclaw/openclaw-weixin \
   --bind wr:/root/.bub"
 
+# Ensure profiles directory exists in workspace-base before boxsh
+# creates the COW overlay (avoids EXDEV on first mkdir inside overlay)
+[ -d /workspace-base ] && mkdir -p /workspace-base/profiles
+
 # 如果没有参数，启动服务
 if [ $# -eq 0 ]; then
   exec boxsh $BOXSH_ARGS -c "cd /app && uv run bub -w /workspace gateway"

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -154,7 +154,15 @@ class FeishuChannel(Channel):
 
         # User profile store
         workspace = self._framework.workspace if self._framework else Path.cwd()
-        self._profile_store = ProfileStore(Path(workspace) / "profiles")
+        profiles_dir = Path(workspace) / "profiles"
+        logger.info(
+            "feishu.profiles workspace={} profiles_dir={} exists={} count={}",
+            workspace,
+            profiles_dir,
+            profiles_dir.exists(),
+            len(list(profiles_dir.glob("*.md"))) if profiles_dir.exists() else 0,
+        )
+        self._profile_store = ProfileStore(profiles_dir)
         self._profile_store.load()
 
     @property
@@ -409,42 +417,45 @@ class FeishuChannel(Channel):
         session_id = f"feishu:{message.chat_id}"
         sender_id = message.sender_open_id or ""
 
-        # Ensure user profile exists
-        if sender_id and message.sender_type != "bot":
-            profile = self._profile_store.lookup("feishu", "open_id", sender_id)
-            if profile is not None:
-                self._profile_store.touch(profile.id)
-            else:
-                extra_ids: dict[str, str] = {}
-                if message.sender_union_id:
-                    extra_ids["union_id"] = message.sender_union_id
-                if message.sender_user_id:
-                    extra_ids["user_id"] = message.sender_user_id
-
-                info = {"name": message.sender_name or sender_id}
-                if self._api_client is not None:
-                    from bub_im_bridge.feishu.api import fetch_user_info
-                    info = fetch_user_info(self._api_client, sender_id)
-
-                self._profile_store.upsert(
-                    platform="feishu",
-                    id_field="open_id",
-                    id_value=sender_id,
-                    name=info.get("name", sender_id),
-                    extra_ids=extra_ids,
-                    department=info.get("department_id", ""),
-                    title=info.get("job_title", ""),
-                    avatar_url=info.get("avatar_url", ""),
-                )
-
         # Remember for reply
         self._last_message_id[message.chat_id] = message.message_id
-        
+
         # Send random reaction to acknowledge message received
         self._add_random_reaction(message.message_id)
-        
+
         # Record start time for elapsed time calculation
         self._message_start_time[message.message_id] = time.time()
+
+        # Best-effort profile enrichment (must not block message dispatch)
+        try:
+            if sender_id and message.sender_type != "bot":
+                profile = self._profile_store.lookup("feishu", "open_id", sender_id)
+                if profile is not None:
+                    self._profile_store.touch(profile.id)
+                else:
+                    extra_ids: dict[str, str] = {}
+                    if message.sender_union_id:
+                        extra_ids["union_id"] = message.sender_union_id
+                    if message.sender_user_id:
+                        extra_ids["user_id"] = message.sender_user_id
+
+                    info = {"name": message.sender_name or sender_id}
+                    if self._api_client is not None:
+                        from bub_im_bridge.feishu.api import fetch_user_info
+                        info = fetch_user_info(self._api_client, sender_id)
+
+                    self._profile_store.upsert(
+                        platform="feishu",
+                        id_field="open_id",
+                        id_value=sender_id,
+                        name=info.get("name", sender_id),
+                        extra_ids=extra_ids,
+                        department=info.get("department_id", ""),
+                        title=info.get("job_title", ""),
+                        avatar_url=info.get("avatar_url", ""),
+                    )
+        except Exception:
+            logger.warning("feishu.profile_enrichment failed sender={}", sender_id, exc_info=True)
 
         # Register a fresh ToolStats keyed by message_id; loguru sink will
         # forward tool.call events into it until we pop() on send().

--- a/src/bub_im_bridge/feishu/feishu_prompts.py
+++ b/src/bub_im_bridge/feishu/feishu_prompts.py
@@ -11,17 +11,18 @@ if TYPE_CHECKING:
 def build_user_context_hint(profile: UserProfile | None) -> str:
     """Build a prompt hint with sender profile context and tool usage guidance."""
     tool_hints = (
-        "当需要处理用户 profile 时，必须使用以下内置工具：\n"
-        "- 创建新 profile：使用 user.create（如果用户已存在会自动更新）\n"
-        "- 查询 profile：使用 user.lookup（按名字或 IM ID）或 user.search（按关键词搜索）\n"
-        "- 更新已有 profile 的字段：使用 user.update\n"
-        "- 当消息中提及其他用户（如 @某某）时，使用 user.lookup 查询该用户的 profile\n"
-        "- 当观察到用户的行为特征、兴趣爱好等信息时，使用 user.update 记录到对应 profile\n\n"
-        "严禁事项：\n"
-        "- 严禁使用 bash、python 或直接编辑文件的方式操作 profiles 目录下的文件\n"
-        "- 严禁手工构造 ProfileStore 或调用其内部方法\n"
-        "- 严禁向终端用户输出 ProfileStore、upsert、工具封装等内部实现细节；"
-        "如果操作失败，只返回简短的面向用户的错误信息"
+        "用户相关信息有多个来源，按用途区分：\n"
+        "- profile（user.lookup / user.search / user.create / user.update）用于长期记忆和结构化记录\n"
+        "- Feishu 消息上下文（sender、mentions）、Feishu API 信息用于当前会话感知\n"
+        "- workspace 中的 USER.md 或其他上下文文件用于理解用户或项目背景\n\n"
+        "规则：\n"
+        "- 当需要读取、创建、更新 profile 时，必须使用内置 user.* 工具\n"
+        "- 当消息中提及其他用户（如 @某某）时，使用 user.lookup 查询\n"
+        "- 当观察到用户的行为特征、兴趣爱好等信息时，使用 user.update 记录\n"
+        "- profile 不存在或不完整时，不要卡住；继续结合 Feishu 信息、当前消息、"
+        "USER.md 等其他来源完成任务\n"
+        "- 不得用 bash、python 或直接文件编辑操作 profiles 目录\n"
+        "- 不要把内部实现细节输出给终端用户"
     )
 
     if profile is None:

--- a/src/bub_im_bridge/feishu/feishu_prompts.py
+++ b/src/bub_im_bridge/feishu/feishu_prompts.py
@@ -11,9 +11,17 @@ if TYPE_CHECKING:
 def build_user_context_hint(profile: UserProfile | None) -> str:
     """Build a prompt hint with sender profile context and tool usage guidance."""
     tool_hints = (
-        "当消息中提及其他用户（如 @某某）时，使用 user.lookup 工具查询该用户的 profile。\n"
-        "当你观察到用户的行为特征、兴趣爱好等信息时，使用 user.update 工具记录到对应 profile。\n"
-        "当需要查找某人或搜索特定用户时，使用 user.search 工具。"
+        "当需要处理用户 profile 时，必须使用以下内置工具：\n"
+        "- 创建新 profile：使用 user.create（如果用户已存在会自动更新）\n"
+        "- 查询 profile：使用 user.lookup（按名字或 IM ID）或 user.search（按关键词搜索）\n"
+        "- 更新已有 profile 的字段：使用 user.update\n"
+        "- 当消息中提及其他用户（如 @某某）时，使用 user.lookup 查询该用户的 profile\n"
+        "- 当观察到用户的行为特征、兴趣爱好等信息时，使用 user.update 记录到对应 profile\n\n"
+        "严禁事项：\n"
+        "- 严禁使用 bash、python 或直接编辑文件的方式操作 profiles 目录下的文件\n"
+        "- 严禁手工构造 ProfileStore 或调用其内部方法\n"
+        "- 严禁向终端用户输出 ProfileStore、upsert、工具封装等内部实现细节；"
+        "如果操作失败，只返回简短的面向用户的错误信息"
     )
 
     if profile is None:

--- a/src/bub_im_bridge/feishu/tools.py
+++ b/src/bub_im_bridge/feishu/tools.py
@@ -113,8 +113,11 @@ def _get_profile_store(context: ToolContext) -> ProfileStore:
     store = context.state.get("_profile_store")
     if store is not None:
         return store
-    # Fallback: create a store if not injected (e.g., comma-command without channel)
-    workspace = context.state.get("_runtime_workspace") or os.getcwd()
+    # Fallback: require _runtime_workspace; never use os.getcwd() which may
+    # resolve to an unrelated directory (e.g. ~/.bub) inside the sandbox.
+    workspace = context.state.get("_runtime_workspace")
+    if not workspace:
+        raise RuntimeError("profile tools require _profile_store or _runtime_workspace in context")
     store = ProfileStore(Path(workspace) / "profiles")
     store.load()
     return store
@@ -240,6 +243,37 @@ async def user_update(params: UserUpdateInput, *, context: ToolContext) -> str:
         return "更新失败"
 
     return f"已更新 {updated.name} 的 {params.field}"
+
+
+class UserCreateInput(BaseModel):
+    """Input for user.create tool."""
+
+    name: str = Field(..., description="用户显示名")
+    platform: str = Field("feishu", description="IM 平台，如 'feishu'")
+    id_field: str = Field("open_id", description="ID 字段名，如 'open_id'")
+    id_value: str = Field(..., description="ID 值，如 'ou_xxx'")
+    department: str = Field("", description="部门")
+    title: str = Field("", description="职位")
+
+
+@tool(name="user.create", model=UserCreateInput, context=True)
+async def user_create(params: UserCreateInput, *, context: ToolContext) -> str:
+    """创建新用户 profile。
+
+    当需要手动创建一个新的用户 profile 时使用此工具。
+    如果用户已存在（相同 platform + id_field + id_value），会更新已有 profile。
+    """
+    store = _get_profile_store(context)
+
+    profile = store.upsert(
+        platform=params.platform,
+        id_field=params.id_field,
+        id_value=params.id_value,
+        name=params.name,
+        department=params.department,
+        title=params.title,
+    )
+    return f"已创建/更新 profile: {profile.name} (id: {profile.id})"
 
 
 def _format_profile(profile) -> str:


### PR DESCRIPTION
## Summary
- Add `user.create` tool exposing `ProfileStore.upsert()` — agent can now create new profiles via built-in tools instead of falling back to bash/python
- Restructure prompt hints as behavioral rules: action→tool mapping, prohibit bash/python/direct file ops, prohibit leaking internal implementation details to end users
- Move profile enrichment after reaction + wrap in try/except (non-blocking)
- Remove `os.getcwd()` fallback in `tools.py` — fail fast if context missing
- Pre-create profiles dir in workspace-base before COW overlay (EXDEV fix)
- Add workspace/profiles diagnostic logging at channel init

## Test plan
- [ ] Deploy container, verify profile enrichment doesn't block message dispatch
- [ ] Have agent create a new profile via `user.create` tool
- [ ] Verify agent no longer falls back to bash for profile operations
- [ ] Verify profiles are written to `/workspace/profiles/` not `~/.bub/profiles/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)