### PR TITLE
refactor: restore HOME to real user home (plan B)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,6 @@ BUB_WORKSPACE=/path/to/your-workspace
 # 容器时区（Docker 模式，默认 Asia/Shanghai）
 # TZ=Asia/Shanghai
 
-BUB_HOME=~/.bub
 BUB_BOXSH=~/work/boxsh/bub-im-bridge
 BUB_BOXSH_HOST=~/work/boxsh/bub-im-bridge-host
 BUB_SKILLS=~/.agents/skills
@@ -35,7 +34,7 @@ BUB_FEISHU_HOME=~/.feishu
 #   BUB_SKILLS      - skills 目录（沙箱内只读）
 #   BUB_WEIXIN_DATA - 微信数据目录（沙箱内可写，可选，含登录凭据和同步状态）
 #   BUB_FEISHU_HOME - feishu CLI 认证目录（沙箱内可写，可选，token 刷新需要）
-#   BUB_HOME        - bub 主目录（tapes、config，可写）
+#   BUB_HOME        - bub 主目录（固定为 ~/.bub，不可配置）
 #
 # 注意：app 代码通过 framework.workspace（来自 bub -w 参数）动态获取路径，
 # 不会硬编码 /workspace。两种模式下 app 行为完全一致。

--- a/run-host.sh
+++ b/run-host.sh
@@ -17,7 +17,6 @@
 #   BUB_SKILLS      - Skills directory (read-only in sandbox)
 #   BUB_WEIXIN_DATA - WeChat data directory (read-write, optional)
 #   BUB_FEISHU_HOME - Feishu CLI auth directory (read-write, optional, default ~/.feishu)
-#   BUB_HOME        - Bub home directory for tapes/config (read-write)
 #
 # COW path mapping (Host mode vs Docker mode):
 #
@@ -70,13 +69,14 @@ BUB_BOXSH_HOST="$(expand_path "${BUB_BOXSH_HOST:?BUB_BOXSH_HOST not set}")"
 BUB_SKILLS="$(expand_path "${BUB_SKILLS:-$HOME/.agents/skills}")"
 BUB_WEIXIN_DATA="$(expand_path "${BUB_WEIXIN_DATA:-$HOME/.openclaw/openclaw-weixin}")"
 BUB_FEISHU_HOME="$(expand_path "${BUB_FEISHU_HOME:-$HOME/.feishu}")"
-BUB_HOME="$(expand_path "${BUB_HOME:-$HOME/.bub}")"
+# BUB_HOME is always $HOME/.bub — bub resolves its state directory via ~.
+# Not configurable: changing it would require also changing bub's own path resolution.
+BUB_HOME="$HOME/.bub"
 
 # Ensure required directories exist
 # NOTE: BUB_BOXSH_HOST must be empty (or non-existent) for boxsh cow:SRC:DST —
 # boxsh rmdir's DST before mounting overlay. Do NOT create files inside it here.
-mkdir -p "$BUB_WORKSPACE" "$BUB_BOXSH_HOST" "$BUB_HOME" \
-  "$BUB_HOME/.local/share" "$BUB_HOME/.local/state" "$BUB_HOME/tmp"
+mkdir -p "$BUB_WORKSPACE" "$BUB_BOXSH_HOST" "$BUB_HOME" "$BUB_HOME/tmp"
 
 # Pre-create profiles in lower layer only (BUB_WORKSPACE).
 # Upper layer profiles is created inside the sandbox after boxsh mounts COW.

--- a/run-host.sh
+++ b/run-host.sh
@@ -34,6 +34,12 @@
 #   boxsh cow:SRC:DST mounts an overlayfs at DST with SRC as read-only base.
 #   Writes go to DST. App code uses framework.workspace (from -w flag),
 #   never hardcodes paths.
+#
+# HOME strategy (plan B):
+#   HOME is set to the real user home directory (not BUB_HOME).
+#   Tools that resolve paths via ~ (skills, feishu, kyuubi, etc.) work naturally.
+#   BUB_HOME is used only for bub-specific state (tapes, config).
+#   Path protection is maintained by selective --bind, not by remapping HOME.
 
 set -e
 
