### PR TITLE
docs: clarify Feishu im_ids field roles in profile spec

### DIFF
--- a/docs/superpowers/specs/2026-04-23-user-profiles-design.md
+++ b/docs/superpowers/specs/2026-04-23-user-profiles-design.md
@@ -46,9 +46,9 @@ aliases: ["小王", "Alice"]         # Optional. Alternative names.
 # === IM Platform IDs ===
 im_ids:                            # Required. At least one platform.
   feishu:
-    open_id: "ou_xxxxxxxxxxxxxxxxxxxx"
-    union_id: "on_xxxxxxxxxxxxxxxxxxxx"
-    user_id: "alice.wang"
+    open_id: "ou_xxxxxxxxxxxxxxxxxxxx"     # Canonical identity. Must start with ou_.
+    union_id: "on_xxxxxxxxxxxxxxxxxxxx"    # Auxiliary. Cross-app ID. Not used for lookup.
+    user_id: "alice.wang"                  # Auxiliary. Tenant-internal ID. Not used for lookup.
   telegram:
     user_id: "8671028832"
   wechat:

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -137,6 +137,29 @@ def test_store_feishu_integration(tmp_path: Path):
     assert reloaded.name == "Alice"
 
 
+def test_feishu_user_id_persists_in_im_ids(tmp_path: Path):
+    """user_id and union_id are persisted in im_ids.feishu after write/read."""
+    store = ProfileStore(tmp_path / "profiles")
+    store.load()
+
+    store.upsert(
+        platform="feishu",
+        id_field="open_id",
+        id_value="ou_persist",
+        name="Persist",
+        extra_ids={"union_id": "on_persist", "user_id": "persist.wang"},
+    )
+
+    # Reload from disk
+    store2 = ProfileStore(tmp_path / "profiles")
+    store2.load()
+    p = store2.lookup("feishu", "open_id", "ou_persist")
+    assert p is not None
+    assert p.im_ids["feishu"]["open_id"] == "ou_persist"
+    assert p.im_ids["feishu"]["union_id"] == "on_persist"
+    assert p.im_ids["feishu"]["user_id"] == "persist.wang"
+
+
 def test_upsert_merges_existing(tmp_path: Path):
     """upsert updates existing profile with new data instead of ignoring."""
     store = ProfileStore(tmp_path / "profiles")


### PR DESCRIPTION
## Summary
- 在 profile spec 中明确 Feishu `im_ids` 各字段角色：
  - `open_id`: canonical identity，必须 `ou_` 前缀
  - `union_id`: auxiliary，跨应用 ID，不作为 lookup 主键
  - `user_id`: auxiliary，租户内 ID，不作为 lookup 主键
- 新增测试验证 `user_id` 通过 write/read roundtrip 持久化到 `im_ids.feishu`

## Context
PR #43 已将 Feishu canonical identity 收敛到 `open_id(ou_*)`。本次补充 spec 文档中对 `user_id` 和 `union_id` 的角色说明，以及 `user_id` 的持久化测试。

## Test plan
- [x] `uv run pytest tests/test_profiles.py` — 20 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)