### PR TITLE
feat: mount ~/.config and ~/.kyuubi into sandbox via symlink

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,8 @@ BUB_BOXSH_HOST=~/work/boxsh/bub-im-bridge-host
 BUB_SKILLS=~/.agents/skills
 BUB_WEIXIN_DATA=~/.openclaw/openclaw-weixin
 BUB_FEISHU_HOME=~/.feishu
+BUB_REAL_CONFIG=~/.config
+BUB_KYUUBI_HOME=~/.kyuubi
 
 # 部署模式：
 #   Docker 模式:  docker compose up    (使用 entrypoint.sh)
@@ -35,6 +37,8 @@ BUB_FEISHU_HOME=~/.feishu
 #   BUB_SKILLS      - skills 目录（沙箱内只读）
 #   BUB_WEIXIN_DATA - 微信数据目录（沙箱内可写，可选，含登录凭据和同步状态）
 #   BUB_FEISHU_HOME - feishu CLI 认证目录（沙箱内可写，可选，token 刷新需要）
+#   BUB_REAL_CONFIG - 宿主机 ~/.config（沙箱内可写，通过 symlink 对齐到 $BUB_HOME/.config）
+#   BUB_KYUUBI_HOME - 宿主机 ~/.kyuubi（沙箱内可写，通过 symlink 对齐到 $BUB_HOME/.kyuubi）
 #   BUB_HOME        - bub 主目录（tapes、config，可写）
 #
 # 注意：app 代码通过 framework.workspace（来自 bub -w 参数）动态获取路径，

--- a/run-host.sh
+++ b/run-host.sh
@@ -65,12 +65,32 @@ BUB_SKILLS="$(expand_path "${BUB_SKILLS:-$HOME/.agents/skills}")"
 BUB_WEIXIN_DATA="$(expand_path "${BUB_WEIXIN_DATA:-$HOME/.openclaw/openclaw-weixin}")"
 BUB_FEISHU_HOME="$(expand_path "${BUB_FEISHU_HOME:-$HOME/.feishu}")"
 BUB_HOME="$(expand_path "${BUB_HOME:-$HOME/.bub}")"
+BUB_REAL_CONFIG="$(expand_path "${BUB_REAL_CONFIG:-$HOME/.config}")"
+BUB_KYUUBI_HOME="$(expand_path "${BUB_KYUUBI_HOME:-$HOME/.kyuubi}")"
 
 # Ensure required directories exist
 # NOTE: BUB_BOXSH_HOST must be empty (or non-existent) for boxsh cow:SRC:DST —
 # boxsh rmdir's DST before mounting overlay. Do NOT create files inside it here.
 mkdir -p "$BUB_WORKSPACE" "$BUB_BOXSH_HOST" "$BUB_HOME" \
-  "$BUB_HOME/.config" "$BUB_HOME/.local/share" "$BUB_HOME/.local/state" "$BUB_HOME/tmp"
+  "$BUB_HOME/.local/share" "$BUB_HOME/.local/state" "$BUB_HOME/tmp"
+
+# Symlink real host directories into $BUB_HOME so tools that resolve ~ find them.
+# Same pattern as skills and feishu: bind at original path, symlink from $BUB_HOME.
+# These must be created before mkdir -p would turn them into plain directories.
+make_home_link() {
+    local real_path="$1" link_path="$2"
+    if [ -d "$real_path" ]; then
+        mkdir -p "$(dirname "$link_path")"
+        if [ ! -e "$link_path" ]; then
+            ln -s "$real_path" "$link_path"
+        elif [ ! -L "$link_path" ] || [ "$(readlink "$link_path")" != "$real_path" ]; then
+            echo "Error: $link_path exists but does not point to $real_path" >&2
+            exit 1
+        fi
+    fi
+}
+make_home_link "$BUB_REAL_CONFIG" "$BUB_HOME/.config"
+make_home_link "$BUB_KYUUBI_HOME" "$BUB_HOME/.kyuubi"
 
 # Pre-create profiles in lower layer only (BUB_WORKSPACE).
 # Upper layer profiles is created inside the sandbox after boxsh mounts COW.
@@ -91,6 +111,9 @@ BOXSH_ARGS="--sandbox \
 [ -d "$UV_DATA_DIR" ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:$UV_DATA_DIR"
 
 # Optional read-only binds (only if directories exist)
+# Real host directories: bind at original path, symlink from $BUB_HOME (via make_home_link above).
+[ -d "$BUB_REAL_CONFIG" ] && BOXSH_ARGS="$BOXSH_ARGS --bind wr:$BUB_REAL_CONFIG"
+[ -d "$BUB_KYUUBI_HOME" ] && BOXSH_ARGS="$BOXSH_ARGS --bind wr:$BUB_KYUUBI_HOME"
 # Skills directory: bind at original path, then symlink from $BUB_HOME/.agents/skills
 # so bub (which follows $HOME) can find it. Same pattern as feishu below.
 if [ -d "$BUB_SKILLS" ]; then

--- a/run-host.sh
+++ b/run-host.sh
@@ -81,6 +81,12 @@ make_home_link() {
     local real_path="$1" link_path="$2"
     if [ -d "$real_path" ]; then
         mkdir -p "$(dirname "$link_path")"
+        if [ -d "$link_path" ] && [ ! -L "$link_path" ]; then
+            # Plain directory left from a previous run — back it up and replace with symlink
+            local backup="${link_path}.bak.$(date +%s)"
+            echo "Migrating $link_path to symlink (backup at $backup)"
+            mv "$link_path" "$backup"
+        fi
         if [ ! -e "$link_path" ]; then
             ln -s "$real_path" "$link_path"
         elif [ ! -L "$link_path" ] || [ "$(readlink "$link_path")" != "$real_path" ]; then

--- a/run-host.sh
+++ b/run-host.sh
@@ -115,6 +115,9 @@ BOXSH_ARGS="--sandbox \
 # uv binary and toolchain (Python installs, caches)
 [ -d "$UV_BIN_DIR" ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:$UV_BIN_DIR"
 [ -d "$UV_DATA_DIR" ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:$UV_DATA_DIR"
+# pipx venvs (for tools installed via pipx, e.g. kyuubi)
+PIPX_HOME="${PIPX_HOME:-$HOME/.local/pipx}"
+[ -d "$PIPX_HOME" ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:$PIPX_HOME"
 
 # Optional read-only binds (only if directories exist)
 # Real host directories: bind at original path, symlink from $BUB_HOME (via make_home_link above).


### PR DESCRIPTION
## Summary
- Bind `~/.config` and `~/.kyuubi` at original paths (wr), symlink from `$BUB_HOME`
- Same pattern as skills (#40) and feishu auth (#36)
- Extracts `make_home_link()` helper to reduce boilerplate
- Adds `BUB_REAL_CONFIG` and `BUB_KYUUBI_HOME` env vars to `.env.example`

## How it works
When `HOME` is set to `$BUB_HOME` (~/.bub) inside the sandbox, tools that resolve `~/.config` or `~/.kyuubi` would look in the wrong place. The symlinks redirect:
- `$BUB_HOME/.config` → real `~/.config`
- `$BUB_HOME/.kyuubi` → real `~/.kyuubi`

## Test plan
- [ ] `./run-host.sh` starts without errors
- [ ] `ls -la ~/.bub/.config` shows symlink to `~/.config`
- [ ] `ls -la ~/.bub/.kyuubi` shows symlink to `~/.kyuubi` (if it exists)
- [ ] Tools using `~/.config` inside sandbox find the real config

🤖 Generated with [Claude Code](https://claude.com/claude-code)