### PR TITLE
fix: change weixin data mount from ro to wr

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,7 +33,7 @@ BUB_FEISHU_HOME=~/.feishu
 #   BUB_BOXSH_HOST  - 宿主机模式 COW upper 层 + runtime workspace
 #                     必须和 BUB_BOXSH 不同，避免两种模式的 COW 产物混在一起
 #   BUB_SKILLS      - skills 目录（沙箱内只读）
-#   BUB_WEIXIN_DATA - 微信数据目录（沙箱内只读，可选）
+#   BUB_WEIXIN_DATA - 微信数据目录（沙箱内可写，可选，含登录凭据和同步状态）
 #   BUB_FEISHU_HOME - feishu CLI 认证目录（沙箱内可写，可选，token 刷新需要）
 #   BUB_HOME        - bub 主目录（tapes、config，可写）
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN chmod +x /entrypoint.sh
 #   /workspace-base                  - agent workspace read-only base (COW lower layer)
 #   /workspace                       - COW upper layer (persists agent writes via $BUB_BOXSH)
 #   /root/.agents/skills             - bub skills directory (read-only in boxsh)
-#   /root/.openclaw/openclaw-weixin  - weixin credentials (read-only in boxsh)
+#   /root/.openclaw/openclaw-weixin  - weixin data (read-write in boxsh for credentials + sync state)
 #   /root/.bub                       - bub home (read-write in boxsh for tapes, config)
 VOLUME /workspace-base
 VOLUME /workspace

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ docker-compose logs -f
 |------|------|------|
 | workspace | COW | Agent 工作空间（COW merged view，基座来自 `$BUB_WORKSPACE`） |
 | skills | 只读 | Bub 技能目录 |
-| weixin data | 只读 | 微信登录凭据 |
+| weixin data | 可写 | 微信登录凭据 + 同步状态 |
 | feishu auth | 可写 | feishu CLI 登录凭据（`~/.feishu`，token 刷新需要写权限） |
 | bub home | 可写 | Bub 运行数据（tapes、配置） |
 

--- a/docs/DOCKER_USAGE.md
+++ b/docs/DOCKER_USAGE.md
@@ -45,7 +45,7 @@ docker-compose logs -f
 | `/workspace-base` | `BUB_WORKSPACE` | (必需) | (基座) | COW 只读基座（Docker volume，不在沙箱内直接暴露） |
 | `/workspace` | `BUB_BOXSH` | `~/work/boxsh/bub-im-bridge` | 🐄 COW | Agent 工作空间（boxsh COW merged view），写入持久化到宿主机 |
 | `/root/.agents/skills` | `BUB_SKILLS` | `~/.agents/skills` | 🔒 只读 | Bub 技能目录 |
-| `/root/.openclaw/openclaw-weixin` | `BUB_WEIXIN_DATA` | `~/.openclaw/openclaw-weixin` | 🔒 只读 | 微信登录凭据 |
+| `/root/.openclaw/openclaw-weixin` | `BUB_WEIXIN_DATA` | `~/.openclaw/openclaw-weixin` | ✏️ 可写 | 微信登录凭据 + 同步状态 |
 | `/root/.bub` | `BUB_HOME` | `~/.bub` | ✏️ 可写 | Bub 运行数据（tapes、配置） |
 
 ## 沙箱保护
@@ -67,7 +67,7 @@ entrypoint 通过 `exec boxsh --sandbox ...` 启动服务，boxsh 使用 `cow:/w
 
 ```bash
 # 1. 启动与 bub 同配置的新 boxsh 调试实例（推荐）
-#    /workspace 可读写（独立的 COW merged view），skills/weixin 只读
+#    /workspace 可读写（独立的 COW merged view），skills 只读
 #    适合验证 agent 在沙箱中的行为、测试文件读写
 docker-compose run --rm bub /entrypoint.sh shell
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,7 @@
 #   /root                            (rw) home directory
 #   /workspace                       (cow) agent workspace (COW merged view)
 #   /root/.agents/skills             (ro) bub skills
-#   /root/.openclaw/openclaw-weixin  (ro) weixin credentials
+#   /root/.openclaw/openclaw-weixin  (rw) weixin data (credentials + sync state)
 #   /root/.bub                       (rw) bub home (tapes, config)
 #
 # COW via boxsh native cow:SRC:DST:
@@ -27,7 +27,7 @@ BOXSH_ARGS="--sandbox \
   --bind ro:/entrypoint.sh \
   --bind cow:/workspace-base:/workspace \
   --bind ro:/root/.agents/skills \
-  --bind ro:/root/.openclaw/openclaw-weixin \
+  --bind wr:/root/.openclaw/openclaw-weixin \
   --bind wr:/root/.bub"
 
 # Ensure profiles directory exists in BOTH lower (workspace-base) and upper

--- a/run-host.sh
+++ b/run-host.sh
@@ -15,7 +15,7 @@
 #   BUB_WORKSPACE   - Workspace base directory (COW lower layer, read-only)
 #   BUB_BOXSH_HOST  - Host mode COW upper layer + runtime workspace (MUST differ from BUB_BOXSH)
 #   BUB_SKILLS      - Skills directory (read-only in sandbox)
-#   BUB_WEIXIN_DATA - WeChat credentials directory (read-only, optional)
+#   BUB_WEIXIN_DATA - WeChat data directory (read-write, optional)
 #   BUB_FEISHU_HOME - Feishu CLI auth directory (read-write, optional, default ~/.feishu)
 #   BUB_HOME        - Bub home directory for tapes/config (read-write)
 #
@@ -94,7 +94,7 @@ BOXSH_ARGS="--sandbox \
 [ -d "$BUB_SKILLS" ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:$BUB_SKILLS"
 # Bind parent dir (~/.openclaw) so weixin-agent can resolve its state path
 BUB_WEIXIN_STATE_DIR="$(dirname "$BUB_WEIXIN_DATA")"
-[ -d "$BUB_WEIXIN_STATE_DIR" ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:$BUB_WEIXIN_STATE_DIR"
+[ -d "$BUB_WEIXIN_STATE_DIR" ] && BOXSH_ARGS="$BOXSH_ARGS --bind wr:$BUB_WEIXIN_STATE_DIR"
 # Feishu CLI auth directory (writable for token refresh)
 # Bind at original path, then symlink from $BUB_HOME/.feishu so the CLI
 # (which follows $HOME) can find it. boxsh wr binds don't support SRC:DST.


### PR DESCRIPTION
## Summary
- weixin runtime writes sync state to `$BUB_WEIXIN_DATA/accounts/*.sync.json`, so the directory must be writable inside the sandbox
- Change weixin mount from `ro` to `wr` in both host mode (`run-host.sh`) and Docker mode (`entrypoint.sh`)
- Update all "weixin read-only" documentation to reflect writable mount

## Test plan
- [x] `./run-host.sh 'feishu auth status'` works (feishu auth bind still functional)
- [x] weixin sync state files can be written inside sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)