### PR TITLE
fix: remove exec from boxsh commands for reliable Ctrl+C cleanup

### DIFF
--- a/run-host.sh
+++ b/run-host.sh
@@ -127,9 +127,13 @@ SANDBOX_INIT="export HOME=$BUB_HOME \
 BOXSH_SHELL="${BOXSH_SHELL:-sh}"
 
 # Run boxsh with signal forwarding for clean Ctrl+C.
-# boxsh/uv create their own process groups, so we walk the process tree
-# to kill all descendants.  set +e around wait prevents set -e from
-# killing the shell before the trap handler fires.
+#
+# IMPORTANT: The command passed to boxsh must NOT use `exec`.  Keeping the
+# inner shell alive (as a wrapper around the real command) ensures that
+# all descendants remain findable via `pgrep -P` even after intermediate
+# processes exit.  If `exec` is used, an intermediate process (e.g. uv)
+# can exit and its children get reparented to PID 1, making them invisible
+# to the tree walk.
 run_supervised() {
     boxsh $BOXSH_ARGS -c "$1" &
     child=$!
@@ -157,7 +161,7 @@ run_supervised() {
 
 # If no arguments, start the gateway
 if [ $# -eq 0 ]; then
-    run_supervised "$SANDBOX_INIT && cd $SCRIPT_DIR && exec uv run bub -w $BUB_BOXSH_HOST gateway"
+    run_supervised "$SANDBOX_INIT && cd $SCRIPT_DIR && uv run bub -w $BUB_BOXSH_HOST gateway"
 fi
 
 # If first argument is "shell" or "sh", launch boxsh native interactive shell
@@ -176,4 +180,4 @@ if [ "$1" = "shell" ] || [ "$1" = "sh" ]; then
 fi
 
 # Otherwise, run the given command in the sandbox
-run_supervised "$SANDBOX_INIT && exec sh -c \"$*\""
+run_supervised "$SANDBOX_INIT && sh -c \"$*\""


### PR DESCRIPTION
## Summary
- Remove `exec` from commands passed to `boxsh -c` in `run_supervised()`
- Keep the inner shell alive as a wrapper so all descendants remain findable via `pgrep -P`
- Fixes intermittent Ctrl+C failures where gateway processes survived cleanup

## Root cause
When `exec` was used (e.g. `exec uv run bub gateway`), intermediate processes like `uv` could exit after spawning the real command. Their children (e.g. `python/bub`) got reparented to PID 1, becoming invisible to `pgrep -P $child`. The cleanup function's tree walk returned nothing, leaving orphaned processes running.

## Fix
By not using `exec`, the inner shell stays alive as a wrapper around the command. All descendants remain children of this wrapper, so `pgrep -P` can always find them during cleanup.

## Test plan
- [ ] `./run-host.sh` starts gateway, Ctrl+C kills all processes cleanly
- [ ] `./run-host.sh 'ls /workspace'` runs and exits cleanly
- [ ] Process tree shows no orphaned processes after Ctrl+C

🤖 Generated with [Claude Code](https://claude.com/claude-code)