@@ -70,7 +76,7 @@ BUB_HOME="$(expand_path "${BUB_HOME:-$HOME/.bub}")"
 # NOTE: BUB_BOXSH_HOST must be empty (or non-existent) for boxsh cow:SRC:DST —
 # boxsh rmdir's DST before mounting overlay. Do NOT create files inside it here.
 mkdir -p "$BUB_WORKSPACE" "$BUB_BOXSH_HOST" "$BUB_HOME" \
-  "$BUB_HOME/.config" "$BUB_HOME/.local/share" "$BUB_HOME/.local/state" "$BUB_HOME/tmp"
+  "$BUB_HOME/.local/share" "$BUB_HOME/.local/state" "$BUB_HOME/tmp"
 
 # Pre-create profiles in lower layer only (BUB_WORKSPACE).
 # Upper layer profiles is created inside the sandbox after boxsh mounts COW.
@@ -81,6 +87,7 @@ UV_BIN_DIR="$(cd "$(dirname "$(command -v uv)")" && pwd)"
 UV_DATA_DIR="$(expand_path "${XDG_DATA_HOME:-$HOME/.local/share}/uv")"
 
 # Build boxsh arguments
+# HOME is the real user home — no remapping. Path protection via selective binds.
 BOXSH_ARGS="--sandbox \
   --bind ro:$SCRIPT_DIR \
   --bind cow:$BUB_WORKSPACE:$BUB_BOXSH_HOST \
@@ -89,54 +96,27 @@ BOXSH_ARGS="--sandbox \
 # uv binary and toolchain (Python installs, caches)
 [ -d "$UV_BIN_DIR" ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:$UV_BIN_DIR"
 [ -d "$UV_DATA_DIR" ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:$UV_DATA_DIR"
+# pipx venvs (for tools installed via pipx, e.g. kyuubi)
+PIPX_HOME="${PIPX_HOME:-$HOME/.local/pipx}"
+[ -d "$PIPX_HOME" ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:$PIPX_HOME"
 
-# Optional read-only binds (only if directories exist)
-# Skills directory: bind at original path, then symlink from $BUB_HOME/.agents/skills
-# so bub (which follows $HOME) can find it. Same pattern as feishu below.
-if [ -d "$BUB_SKILLS" ]; then
-    BOXSH_ARGS="$BOXSH_ARGS --bind ro:$BUB_SKILLS"
-    SKILLS_LINK="$BUB_HOME/.agents/skills"
-    mkdir -p "$(dirname "$SKILLS_LINK")"
-    if [ ! -e "$SKILLS_LINK" ]; then
-        ln -s "$BUB_SKILLS" "$SKILLS_LINK"
-    elif [ ! -L "$SKILLS_LINK" ] || [ "$(readlink "$SKILLS_LINK")" != "$BUB_SKILLS" ]; then
-        echo "Error: $SKILLS_LINK exists but does not point to $BUB_SKILLS" >&2
-        exit 1
-    fi
-fi
+# Optional binds — real user directories, accessed at their real paths via ~
+# Skills directory (read-only)
+[ -d "$BUB_SKILLS" ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:$BUB_SKILLS"
 # Weixin parent dir (ro for path resolution) and data dir (wr for sync state)
 BUB_WEIXIN_STATE_DIR="$(dirname "$BUB_WEIXIN_DATA")"
 [ -d "$BUB_WEIXIN_STATE_DIR" ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:$BUB_WEIXIN_STATE_DIR"
 [ -d "$BUB_WEIXIN_DATA" ] && BOXSH_ARGS="$BOXSH_ARGS --bind wr:$BUB_WEIXIN_DATA"
 # Feishu CLI auth directory (writable for token refresh)
-# Bind at original path, then symlink from $BUB_HOME/.feishu so the CLI
-# (which follows $HOME) can find it. boxsh wr binds don't support SRC:DST.
-if [ -d "$BUB_FEISHU_HOME" ]; then
-    BOXSH_ARGS="$BOXSH_ARGS --bind wr:$BUB_FEISHU_HOME"
-    FEISHU_LINK="$BUB_HOME/.feishu"
-    if [ ! -e "$FEISHU_LINK" ]; then
-        ln -s "$BUB_FEISHU_HOME" "$FEISHU_LINK"
-    elif [ ! -L "$FEISHU_LINK" ] || [ "$(readlink "$FEISHU_LINK")" != "$BUB_FEISHU_HOME" ]; then
-        echo "Error: $FEISHU_LINK exists but does not point to $BUB_FEISHU_HOME" >&2
-        exit 1
-    fi
-fi
+[ -d "$BUB_FEISHU_HOME" ] && BOXSH_ARGS="$BOXSH_ARGS --bind wr:$BUB_FEISHU_HOME"
 
-# Sandbox init: set HOME/XDG to writable BUB_HOME, ensure PATH includes uv,
-# create profiles in COW upper layer
-SANDBOX_INIT="export HOME=$BUB_HOME \
-  XDG_CONFIG_HOME=$BUB_HOME/.config \
-  XDG_DATA_HOME=$BUB_HOME/.local/share \
-  XDG_STATE_HOME=$BUB_HOME/.local/state \
+# Sandbox init: HOME is the real user home, TMPDIR in BUB_HOME for isolation
+SANDBOX_INIT="export HOME=$HOME \
   TMPDIR=$BUB_HOME/tmp TEMP=$BUB_HOME/tmp TMP=$BUB_HOME/tmp \
   OPENCLAW_STATE_DIR=$BUB_WEIXIN_STATE_DIR \
   CLAWDBOT_STATE_DIR=$BUB_WEIXIN_STATE_DIR \
   PATH=$UV_BIN_DIR:\$PATH \
-  && mkdir -p \$HOME \$XDG_CONFIG_HOME \$XDG_DATA_HOME \$XDG_STATE_HOME \
-  \$TMPDIR $BUB_BOXSH_HOST/profiles"
-
-# Shell to use inside sandbox (default: sh; override with BOXSH_SHELL=fish etc.)
-BOXSH_SHELL="${BOXSH_SHELL:-sh}"
+  && mkdir -p $BUB_HOME/tmp $BUB_BOXSH_HOST/profiles"
 
 # Run boxsh with signal forwarding for clean Ctrl+C.
 #
@@ -180,10 +160,7 @@ fi
 if [ "$1" = "shell" ] || [ "$1" = "sh" ]; then
     shift
     exec env \
-      HOME="$BUB_HOME" \
-      XDG_CONFIG_HOME="$BUB_HOME/.config" \
-      XDG_DATA_HOME="$BUB_HOME/.local/share" \
-      XDG_STATE_HOME="$BUB_HOME/.local/state" \
+      HOME="$HOME" \
       TMPDIR="$BUB_HOME/tmp" TEMP="$BUB_HOME/tmp" TMP="$BUB_HOME/tmp" \
       OPENCLAW_STATE_DIR="$BUB_WEIXIN_STATE_DIR" \
       CLAWDBOT_STATE_DIR="$BUB_WEIXIN_STATE_DIR" \

--- a/run-host.sh
+++ b/run-host.sh
@@ -109,6 +109,9 @@ BUB_WEIXIN_STATE_DIR="$(dirname "$BUB_WEIXIN_DATA")"
 [ -d "$BUB_WEIXIN_DATA" ] && BOXSH_ARGS="$BOXSH_ARGS --bind wr:$BUB_WEIXIN_DATA"
 # Feishu CLI auth directory (writable for token refresh)
 [ -d "$BUB_FEISHU_HOME" ] && BOXSH_ARGS="$BOXSH_ARGS --bind wr:$BUB_FEISHU_HOME"
+# User config and kyuubi (writable, tools resolve via ~)
+[ -d "$HOME/.config" ] && BOXSH_ARGS="$BOXSH_ARGS --bind wr:$HOME/.config"
+[ -d "$HOME/.kyuubi" ] && BOXSH_ARGS="$BOXSH_ARGS --bind wr:$HOME/.kyuubi"
 
 # Sandbox init: HOME is the real user home, TMPDIR in BUB_HOME for isolation
 SANDBOX_INIT="export HOME=$HOME \


### PR DESCRIPTION
## Summary
- HOME set to real user home (`$HOME`) instead of `$BUB_HOME`
- Selective `--bind` whitelist controls path protection (no symlink tricks)
- `BUB_HOME` hardcoded to `$HOME/.bub` (not configurable, matches bub's own resolution)
- Removes all symlink logic (skills, feishu, config, kyuubi)
- Adds `~/.config`, `~/.kyuubi`, `PIPX_HOME` to bind whitelist
- Net -24 lines

## Verification
Meta42 verified on host: `./run-host.sh` starts correctly, skills/config/kyuubi accessible.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>