### PR TITLE
feat: add host-mode boxsh startup script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,15 +10,26 @@ BUB_API_BASE=https://api.anthropic.com
 BUB_WORKSPACE=/path/to/your-workspace
 
 # ---------------------------------------------------------------------------
-# Docker 部署（docker compose 使用）
+# 部署路径（docker compose 和 run-host.sh 共用）
 # ---------------------------------------------------------------------------
-# 容器时区（默认 Asia/Shanghai）
+# 容器时区（Docker 模式，默认 Asia/Shanghai）
 # TZ=Asia/Shanghai
 
 BUB_HOME=~/.bub
 BUB_BOXSH=~/work/boxsh/bub-im-bridge
 BUB_SKILLS=~/.agents/skills
 BUB_WEIXIN_DATA=~/.openclaw/openclaw-weixin
+
+# 部署模式说明：
+#   Docker 模式:  docker compose up (使用 entrypoint.sh)
+#   宿主机模式:   ./run-host.sh     (直接用 boxsh，不需要 Docker)
+#
+# 两种模式共用以上路径变量：
+#   BUB_WORKSPACE  - 工作区基础目录（COW lower 层，只读）
+#   BUB_BOXSH      - COW upper 层目录（持久化 agent 写入）
+#   BUB_SKILLS     - skills 目录（只读）
+#   BUB_WEIXIN_DATA - 微信数据目录（只读，可选）
+#   BUB_HOME       - bub 主目录（tapes、config）
 
 # ---------------------------------------------------------------------------
 # Agent runtime（可选）

--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,7 @@ BUB_WORKSPACE=/path/to/your-workspace
 
 BUB_HOME=~/.bub
 BUB_BOXSH=~/work/boxsh/bub-im-bridge
+BUB_BOXSH_HOST=~/work/boxsh/bub-im-bridge-host
 BUB_SKILLS=~/.agents/skills
 BUB_WEIXIN_DATA=~/.openclaw/openclaw-weixin
 
@@ -26,13 +27,13 @@ BUB_WEIXIN_DATA=~/.openclaw/openclaw-weixin
 #
 # 两种模式共用以上路径变量，COW 语义说明：
 #
-#   BUB_WORKSPACE  - 工作区基础目录（COW lower 层，只读，agent 不可修改）
-#   BUB_BOXSH      - COW upper 层目录（持久化 agent 写入）
-#                    Docker 模式：映射为容器内 /workspace（runtime workspace）
-#                    宿主机模式：直接作为 runtime workspace（bub -w $BUB_BOXSH）
-#   BUB_SKILLS     - skills 目录（沙箱内只读）
+#   BUB_WORKSPACE   - 工作区基础目录（COW lower 层，只读，agent 不可修改）
+#   BUB_BOXSH       - Docker 模式 COW upper 层（映射为容器内 /workspace）
+#   BUB_BOXSH_HOST  - 宿主机模式 COW upper 层 + runtime workspace
+#                     必须和 BUB_BOXSH 不同，避免两种模式的 COW 产物混在一起
+#   BUB_SKILLS      - skills 目录（沙箱内只读）
 #   BUB_WEIXIN_DATA - 微信数据目录（沙箱内只读，可选）
-#   BUB_HOME       - bub 主目录（tapes、config，可写）
+#   BUB_HOME        - bub 主目录（tapes、config，可写）
 #
 # 注意：app 代码通过 framework.workspace（来自 bub -w 参数）动态获取路径，
 # 不会硬编码 /workspace。两种模式下 app 行为完全一致。

--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,7 @@ BUB_WEIXIN_DATA=~/.openclaw/openclaw-weixin
 
 # 部署模式：
 #   Docker 模式:  docker compose up    (使用 entrypoint.sh)
-#   宿主机模式:   ./run-host.sh        (直接用 boxsh >= 2.0，不需要 Docker)
+#   宿主机模式:   ./run-host.sh        (直接用 boxsh >= 2.1.0，不需要 Docker)
 #
 # 两种模式共用以上路径变量，COW 语义说明：
 #

--- a/.env.example
+++ b/.env.example
@@ -20,16 +20,22 @@ BUB_BOXSH=~/work/boxsh/bub-im-bridge
 BUB_SKILLS=~/.agents/skills
 BUB_WEIXIN_DATA=~/.openclaw/openclaw-weixin
 
-# 部署模式说明：
-#   Docker 模式:  docker compose up (使用 entrypoint.sh)
-#   宿主机模式:   ./run-host.sh     (直接用 boxsh，不需要 Docker)
+# 部署模式：
+#   Docker 模式:  docker compose up    (使用 entrypoint.sh)
+#   宿主机模式:   ./run-host.sh        (直接用 boxsh >= 2.0，不需要 Docker)
 #
-# 两种模式共用以上路径变量：
-#   BUB_WORKSPACE  - 工作区基础目录（COW lower 层，只读）
+# 两种模式共用以上路径变量，COW 语义说明：
+#
+#   BUB_WORKSPACE  - 工作区基础目录（COW lower 层，只读，agent 不可修改）
 #   BUB_BOXSH      - COW upper 层目录（持久化 agent 写入）
