### PR TITLE
feat: mount feishu CLI auth directory in sandbox

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,7 @@ BUB_BOXSH=~/work/boxsh/bub-im-bridge
 BUB_BOXSH_HOST=~/work/boxsh/bub-im-bridge-host
 BUB_SKILLS=~/.agents/skills
 BUB_WEIXIN_DATA=~/.openclaw/openclaw-weixin
+BUB_FEISHU_HOME=~/.feishu
 
 # 部署模式：
 #   Docker 模式:  docker compose up    (使用 entrypoint.sh)
@@ -33,6 +34,7 @@ BUB_WEIXIN_DATA=~/.openclaw/openclaw-weixin
 #                     必须和 BUB_BOXSH 不同，避免两种模式的 COW 产物混在一起
 #   BUB_SKILLS      - skills 目录（沙箱内只读）
 #   BUB_WEIXIN_DATA - 微信数据目录（沙箱内只读，可选）
+#   BUB_FEISHU_HOME - feishu CLI 认证目录（沙箱内可写，可选，token 刷新需要）
 #   BUB_HOME        - bub 主目录（tapes、config，可写）
 #
 # 注意：app 代码通过 framework.workspace（来自 bub -w 参数）动态获取路径，

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ docker-compose logs -f
 | workspace | COW | Agent 工作空间（COW merged view，基座来自 `$BUB_WORKSPACE`） |
 | skills | 只读 | Bub 技能目录 |
 | weixin data | 只读 | 微信登录凭据 |
+| feishu auth | 可写 | feishu CLI 登录凭据（`~/.feishu`，token 刷新需要写权限） |
 | bub home | 可写 | Bub 运行数据（tapes、配置） |
 
 ### Docker 调试

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - ${BUB_BOXSH}:/workspace
       - ${BUB_SKILLS}:/root/.agents/skills
       - ${BUB_WEIXIN_DATA}:/root/.openclaw/openclaw-weixin
-      - ${BUB_FEISHU_HOME:-~/.feishu}:/root/.feishu
+      - ${BUB_FEISHU_HOME}:/root/.feishu
       - ${BUB_HOME}:/root/.bub
     # Required for boxsh sandbox (nested namespaces) inside Docker
     privileged: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - ${BUB_BOXSH}:/workspace
       - ${BUB_SKILLS}:/root/.agents/skills
       - ${BUB_WEIXIN_DATA}:/root/.openclaw/openclaw-weixin
+      - ${BUB_FEISHU_HOME:-~/.feishu}:/root/.feishu
       - ${BUB_HOME}:/root/.bub
     # Required for boxsh sandbox (nested namespaces) inside Docker
     privileged: true

--- a/run-host.sh
+++ b/run-host.sh
@@ -164,4 +164,4 @@ if [ "$1" = "shell" ] || [ "$1" = "sh" ]; then
 fi
 
 # Otherwise, run the given command in the sandbox
-run_supervised "$SANDBOX_INIT && exec $*"
+run_supervised "$SANDBOX_INIT && exec sh -c \"$*\""

--- a/run-host.sh
+++ b/run-host.sh
@@ -69,7 +69,7 @@ BUB_HOME="$(expand_path "${BUB_HOME:-$HOME/.bub}")"
 # Ensure required directories exist
 # NOTE: BUB_BOXSH_HOST must be empty (or non-existent) for boxsh cow:SRC:DST —
 # boxsh rmdir's DST before mounting overlay. Do NOT create files inside it here.
-mkdir -p "$BUB_WORKSPACE" "$BUB_BOXSH_HOST" "$BUB_HOME" "$BUB_FEISHU_HOME" \
+mkdir -p "$BUB_WORKSPACE" "$BUB_BOXSH_HOST" "$BUB_HOME" \
   "$BUB_HOME/.config" "$BUB_HOME/.local/share" "$BUB_HOME/.local/state" "$BUB_HOME/tmp"
 
 # Pre-create profiles in lower layer only (BUB_WORKSPACE).

--- a/run-host.sh
+++ b/run-host.sh
@@ -16,6 +16,7 @@
 #   BUB_BOXSH_HOST  - Host mode COW upper layer + runtime workspace (MUST differ from BUB_BOXSH)
 #   BUB_SKILLS      - Skills directory (read-only in sandbox)
 #   BUB_WEIXIN_DATA - WeChat credentials directory (read-only, optional)
+#   BUB_FEISHU_HOME - Feishu CLI auth directory (read-write, optional, default ~/.feishu)
 #   BUB_HOME        - Bub home directory for tapes/config (read-write)
 #
 # COW path mapping (Host mode vs Docker mode):
@@ -62,12 +63,13 @@ BUB_WORKSPACE="$(expand_path "${BUB_WORKSPACE:?BUB_WORKSPACE not set}")"
 BUB_BOXSH_HOST="$(expand_path "${BUB_BOXSH_HOST:?BUB_BOXSH_HOST not set}")"
 BUB_SKILLS="$(expand_path "${BUB_SKILLS:-$HOME/.agents/skills}")"
 BUB_WEIXIN_DATA="$(expand_path "${BUB_WEIXIN_DATA:-$HOME/.openclaw/openclaw-weixin}")"
+BUB_FEISHU_HOME="$(expand_path "${BUB_FEISHU_HOME:-$HOME/.feishu}")"
 BUB_HOME="$(expand_path "${BUB_HOME:-$HOME/.bub}")"
 
 # Ensure required directories exist
 # NOTE: BUB_BOXSH_HOST must be empty (or non-existent) for boxsh cow:SRC:DST —
 # boxsh rmdir's DST before mounting overlay. Do NOT create files inside it here.
