### PR TITLE
fix: enforce Feishu canonical identity as open_id with ou_ prefix

### DIFF
--- a/src/bub_im_bridge/feishu/tools.py
+++ b/src/bub_im_bridge/feishu/tools.py
@@ -143,16 +143,23 @@ async def user_lookup(params: UserLookupInput, *, context: ToolContext) -> str:
 
     当消息中提及某个用户（如 @某某），或需要了解某人的信息时使用此工具。
     按名字查找时使用 name 参数，按 IM ID 查找时使用 platform + id_field + id_value。
+    Feishu 用户只能用 open_id (ou_ 开头) 查找。
     """
     store = _get_profile_store(context)
 
     profile = None
     if params.name:
         profile = store.lookup_by_name(params.name)
-    elif params.platform and params.id_field and params.id_value:
-        profile = store.lookup(params.platform, params.id_field, params.id_value)
+    elif params.platform and params.id_value:
+        platform = params.platform
+        id_field = params.id_field or ("open_id" if platform == "feishu" else None)
+        if not id_field:
+            return "错误：需要提供 id_field"
+        if platform == "feishu" and id_field != "open_id":
+            return "错误：Feishu 用户只能用 open_id 查找"
+        profile = store.lookup(platform, id_field, params.id_value)
     else:
-        return "错误：需要提供 name 或 platform+id_field+id_value"
+        return "错误：需要提供 name 或 platform+id_value"
 
     if profile is None:
         return f"未找到用户 profile（查询: name={params.name}, platform={params.platform}）"
@@ -262,7 +269,14 @@ async def user_create(params: UserCreateInput, *, context: ToolContext) -> str:
 
     当需要手动创建一个新的用户 profile 时使用此工具。
     如果用户已存在（相同 platform + id_field + id_value），会更新已有 profile。
+    Feishu 用户必须用 open_id (ou_ 开头) 创建。
     """
+    if params.platform == "feishu":
+        if params.id_field != "open_id":
+            return "错误：Feishu 用户必须用 open_id 创建"
+        if not params.id_value.startswith("ou_"):
+            return "错误：Feishu open_id 必须以 ou_ 开头"
+
     store = _get_profile_store(context)
 
     profile = store.upsert(

--- a/src/bub_im_bridge/profiles.py
+++ b/src/bub_im_bridge/profiles.py
@@ -16,6 +16,11 @@ def _short_uuid() -> str:
     return uuid.uuid4().hex[:8]
 
 
+def _is_valid_feishu_user_id(id_field: str, id_value: str) -> bool:
+    """Only open_id with ou_ prefix is a valid Feishu user canonical identity."""
+    return id_field == "open_id" and id_value.startswith("ou_")
+
+
 def _now_iso() -> str:
     return datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds")
 
@@ -112,6 +117,8 @@ class ProfileStore:
     def _build_index(self, profile: UserProfile) -> None:
         for platform, ids in profile.im_ids.items():
             for field, value in ids.items():
+                if platform == "feishu" and not _is_valid_feishu_user_id(field, value):
+                    continue
                 key = f"{platform}:{field}:{value}"
                 self._index[key] = profile.id
 
@@ -135,6 +142,11 @@ class ProfileStore:
         title: str = "",
         avatar_url: str = "",
     ) -> UserProfile:
+        if platform == "feishu" and not _is_valid_feishu_user_id(id_field, id_value):
+            raise ValueError(
+                f"Feishu canonical identity must be open_id with ou_ prefix, "
+                f"got id_field={id_field!r}, id_value={id_value!r}"
+            )
         existing = self.lookup(platform, id_field, id_value)
         if existing is not None:
             # Merge new data into existing profile

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -203,3 +203,120 @@ def test_lookup_by_name(tmp_path: Path):
     assert store.lookup_by_name("小王") is not None
     assert store.lookup_by_name("alice") is not None  # case insensitive
     assert store.lookup_by_name("Unknown") is None