-#   BUB_SKILLS     - skills 目录（只读）
-#   BUB_WEIXIN_DATA - 微信数据目录（只读，可选）
-#   BUB_HOME       - bub 主目录（tapes、config）
+#                    Docker 模式：映射为容器内 /workspace（runtime workspace）
+#                    宿主机模式：直接作为 runtime workspace（bub -w $BUB_BOXSH）
+#   BUB_SKILLS     - skills 目录（沙箱内只读）
+#   BUB_WEIXIN_DATA - 微信数据目录（沙箱内只读，可选）
+#   BUB_HOME       - bub 主目录（tapes、config，可写）
+#
+# 注意：app 代码通过 framework.workspace（来自 bub -w 参数）动态获取路径，
+# 不会硬编码 /workspace。两种模式下 app 行为完全一致。
 
 # ---------------------------------------------------------------------------
 # Agent runtime（可选）

--- a/README.md
+++ b/README.md
@@ -88,11 +88,27 @@ uv run bub gateway
 
 </details>
 
-## Docker 部署
+## 沙箱部署
 
-容器内通过 [boxsh](https://github.com/xicilion/boxsh) 沙箱运行，Agent 对工作空间的写入通过 COW（写时复制）隔离到独立目录，原始工作空间不受影响。
+通过 [boxsh](https://github.com/xicilion/boxsh) 沙箱运行，Agent 对工作空间的写入通过 COW（写时复制）隔离到独立目录，原始工作空间不受影响。支持两种部署模式：
 
-### 快速开始
+### 宿主机模式（推荐开发调试）
+
+直接在宿主机用 boxsh 沙箱运行，无需 Docker。要求 boxsh >= 2.0。
+
+```bash
+# 1. 准备配置
+cp .env.example .env
+# 编辑 .env，填入必要配置
+
+# 2. 启动
+./run-host.sh
+
+# 3. 进入沙箱调试
+./run-host.sh shell
+```
+
+### Docker 模式（推荐生产部署）
 
 ```bash
 # 1. 准备配置
@@ -112,25 +128,37 @@ docker-compose up -d
 docker-compose logs -f
 ```
 
+### COW 路径映射
+
+两种模式使用相同的环境变量（`BUB_WORKSPACE`、`BUB_BOXSH`），COW 语义一致：
+
+| 角色 | Docker 模式 | 宿主机模式 |
+|------|-------------|------------|
+| Lower（只读基座） | `/workspace-base`（来自 `$BUB_WORKSPACE`） | `$BUB_WORKSPACE` |
+| Upper（持久化写入） | `/workspace`（来自 `$BUB_BOXSH`） | `$BUB_BOXSH` |
+| Runtime workspace | `/workspace` | `$BUB_BOXSH` |
+
+> App 代码通过 `bub -w` 参数动态获取 workspace 路径，不硬编码任何路径。两种模式下行为完全一致。
+
 ### 沙箱保护
 
 | 目录 | 权限 | 说明 |
 |------|------|------|
-| `/workspace` | 🐄 COW | Agent 工作空间（boxsh COW merged view，基座来自 $BUB_WORKSPACE） |
-| `/root/.agents/skills` | 🔒 只读 | Bub 技能目录 |
-| `/root/.openclaw/openclaw-weixin` | 🔒 只读 | 微信登录凭据 |
-| `/root/.bub` | ✏️ 可写 | Bub 运行数据（tapes、配置） |
+| workspace | COW | Agent 工作空间（COW merged view，基座来自 `$BUB_WORKSPACE`） |
+| skills | 只读 | Bub 技能目录 |
+| weixin data | 只读 | 微信登录凭据 |
+| bub home | 可写 | Bub 运行数据（tapes、配置） |
 
-### 调试
+### Docker 调试
 
 ```bash
-# 启动与 bub 同配置的 boxsh 调试实例（/workspace 可读写）
+# 启动与 bub 同配置的 boxsh 调试实例
 docker-compose run --rm bub /entrypoint.sh shell
 
-# 查看当前运行态（继承服务视图，/workspace 受限）
+# 查看当前运行态
 docker-compose exec bub /entrypoint.sh shell
 
-# 进入原始镜像环境（绕过 boxsh，排查镜像内容）
+# 进入原始镜像环境（绕过 boxsh）
 docker-compose run --rm --entrypoint sh bub
 ```
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ uv run bub gateway
 
 ### 宿主机模式（推荐开发调试）
 
-直接在宿主机用 boxsh 沙箱运行，无需 Docker。要求 boxsh >= 2.0。
+直接在宿主机用 boxsh 沙箱运行，无需 Docker。要求 boxsh >= 2.1.0。
 
 ```bash
 # 1. 准备配置
@@ -130,15 +130,15 @@ docker-compose logs -f
 
 ### COW 路径映射
 
-两种模式使用相同的环境变量（`BUB_WORKSPACE`、`BUB_BOXSH`），COW 语义一致：
+两种模式使用独立的 upper 目录，避免 COW 产物互相干扰：
 
 | 角色 | Docker 模式 | 宿主机模式 |
 |------|-------------|------------|
 | Lower（只读基座） | `/workspace-base`（来自 `$BUB_WORKSPACE`） | `$BUB_WORKSPACE` |
-| Upper（持久化写入） | `/workspace`（来自 `$BUB_BOXSH`） | `$BUB_BOXSH` |
-| Runtime workspace | `/workspace` | `$BUB_BOXSH` |
+| Upper（持久化写入） | `/workspace`（来自 `$BUB_BOXSH`） | `$BUB_BOXSH_HOST` |
+| Runtime workspace | `/workspace` | `$BUB_BOXSH_HOST` |
 
-> App 代码通过 `bub -w` 参数动态获取 workspace 路径，不硬编码任何路径。两种模式下行为完全一致。
+> **重要：** Docker 模式使用 `BUB_BOXSH`，宿主机模式使用 `BUB_BOXSH_HOST`，两者不可混用。App 代码通过 `bub -w` 参数动态获取 workspace 路径，不硬编码任何路径。
 
 ### 沙箱保护
 

--- a/run-host.sh
+++ b/run-host.sh
@@ -7,38 +7,51 @@
 #   run-host.sh <command>    - Run command in boxsh sandbox
 #
 # Requires:
-#   - boxsh >= 2.0.0 (https://github.com/xicilion/boxsh)
+#   - boxsh >= 2.1.0 (https://github.com/xicilion/boxsh)
 #   - uv (https://github.com/astral-sh/uv)
 #   - .env file with required configuration
 #
 # Environment variables (loaded from .env):
 #   BUB_WORKSPACE   - Workspace base directory (COW lower layer, read-only)
-#   BUB_BOXSH       - COW upper layer (persists agent writes, also runtime workspace)
+#   BUB_BOXSH_HOST  - Host mode COW upper layer + runtime workspace (MUST differ from BUB_BOXSH)
 #   BUB_SKILLS      - Skills directory (read-only in sandbox)
 #   BUB_WEIXIN_DATA - WeChat credentials directory (read-only, optional)
 #   BUB_HOME        - Bub home directory for tapes/config (read-write)
 #
 # COW path mapping (Host mode vs Docker mode):
 #
-#   Role                  Docker mode          Host mode
-#   ----                  -----------          ---------
-#   Lower (read-only)     /workspace-base      $BUB_WORKSPACE
-#   Upper (writes)        /workspace           $BUB_BOXSH
-#   Sandbox mount point   /workspace           $BUB_BOXSH
-#   bub -w flag           /workspace           $BUB_BOXSH
+#   Role                  Docker mode                    Host mode
+#   ----                  -----------                    ---------
+#   Lower (read-only)     /workspace-base ($BUB_WORKSPACE)  $BUB_WORKSPACE
+#   Upper (writes)        /workspace ($BUB_BOXSH)            $BUB_BOXSH_HOST
+#   Runtime workspace     /workspace                         $BUB_BOXSH_HOST
+#   bub -w flag           /workspace                         $BUB_BOXSH_HOST
+#
+#   IMPORTANT: Host and Docker modes use SEPARATE upper directories to avoid
+#   mixing COW artifacts. Docker uses BUB_BOXSH, Host uses BUB_BOXSH_HOST.
 #
 #   boxsh cow:SRC:DST mounts an overlayfs at DST with SRC as read-only base.
-#   Writes go to DST. In Host mode, DST = $BUB_BOXSH = runtime workspace.
-#   App code uses framework.workspace (from -w flag), never hardcodes paths.
+#   Writes go to DST. App code uses framework.workspace (from -w flag),
+#   never hardcodes paths.
 
 set -e
 
 # Resolve project root (directory containing this script)
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-# Check boxsh is available
+# Check boxsh is available and version >= 2.1.0
 if ! command -v boxsh >/dev/null 2>&1; then
     echo "Error: boxsh not found. Install from https://github.com/xicilion/boxsh" >&2
+    exit 1
+fi
+
+BOXSH_VER="$(boxsh --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "0.0.0")"
+BOXSH_MAJOR="$(echo "$BOXSH_VER" | cut -d. -f1)"
+BOXSH_MINOR="$(echo "$BOXSH_VER" | cut -d. -f2)"
+if [ "$BOXSH_MAJOR" -lt 2 ] || { [ "$BOXSH_MAJOR" -eq 2 ] && [ "$BOXSH_MINOR" -lt 1 ]; }; then
+    echo "Error: boxsh >= 2.1.0 required (found $BOXSH_VER)." >&2
+    echo "  Host mode requires boxsh 2.1.0+ for non-empty COW DST support." >&2
+    echo "  Upgrade: https://github.com/xicilion/boxsh/releases" >&2
     exit 1
 fi
 
@@ -56,22 +69,22 @@ expand_path() {
 }
 
 BUB_WORKSPACE="$(expand_path "${BUB_WORKSPACE:?BUB_WORKSPACE not set}")"
-BUB_BOXSH="$(expand_path "${BUB_BOXSH:?BUB_BOXSH not set}")"
+BUB_BOXSH_HOST="$(expand_path "${BUB_BOXSH_HOST:?BUB_BOXSH_HOST not set}")"
 BUB_SKILLS="$(expand_path "${BUB_SKILLS:-$HOME/.agents/skills}")"
 BUB_WEIXIN_DATA="$(expand_path "${BUB_WEIXIN_DATA:-$HOME/.openclaw/openclaw-weixin}")"
 BUB_HOME="$(expand_path "${BUB_HOME:-$HOME/.bub}")"
 
 # Ensure required directories exist
-mkdir -p "$BUB_WORKSPACE" "$BUB_BOXSH" "$BUB_HOME"
+mkdir -p "$BUB_WORKSPACE" "$BUB_BOXSH_HOST" "$BUB_HOME"
 
 # Pre-create profiles directory in both COW layers (avoids EXDEV)
 mkdir -p "$BUB_WORKSPACE/profiles"
-mkdir -p "$BUB_BOXSH/profiles"
+mkdir -p "$BUB_BOXSH_HOST/profiles"
 
 # Build boxsh arguments
 BOXSH_ARGS="--sandbox \
   --bind ro:$SCRIPT_DIR \
-  --bind cow:$BUB_WORKSPACE:$BUB_BOXSH \
+  --bind cow:$BUB_WORKSPACE:$BUB_BOXSH_HOST \
   --bind wr:$BUB_HOME"
 
 # Optional read-only binds (only if directories exist)
@@ -80,7 +93,7 @@ BOXSH_ARGS="--sandbox \
 
 # If no arguments, start the gateway
 if [ $# -eq 0 ]; then
-    exec boxsh $BOXSH_ARGS -c "cd $SCRIPT_DIR && uv run bub -w $BUB_BOXSH gateway"
+    exec boxsh $BOXSH_ARGS -c "cd $SCRIPT_DIR && uv run bub -w $BUB_BOXSH_HOST gateway"
 fi
 
 # If first argument is "shell" or "sh", start interactive shell

--- a/run-host.sh
+++ b/run-host.sh
@@ -109,16 +109,26 @@ SANDBOX_INIT="export HOME=$BUB_HOME \
 # Shell to use inside sandbox (default: sh; override with BOXSH_SHELL=fish etc.)
 BOXSH_SHELL="${BOXSH_SHELL:-sh}"
 
+# Run boxsh as supervised child with signal forwarding for clean Ctrl+C
+run_supervised() {
+    boxsh $BOXSH_ARGS -c "$1" &
+    child=$!
+    trap 'kill -INT "$child" 2>/dev/null; sleep 0.2; kill -TERM "$child" 2>/dev/null || true' INT
+    trap 'kill -TERM "$child" 2>/dev/null || true' TERM HUP
+    wait "$child" 2>/dev/null
+    exit $?
+}
+
 # If no arguments, start the gateway
 if [ $# -eq 0 ]; then
-    exec boxsh $BOXSH_ARGS -c "$SANDBOX_INIT && cd $SCRIPT_DIR && exec uv run bub -w $BUB_BOXSH_HOST gateway"
+    run_supervised "$SANDBOX_INIT && cd $SCRIPT_DIR && exec uv run bub -w $BUB_BOXSH_HOST gateway"
 fi
 
-# If first argument is "shell" or "sh", start interactive shell
+# If first argument is "shell" or "sh", start interactive shell (no supervisor)
 if [ "$1" = "shell" ] || [ "$1" = "sh" ]; then
     shift
     exec boxsh $BOXSH_ARGS -c "$SANDBOX_INIT && exec $BOXSH_SHELL $*"
 fi
 
 # Otherwise, run the given command in the sandbox
-exec boxsh $BOXSH_ARGS -c "$SANDBOX_INIT && exec $*"
+run_supervised "$SANDBOX_INIT && exec $*"

--- a/run-host.sh
+++ b/run-host.sh
@@ -97,9 +97,10 @@ SANDBOX_INIT="export HOME=$BUB_HOME \
   XDG_CONFIG_HOME=$BUB_HOME/.config \
   XDG_DATA_HOME=$BUB_HOME/.local/share \
   XDG_STATE_HOME=$BUB_HOME/.local/state \
+  TMPDIR=$BUB_HOME/tmp TEMP=$BUB_HOME/tmp TMP=$BUB_HOME/tmp \
   PATH=$UV_BIN_DIR:\$PATH \
   && mkdir -p \$HOME \$XDG_CONFIG_HOME \$XDG_DATA_HOME \$XDG_STATE_HOME \
-  $BUB_BOXSH_HOST/profiles"
+  \$TMPDIR $BUB_BOXSH_HOST/profiles"
 
 # Shell to use inside sandbox (default: sh; override with BOXSH_SHELL=fish etc.)
 BOXSH_SHELL="${BOXSH_SHELL:-sh}"

--- a/run-host.sh
+++ b/run-host.sh
@@ -89,7 +89,9 @@ BOXSH_ARGS="--sandbox \
 
 # Optional read-only binds (only if directories exist)
 [ -d "$BUB_SKILLS" ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:$BUB_SKILLS"
-[ -d "$BUB_WEIXIN_DATA" ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:$BUB_WEIXIN_DATA"
+# Bind parent dir (~/.openclaw) so weixin-agent can resolve its state path
+BUB_WEIXIN_STATE_DIR="$(dirname "$BUB_WEIXIN_DATA")"
+[ -d "$BUB_WEIXIN_STATE_DIR" ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:$BUB_WEIXIN_STATE_DIR"
 
 # Sandbox init: set HOME/XDG to writable BUB_HOME, ensure PATH includes uv,
 # create profiles in COW upper layer
@@ -98,6 +100,8 @@ SANDBOX_INIT="export HOME=$BUB_HOME \
   XDG_DATA_HOME=$BUB_HOME/.local/share \
   XDG_STATE_HOME=$BUB_HOME/.local/state \
   TMPDIR=$BUB_HOME/tmp TEMP=$BUB_HOME/tmp TMP=$BUB_HOME/tmp \
+  OPENCLAW_STATE_DIR=$BUB_WEIXIN_STATE_DIR \
+  CLAWDBOT_STATE_DIR=$BUB_WEIXIN_STATE_DIR \
   PATH=$UV_BIN_DIR:\$PATH \
   && mkdir -p \$HOME \$XDG_CONFIG_HOME \$XDG_DATA_HOME \$XDG_STATE_HOME \
   \$TMPDIR $BUB_BOXSH_HOST/profiles"

--- a/run-host.sh
+++ b/run-host.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+# run-host.sh - Run bub with boxsh sandbox directly on the host (no Docker)
+#
+# Usage:
+#   run-host.sh              - Start bub gateway
+#   run-host.sh shell        - Interactive shell in boxsh sandbox
+#   run-host.sh <command>    - Run command in boxsh sandbox
+#
+# Requires:
+#   - boxsh installed (https://github.com/xicilion/boxsh)
+#   - uv installed (https://github.com/astral-sh/uv)
+#   - .env file with required configuration
+#
+# Environment variables (loaded from .env):
+#   BUB_WORKSPACE   - Agent workspace base directory (read-only lower layer)
+#   BUB_BOXSH       - COW upper layer directory (persists agent writes)
+#   BUB_SKILLS      - Skills directory (read-only)
+#   BUB_WEIXIN_DATA - WeChat credentials directory (read-only, optional)
+#   BUB_HOME        - Bub home directory for tapes/config (read-write)
+#
+# Directory layout inside the sandbox:
+#   /workspace   (cow) agent workspace (COW merged view)
+#   /skills      (ro)  bub skills
+#   /bub-home    (rw)  bub home (tapes, config)
+#   Project dir  (ro)  application code
+
+set -e
+
+# Resolve project root (directory containing this script)
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Load .env file
+if [ -f "$SCRIPT_DIR/.env" ]; then
+    # Export variables from .env, skipping comments and empty lines
+    set -a
+    . "$SCRIPT_DIR/.env"
+    set +a
+fi
+
+# Expand ~ in paths
+expand_path() {
+    eval echo "$1"
+}
+
+BUB_WORKSPACE="$(expand_path "${BUB_WORKSPACE:?BUB_WORKSPACE not set}")"
+BUB_BOXSH="$(expand_path "${BUB_BOXSH:?BUB_BOXSH not set}")"
+BUB_SKILLS="$(expand_path "${BUB_SKILLS:-$HOME/.agents/skills}")"
+BUB_WEIXIN_DATA="$(expand_path "${BUB_WEIXIN_DATA:-$HOME/.openclaw/openclaw-weixin}")"
+BUB_HOME="$(expand_path "${BUB_HOME:-$HOME/.bub}")"
+
+# Ensure required directories exist
+mkdir -p "$BUB_WORKSPACE" "$BUB_BOXSH" "$BUB_HOME"
+
+# Pre-create profiles directory in both COW layers (avoids EXDEV)
+mkdir -p "$BUB_WORKSPACE/profiles"
+mkdir -p "$BUB_BOXSH/profiles"
+
+# Build boxsh arguments
+BOXSH_ARGS="--sandbox \
+  --bind ro:$SCRIPT_DIR \
+  --bind cow:$BUB_WORKSPACE:$BUB_BOXSH \
+  --bind wr:$BUB_HOME"
+
+# Optional read-only binds (only if directories exist)
+[ -d "$BUB_SKILLS" ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:$BUB_SKILLS"
+[ -d "$BUB_WEIXIN_DATA" ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:$BUB_WEIXIN_DATA"
+
+# If no arguments, start the gateway
+if [ $# -eq 0 ]; then
+    exec boxsh $BOXSH_ARGS -c "cd $SCRIPT_DIR && uv run bub -w $BUB_BOXSH gateway"
+fi
+
+# If first argument is "shell" or "sh", start interactive shell
+if [ "$1" = "shell" ] || [ "$1" = "sh" ]; then
+    shift
+    exec boxsh $BOXSH_ARGS "$@"
+fi
+
+# Otherwise, run the given command in the sandbox
+exec boxsh $BOXSH_ARGS -c "$*"

--- a/run-host.sh
+++ b/run-host.sh
@@ -7,27 +7,40 @@
 #   run-host.sh <command>    - Run command in boxsh sandbox
 #
 # Requires:
-#   - boxsh installed (https://github.com/xicilion/boxsh)
-#   - uv installed (https://github.com/astral-sh/uv)
+#   - boxsh >= 2.0.0 (https://github.com/xicilion/boxsh)
+#   - uv (https://github.com/astral-sh/uv)
 #   - .env file with required configuration
 #
 # Environment variables (loaded from .env):
-#   BUB_WORKSPACE   - Agent workspace base directory (read-only lower layer)
-#   BUB_BOXSH       - COW upper layer directory (persists agent writes)
-#   BUB_SKILLS      - Skills directory (read-only)
+#   BUB_WORKSPACE   - Workspace base directory (COW lower layer, read-only)
+#   BUB_BOXSH       - COW upper layer (persists agent writes, also runtime workspace)
+#   BUB_SKILLS      - Skills directory (read-only in sandbox)
 #   BUB_WEIXIN_DATA - WeChat credentials directory (read-only, optional)
 #   BUB_HOME        - Bub home directory for tapes/config (read-write)
 #
-# Directory layout inside the sandbox:
-#   /workspace   (cow) agent workspace (COW merged view)
-#   /skills      (ro)  bub skills
-#   /bub-home    (rw)  bub home (tapes, config)
-#   Project dir  (ro)  application code
+# COW path mapping (Host mode vs Docker mode):
+#
+#   Role                  Docker mode          Host mode
+#   ----                  -----------          ---------
+#   Lower (read-only)     /workspace-base      $BUB_WORKSPACE
+#   Upper (writes)        /workspace           $BUB_BOXSH
+#   Sandbox mount point   /workspace           $BUB_BOXSH
+#   bub -w flag           /workspace           $BUB_BOXSH
+#
+#   boxsh cow:SRC:DST mounts an overlayfs at DST with SRC as read-only base.
+#   Writes go to DST. In Host mode, DST = $BUB_BOXSH = runtime workspace.
+#   App code uses framework.workspace (from -w flag), never hardcodes paths.
 
 set -e
 
 # Resolve project root (directory containing this script)
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Check boxsh is available
+if ! command -v boxsh >/dev/null 2>&1; then
+    echo "Error: boxsh not found. Install from https://github.com/xicilion/boxsh" >&2
+    exit 1
+fi
 
 # Load .env file
 if [ -f "$SCRIPT_DIR/.env" ]; then

--- a/run-host.sh
+++ b/run-host.sh
@@ -65,11 +65,13 @@ BUB_WEIXIN_DATA="$(expand_path "${BUB_WEIXIN_DATA:-$HOME/.openclaw/openclaw-weix
 BUB_HOME="$(expand_path "${BUB_HOME:-$HOME/.bub}")"
 
 # Ensure required directories exist
+# NOTE: BUB_BOXSH_HOST must be empty (or non-existent) for boxsh cow:SRC:DST —
+# boxsh rmdir's DST before mounting overlay. Do NOT create files inside it here.
 mkdir -p "$BUB_WORKSPACE" "$BUB_BOXSH_HOST" "$BUB_HOME"
 
-# Pre-create profiles directory in both COW layers (avoids EXDEV)
+# Pre-create profiles in lower layer only (BUB_WORKSPACE).
+# Upper layer profiles is created inside the sandbox after boxsh mounts COW.
 mkdir -p "$BUB_WORKSPACE/profiles"
-mkdir -p "$BUB_BOXSH_HOST/profiles"
 
 # Build boxsh arguments
 BOXSH_ARGS="--sandbox \
@@ -81,16 +83,19 @@ BOXSH_ARGS="--sandbox \
 [ -d "$BUB_SKILLS" ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:$BUB_SKILLS"
 [ -d "$BUB_WEIXIN_DATA" ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:$BUB_WEIXIN_DATA"
 
+# Helper: create profiles dir inside sandbox (avoids EXDEV in COW upper layer)
+SANDBOX_INIT="mkdir -p $BUB_BOXSH_HOST/profiles"
+
 # If no arguments, start the gateway
 if [ $# -eq 0 ]; then
-    exec boxsh $BOXSH_ARGS -c "cd $SCRIPT_DIR && uv run bub -w $BUB_BOXSH_HOST gateway"
+    exec boxsh $BOXSH_ARGS -c "$SANDBOX_INIT && cd $SCRIPT_DIR && uv run bub -w $BUB_BOXSH_HOST gateway"
 fi
 
 # If first argument is "shell" or "sh", start interactive shell
 if [ "$1" = "shell" ] || [ "$1" = "sh" ]; then
     shift
-    exec boxsh $BOXSH_ARGS "$@"
+    exec boxsh $BOXSH_ARGS -c "$SANDBOX_INIT && exec \$SHELL $*"
 fi
 
 # Otherwise, run the given command in the sandbox
-exec boxsh $BOXSH_ARGS -c "$*"
+exec boxsh $BOXSH_ARGS -c "$SANDBOX_INIT && $*"

--- a/run-host.sh
+++ b/run-host.sh
@@ -83,8 +83,16 @@ BOXSH_ARGS="--sandbox \
 [ -d "$BUB_SKILLS" ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:$BUB_SKILLS"
 [ -d "$BUB_WEIXIN_DATA" ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:$BUB_WEIXIN_DATA"
 
-# Helper: create profiles dir inside sandbox (avoids EXDEV in COW upper layer)
-SANDBOX_INIT="mkdir -p $BUB_BOXSH_HOST/profiles"
+# Sandbox init: set HOME/XDG to writable BUB_HOME, create profiles in COW upper
+SANDBOX_INIT="export HOME=$BUB_HOME \
+  XDG_CONFIG_HOME=$BUB_HOME/.config \
+  XDG_DATA_HOME=$BUB_HOME/.local/share \
+  XDG_STATE_HOME=$BUB_HOME/.local/state \
+  && mkdir -p \$HOME \$XDG_CONFIG_HOME \$XDG_DATA_HOME \$XDG_STATE_HOME \
+  $BUB_BOXSH_HOST/profiles"
+
+# Shell to use inside sandbox (default: sh; override with BOXSH_SHELL=fish etc.)
+BOXSH_SHELL="${BOXSH_SHELL:-sh}"
 
 # If no arguments, start the gateway
 if [ $# -eq 0 ]; then
@@ -94,7 +102,7 @@ fi
 # If first argument is "shell" or "sh", start interactive shell
 if [ "$1" = "shell" ] || [ "$1" = "sh" ]; then
     shift
-    exec boxsh $BOXSH_ARGS -c "$SANDBOX_INIT && exec \$SHELL $*"
+    exec boxsh $BOXSH_ARGS -c "$SANDBOX_INIT && exec $BOXSH_SHELL $*"
 fi
 
 # Otherwise, run the given command in the sandbox

--- a/run-host.sh
+++ b/run-host.sh
@@ -73,21 +73,31 @@ mkdir -p "$BUB_WORKSPACE" "$BUB_BOXSH_HOST" "$BUB_HOME"
 # Upper layer profiles is created inside the sandbox after boxsh mounts COW.
 mkdir -p "$BUB_WORKSPACE/profiles"
 
+# Resolve uv toolchain paths for sandbox bind
+UV_BIN_DIR="$(cd "$(dirname "$(command -v uv)")" && pwd)"
+UV_DATA_DIR="$(expand_path "${XDG_DATA_HOME:-$HOME/.local/share}/uv")"
+
 # Build boxsh arguments
 BOXSH_ARGS="--sandbox \
   --bind ro:$SCRIPT_DIR \
   --bind cow:$BUB_WORKSPACE:$BUB_BOXSH_HOST \
   --bind wr:$BUB_HOME"
 
+# uv binary and toolchain (Python installs, caches)
+[ -d "$UV_BIN_DIR" ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:$UV_BIN_DIR"
+[ -d "$UV_DATA_DIR" ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:$UV_DATA_DIR"
+
 # Optional read-only binds (only if directories exist)
 [ -d "$BUB_SKILLS" ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:$BUB_SKILLS"
 [ -d "$BUB_WEIXIN_DATA" ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:$BUB_WEIXIN_DATA"
 
-# Sandbox init: set HOME/XDG to writable BUB_HOME, create profiles in COW upper
+# Sandbox init: set HOME/XDG to writable BUB_HOME, ensure PATH includes uv,
+# create profiles in COW upper layer
 SANDBOX_INIT="export HOME=$BUB_HOME \
   XDG_CONFIG_HOME=$BUB_HOME/.config \
   XDG_DATA_HOME=$BUB_HOME/.local/share \
   XDG_STATE_HOME=$BUB_HOME/.local/state \
+  PATH=$UV_BIN_DIR:\$PATH \
   && mkdir -p \$HOME \$XDG_CONFIG_HOME \$XDG_DATA_HOME \$XDG_STATE_HOME \
   $BUB_BOXSH_HOST/profiles"
 

--- a/run-host.sh
+++ b/run-host.sh
@@ -39,19 +39,9 @@ set -e
 # Resolve project root (directory containing this script)
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-# Check boxsh is available and version >= 2.1.0
+# Check boxsh is available (tested with boxsh 2.1.0)
 if ! command -v boxsh >/dev/null 2>&1; then
     echo "Error: boxsh not found. Install from https://github.com/xicilion/boxsh" >&2
-    exit 1
-fi
-
-BOXSH_VER="$(boxsh --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "0.0.0")"
-BOXSH_MAJOR="$(echo "$BOXSH_VER" | cut -d. -f1)"
-BOXSH_MINOR="$(echo "$BOXSH_VER" | cut -d. -f2)"
-if [ "$BOXSH_MAJOR" -lt 2 ] || { [ "$BOXSH_MAJOR" -eq 2 ] && [ "$BOXSH_MINOR" -lt 1 ]; }; then
-    echo "Error: boxsh >= 2.1.0 required (found $BOXSH_VER)." >&2
-    echo "  Host mode requires boxsh 2.1.0+ for non-empty COW DST support." >&2
-    echo "  Upgrade: https://github.com/xicilion/boxsh/releases" >&2
     exit 1
 fi
 

--- a/run-host.sh
+++ b/run-host.sh
@@ -107,7 +107,7 @@ BOXSH_SHELL="${BOXSH_SHELL:-sh}"
 
 # If no arguments, start the gateway
 if [ $# -eq 0 ]; then
-    exec boxsh $BOXSH_ARGS -c "$SANDBOX_INIT && cd $SCRIPT_DIR && uv run bub -w $BUB_BOXSH_HOST gateway"
+    exec boxsh $BOXSH_ARGS -c "$SANDBOX_INIT && cd $SCRIPT_DIR && exec uv run bub -w $BUB_BOXSH_HOST gateway"
 fi
 
 # If first argument is "shell" or "sh", start interactive shell
@@ -117,4 +117,4 @@ if [ "$1" = "shell" ] || [ "$1" = "sh" ]; then
 fi
 
 # Otherwise, run the given command in the sandbox
-exec boxsh $BOXSH_ARGS -c "$SANDBOX_INIT && $*"
+exec boxsh $BOXSH_ARGS -c "$SANDBOX_INIT && exec $*"

--- a/run-host.sh
+++ b/run-host.sh
@@ -67,7 +67,8 @@ BUB_HOME="$(expand_path "${BUB_HOME:-$HOME/.bub}")"
 # Ensure required directories exist
 # NOTE: BUB_BOXSH_HOST must be empty (or non-existent) for boxsh cow:SRC:DST —
 # boxsh rmdir's DST before mounting overlay. Do NOT create files inside it here.
-mkdir -p "$BUB_WORKSPACE" "$BUB_BOXSH_HOST" "$BUB_HOME"
+mkdir -p "$BUB_WORKSPACE" "$BUB_BOXSH_HOST" "$BUB_HOME" \
+  "$BUB_HOME/.config" "$BUB_HOME/.local/share" "$BUB_HOME/.local/state" "$BUB_HOME/tmp"
 
 # Pre-create profiles in lower layer only (BUB_WORKSPACE).
 # Upper layer profiles is created inside the sandbox after boxsh mounts COW.
@@ -124,10 +125,19 @@ if [ $# -eq 0 ]; then
     run_supervised "$SANDBOX_INIT && cd $SCRIPT_DIR && exec uv run bub -w $BUB_BOXSH_HOST gateway"
 fi
 
-# If first argument is "shell" or "sh", start interactive shell (no supervisor)
+# If first argument is "shell" or "sh", start interactive shell directly
+# (no -c wrapper — let boxsh launch the shell with proper TTY)
 if [ "$1" = "shell" ] || [ "$1" = "sh" ]; then
     shift
-    exec boxsh $BOXSH_ARGS -c "$SANDBOX_INIT && exec $BOXSH_SHELL $*"
+    HOME="$BUB_HOME" \
+    XDG_CONFIG_HOME="$BUB_HOME/.config" \
+    XDG_DATA_HOME="$BUB_HOME/.local/share" \
+    XDG_STATE_HOME="$BUB_HOME/.local/state" \
+    TMPDIR="$BUB_HOME/tmp" TEMP="$BUB_HOME/tmp" TMP="$BUB_HOME/tmp" \
+    OPENCLAW_STATE_DIR="$BUB_WEIXIN_STATE_DIR" \
+    CLAWDBOT_STATE_DIR="$BUB_WEIXIN_STATE_DIR" \
+    PATH="$UV_BIN_DIR:$PATH" \
+    exec boxsh $BOXSH_ARGS "$@"
 fi
 
 # Otherwise, run the given command in the sandbox

--- a/run-host.sh
+++ b/run-host.sh
@@ -125,19 +125,19 @@ if [ $# -eq 0 ]; then
     run_supervised "$SANDBOX_INIT && cd $SCRIPT_DIR && exec uv run bub -w $BUB_BOXSH_HOST gateway"
 fi
 
-# If first argument is "shell" or "sh", start interactive shell directly
-# (no -c wrapper — let boxsh launch the shell with proper TTY)
+# If first argument is "shell" or "sh", launch boxsh native interactive shell
 if [ "$1" = "shell" ] || [ "$1" = "sh" ]; then
     shift
-    HOME="$BUB_HOME" \
-    XDG_CONFIG_HOME="$BUB_HOME/.config" \
-    XDG_DATA_HOME="$BUB_HOME/.local/share" \
-    XDG_STATE_HOME="$BUB_HOME/.local/state" \
-    TMPDIR="$BUB_HOME/tmp" TEMP="$BUB_HOME/tmp" TMP="$BUB_HOME/tmp" \
-    OPENCLAW_STATE_DIR="$BUB_WEIXIN_STATE_DIR" \
-    CLAWDBOT_STATE_DIR="$BUB_WEIXIN_STATE_DIR" \
-    PATH="$UV_BIN_DIR:$PATH" \
-    exec boxsh $BOXSH_ARGS "$@"
+    exec env \
+      HOME="$BUB_HOME" \
+      XDG_CONFIG_HOME="$BUB_HOME/.config" \
+      XDG_DATA_HOME="$BUB_HOME/.local/share" \
+      XDG_STATE_HOME="$BUB_HOME/.local/state" \
+      TMPDIR="$BUB_HOME/tmp" TEMP="$BUB_HOME/tmp" TMP="$BUB_HOME/tmp" \
+      OPENCLAW_STATE_DIR="$BUB_WEIXIN_STATE_DIR" \
+      CLAWDBOT_STATE_DIR="$BUB_WEIXIN_STATE_DIR" \
+      PATH="$UV_BIN_DIR:$PATH" \
+      boxsh $BOXSH_ARGS
 fi
 
 # Otherwise, run the given command in the sandbox


### PR DESCRIPTION
## Summary
- Add `run-host.sh` for running bub directly on the host with boxsh sandbox (no Docker required)
- Uses same COW overlay pattern as docker-compose: `cow:$BUB_WORKSPACE:$BUB_BOXSH`
- Pre-creates profiles dir in both COW layers to avoid EXDEV
- Loads `.env` automatically, expands `~` in paths
- Updates `.env.example` to document both deployment modes

## Usage
```bash
# Start gateway
./run-host.sh

# Interactive shell in sandbox
./run-host.sh shell

# Run a command in sandbox
./run-host.sh echo hello
```

## COW path mapping
| Role | Docker mode | Host mode |
|------|-------------|-----------|
| Lower (read-only base) | `/workspace-base` (volume from `$BUB_WORKSPACE`) | `$BUB_WORKSPACE` |
| Upper (persists writes) | `/workspace` (volume from `$BUB_BOXSH`) | `$BUB_BOXSH` |
| Sandbox mount point | `/workspace` | `$BUB_BOXSH` |
| bub `-w` flag | `/workspace` | `$BUB_BOXSH` |

## Test plan
- [ ] Run `./run-host.sh shell` and verify sandbox has COW workspace
- [ ] Create a file in workspace, verify it persists in `$BUB_BOXSH`
- [ ] Verify `$BUB_WORKSPACE` is not modified (read-only base)
- [ ] Run `./run-host.sh` to start gateway, verify it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)