### PR TITLE
fix: symlink skills into sandbox HOME so bub finds them

### DIFF
--- a/run-host.sh
+++ b/run-host.sh
@@ -91,7 +91,19 @@ BOXSH_ARGS="--sandbox \
 [ -d "$UV_DATA_DIR" ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:$UV_DATA_DIR"
 
 # Optional read-only binds (only if directories exist)
-[ -d "$BUB_SKILLS" ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:$BUB_SKILLS"
+# Skills directory: bind at original path, then symlink from $BUB_HOME/.agents/skills
+# so bub (which follows $HOME) can find it. Same pattern as feishu below.
+if [ -d "$BUB_SKILLS" ]; then
+    BOXSH_ARGS="$BOXSH_ARGS --bind ro:$BUB_SKILLS"
+    SKILLS_LINK="$BUB_HOME/.agents/skills"
+    mkdir -p "$(dirname "$SKILLS_LINK")"
+    if [ ! -e "$SKILLS_LINK" ]; then
+        ln -s "$BUB_SKILLS" "$SKILLS_LINK"
+    elif [ ! -L "$SKILLS_LINK" ] || [ "$(readlink "$SKILLS_LINK")" != "$BUB_SKILLS" ]; then
+        echo "Error: $SKILLS_LINK exists but does not point to $BUB_SKILLS" >&2
+        exit 1
+    fi
+fi
 # Weixin parent dir (ro for path resolution) and data dir (wr for sync state)
 BUB_WEIXIN_STATE_DIR="$(dirname "$BUB_WEIXIN_DATA")"
 [ -d "$BUB_WEIXIN_STATE_DIR" ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:$BUB_WEIXIN_STATE_DIR"


### PR DESCRIPTION
## Summary
- When `HOME` is set to `BUB_HOME` (~/.bub) inside the sandbox, bub resolves `~/.agents/skills` as `/Users/mi/.bub/.agents/skills` instead of the real `/Users/mi/.agents/skills`
- Create a symlink from `$BUB_HOME/.agents/skills` → `$BUB_SKILLS` so bub can find skills at the expected path
- Same symlink pattern already used for feishu auth (`$BUB_HOME/.feishu` → `$BUB_FEISHU_HOME`)

## Root cause
`SANDBOX_INIT` exports `HOME=$BUB_HOME` so bub's state goes to `~/.bub`. But this also changes tilde expansion for `~/.agents/skills`, pointing it to the wrong location.

## Test plan
- [ ] `./run-host.sh` starts and loads skills from `~/.agents/skills` (check logs for skill loading)
- [ ] `ls -la ~/.bub/.agents/skills` shows symlink to real skills directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)