+
+
+def test_feishu_ou_prefix_valid(tmp_path: Path):
+    """ou_ prefixed open_id works normally for Feishu."""
+    store = ProfileStore(tmp_path / "profiles")
+    store.load()
+
+    p = store.upsert(
+        platform="feishu",
+        id_field="open_id",
+        id_value="ou_abc123",
+        name="Alice",
+    )
+    assert p.name == "Alice"
+    assert store.lookup("feishu", "open_id", "ou_abc123") is not None
+
+
+def test_feishu_rejects_non_ou_open_id(tmp_path: Path):
+    """Non-ou_ open_id is rejected for Feishu."""
+    store = ProfileStore(tmp_path / "profiles")
+    store.load()
+
+    import pytest
+    with pytest.raises(ValueError, match="ou_ prefix"):
+        store.upsert(
+            platform="feishu",
+            id_field="open_id",
+            id_value="cli_abc123",
+            name="BotUser",
+        )
+
+
+def test_feishu_rejects_union_id_as_primary(tmp_path: Path):
+    """union_id cannot be used as primary Feishu identity."""
+    store = ProfileStore(tmp_path / "profiles")
+    store.load()
+
+    import pytest
+    with pytest.raises(ValueError, match="ou_ prefix"):
+        store.upsert(
+            platform="feishu",
+            id_field="union_id",
+            id_value="on_abc123",
+            name="Alice",
+        )
+
+
+def test_feishu_rejects_user_id_as_primary(tmp_path: Path):
+    """user_id cannot be used as primary Feishu identity."""
+    store = ProfileStore(tmp_path / "profiles")
+    store.load()
+
+    import pytest
+    with pytest.raises(ValueError, match="ou_ prefix"):
+        store.upsert(
+            platform="feishu",
+            id_field="user_id",
+            id_value="alice.wang",
+            name="Alice",
+        )
+
+
+def test_feishu_extra_ids_not_indexed(tmp_path: Path):
+    """union_id/user_id stored as extra_ids are not indexed for lookup."""
+    store = ProfileStore(tmp_path / "profiles")
+    store.load()
+
+    store.upsert(
+        platform="feishu",
+        id_field="open_id",
+        id_value="ou_alice",
+        name="Alice",
+        extra_ids={"union_id": "on_alice", "user_id": "alice.wang"},
+    )
+
+    # Primary lookup works
+    assert store.lookup("feishu", "open_id", "ou_alice") is not None
+    # union_id/user_id should NOT be indexed as lookup keys
+    assert store.lookup("feishu", "union_id", "on_alice") is None
+    assert store.lookup("feishu", "user_id", "alice.wang") is None
+
+
+def test_non_feishu_platform_unaffected(tmp_path: Path):
+    """Other platforms are not affected by Feishu validation."""
+    store = ProfileStore(tmp_path / "profiles")
+    store.load()
+
+    # Telegram with arbitrary user_id should work fine
+    p = store.upsert(
+        platform="telegram",
+        id_field="user_id",
+        id_value="8671028832",
+        name="Bob",
+    )
+    assert p.name == "Bob"
+    assert store.lookup("telegram", "user_id", "8671028832") is not None
+
+
+def test_feishu_reload_extras_not_indexed(tmp_path: Path):
+    """After reload, extra_ids (union_id/user_id) are still not indexed."""
+    store = ProfileStore(tmp_path / "profiles")
+    store.load()
+
+    store.upsert(
+        platform="feishu",
+        id_field="open_id",
+        id_value="ou_reload",
+        name="Reload",
+        extra_ids={"union_id": "on_reload"},
+    )
+
+    # Reload from disk
+    store2 = ProfileStore(tmp_path / "profiles")
+    store2.load()
+
+    assert store2.lookup("feishu", "open_id", "ou_reload") is not None
+    assert store2.lookup("feishu", "union_id", "on_reload") is None


### PR DESCRIPTION
## Summary
- Feishu profiles 的 canonical identity 收敛为 `open_id` + `ou_` 前缀
- `union_id` / `user_id` 仍保留在 `extra_ids`，但不再作为 lookup 索引键
- `cli_*`、chat id、非 `ou_` 值不参与用户 profile 唯一归并
- 只改新写入/新查找路径，不做历史数据迁移
- `profile.id` 保持内部随机 ID，不变
- 其他 channel 不受影响

## Changes
- `profiles.py`: `_build_index()` 只索引 `ou_` 开头的 Feishu open_id；`upsert()` 校验 `ou_` 前缀
- `tools.py`: `user.lookup` Feishu 强制 `open_id`；`user.create` 校验 `ou_` 前缀
- `test_profiles.py`: 新增 7 个测试覆盖 ou_ 校验、extra_ids 隔离、非 Feishu 不受影响

## Test plan
- [x] `uv run pytest tests/test_profiles.py` — 19 passed
- [x] `uv run pytest` — 41 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)