-mkdir -p "$BUB_WORKSPACE" "$BUB_BOXSH_HOST" "$BUB_HOME" \
+mkdir -p "$BUB_WORKSPACE" "$BUB_BOXSH_HOST" "$BUB_HOME" "$BUB_FEISHU_HOME" \
   "$BUB_HOME/.config" "$BUB_HOME/.local/share" "$BUB_HOME/.local/state" "$BUB_HOME/tmp"
 
 # Pre-create profiles in lower layer only (BUB_WORKSPACE).
@@ -93,6 +95,8 @@ BOXSH_ARGS="--sandbox \
 # Bind parent dir (~/.openclaw) so weixin-agent can resolve its state path
 BUB_WEIXIN_STATE_DIR="$(dirname "$BUB_WEIXIN_DATA")"
 [ -d "$BUB_WEIXIN_STATE_DIR" ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:$BUB_WEIXIN_STATE_DIR"
+# Feishu CLI auth directory (writable for token refresh)
+[ -d "$BUB_FEISHU_HOME" ] && BOXSH_ARGS="$BOXSH_ARGS --bind wr:$BUB_FEISHU_HOME:$BUB_HOME/.feishu"
 
 # Sandbox init: set HOME/XDG to writable BUB_HOME, ensure PATH includes uv,
 # create profiles in COW upper layer

--- a/run-host.sh
+++ b/run-host.sh
@@ -96,10 +96,18 @@ BOXSH_ARGS="--sandbox \
 BUB_WEIXIN_STATE_DIR="$(dirname "$BUB_WEIXIN_DATA")"
 [ -d "$BUB_WEIXIN_STATE_DIR" ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:$BUB_WEIXIN_STATE_DIR"
 # Feishu CLI auth directory (writable for token refresh)
-# Bind to REAL home (not BUB_HOME) because feishu CLI uses os.homedir()
-# which reads /etc/passwd, ignoring the sandboxed HOME env var.
-FEISHU_BIND_TARGET="$(expand_path "~")/.feishu"
-[ -d "$BUB_FEISHU_HOME" ] && BOXSH_ARGS="$BOXSH_ARGS --bind wr:$BUB_FEISHU_HOME:$FEISHU_BIND_TARGET"
+# Bind at original path, then symlink from $BUB_HOME/.feishu so the CLI
+# (which follows $HOME) can find it. boxsh wr binds don't support SRC:DST.
+if [ -d "$BUB_FEISHU_HOME" ]; then
+    BOXSH_ARGS="$BOXSH_ARGS --bind wr:$BUB_FEISHU_HOME"
+    FEISHU_LINK="$BUB_HOME/.feishu"
+    if [ ! -e "$FEISHU_LINK" ]; then
+        ln -s "$BUB_FEISHU_HOME" "$FEISHU_LINK"
+    elif [ ! -L "$FEISHU_LINK" ] || [ "$(readlink "$FEISHU_LINK")" != "$BUB_FEISHU_HOME" ]; then
+        echo "Error: $FEISHU_LINK exists but does not point to $BUB_FEISHU_HOME" >&2
+        exit 1
+    fi
+fi
 
 # Sandbox init: set HOME/XDG to writable BUB_HOME, ensure PATH includes uv,
 # create profiles in COW upper layer

--- a/run-host.sh
+++ b/run-host.sh
@@ -96,7 +96,10 @@ BOXSH_ARGS="--sandbox \
 BUB_WEIXIN_STATE_DIR="$(dirname "$BUB_WEIXIN_DATA")"
 [ -d "$BUB_WEIXIN_STATE_DIR" ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:$BUB_WEIXIN_STATE_DIR"
 # Feishu CLI auth directory (writable for token refresh)
-[ -d "$BUB_FEISHU_HOME" ] && BOXSH_ARGS="$BOXSH_ARGS --bind wr:$BUB_FEISHU_HOME:$BUB_HOME/.feishu"
+# Bind to REAL home (not BUB_HOME) because feishu CLI uses os.homedir()
+# which reads /etc/passwd, ignoring the sandboxed HOME env var.
+FEISHU_BIND_TARGET="$(expand_path "~")/.feishu"
+[ -d "$BUB_FEISHU_HOME" ] && BOXSH_ARGS="$BOXSH_ARGS --bind wr:$BUB_FEISHU_HOME:$FEISHU_BIND_TARGET"
 
 # Sandbox init: set HOME/XDG to writable BUB_HOME, ensure PATH includes uv,
 # create profiles in COW upper layer

--- a/uv.lock
+++ b/uv.lock
@@ -228,7 +228,7 @@ wheels = [
 
 [[package]]
 name = "bub-im-bridge"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "bub" },


### PR DESCRIPTION
## Summary
- Add `BUB_FEISHU_HOME` (default `~/.feishu`) as writable bind mount in host mode and Docker mode
- Use `wr` bind at original path + symlink from `$BUB_HOME/.feishu` to adapt sandbox `HOME` rewrite
- Fix `exec $*` bug in `run-host.sh` ad-hoc command mode (compound commands with `;` or `&&` were truncated)
- Update `.env.example`, `README.md`, `docker-compose.yml`

## Test plan
- [x] `./run-host.sh 'feishu auth status'` returns `logged_in: true` inside sandbox
- [x] `feishu auth status` still works on host
- [x] Symlink conflict detection (errors if `$BUB_HOME/.feishu` points elsewhere)

🤖 Generated with [Claude Code](https://claude.com/claude-code)