### PR TITLE
fix: scope weixin wr bind to data dir only, parent stays ro

### DIFF
--- a/run-host.sh
+++ b/run-host.sh
@@ -92,9 +92,10 @@ BOXSH_ARGS="--sandbox \
 
 # Optional read-only binds (only if directories exist)
 [ -d "$BUB_SKILLS" ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:$BUB_SKILLS"
-# Bind parent dir (~/.openclaw) so weixin-agent can resolve its state path
+# Weixin parent dir (ro for path resolution) and data dir (wr for sync state)
 BUB_WEIXIN_STATE_DIR="$(dirname "$BUB_WEIXIN_DATA")"
-[ -d "$BUB_WEIXIN_STATE_DIR" ] && BOXSH_ARGS="$BOXSH_ARGS --bind wr:$BUB_WEIXIN_STATE_DIR"
+[ -d "$BUB_WEIXIN_STATE_DIR" ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:$BUB_WEIXIN_STATE_DIR"
+[ -d "$BUB_WEIXIN_DATA" ] && BOXSH_ARGS="$BOXSH_ARGS --bind wr:$BUB_WEIXIN_DATA"
 # Feishu CLI auth directory (writable for token refresh)
 # Bind at original path, then symlink from $BUB_HOME/.feishu so the CLI
 # (which follows $HOME) can find it. boxsh wr binds don't support SRC:DST.


### PR DESCRIPTION
## Summary
- Keep weixin parent dir (`~/.openclaw`) as `ro` for path resolution
- Bind only the data dir (`~/.openclaw/openclaw-weixin`) as `wr` for sync state writes
- Aligns host mode scope with Docker mode (`entrypoint.sh` binds only `/root/.openclaw/openclaw-weixin` as `wr`)

## Context
PR #37 changed the parent dir from `ro` to `wr` to fix "Operation not permitted" on `*.sync.json` writes. This PR narrows the write scope back down — only the actual data directory needs write access.

## Test plan
- [ ] `./run-host.sh 'feishu auth status'` still works (feishu bind unaffected)
- [ ] Weixin sync state writes succeed without permission errors
- [ ] Parent dir `~/.openclaw` is read-only inside sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)