### PR TITLE
feat: user profile logic refinement (phases 1-5)

### DIFF
--- a/docs/superpowers/plans/2026-04-29-user-profile-logic-refinement.md
+++ b/docs/superpowers/plans/2026-04-29-user-profile-logic-refinement.md
@@ -1,0 +1,226 @@
+# User Profile Logic Refinement — Implementation Plan
+
+> Based on: `docs/superpowers/specs/2026-04-29-user-profile-logic-refinement-design.md`
+
+**Goal:** Make Feishu user profiles predictable by separating identity patch from knowledge patch, enforcing `open_id` as canonical lookup key, and eliminating sender/mention/reply-target confusion in group chats.
+
+**Architecture:** Keep the existing one-file-per-user profile format. Refine semantics in three places:
+
+- `profiles.py` owns field-level persistence semantics
+- `feishu/channel.py` owns sender identity patch and structured inbound actor context
+- `feishu/tools.py` owns manual profile tools and knowledge-field update boundaries
+
+**Tech Stack:** Python 3.14, existing `ProfileStore` / `UserProfile`, Feishu channel runtime, pytest.
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|:-------|:-----|:---------------|
+| Modify | `src/bub_im_bridge/profiles.py` | Add explicit identity-patch semantics and placeholder-name upgrade rules |
+| Modify | `src/bub_im_bridge/feishu/channel.py` | Refine sender bootstrap into identity patch; inject structured sender/mentions/reply_target |
+| Modify | `src/bub_im_bridge/feishu/feishu_prompts.py` | Add prompt rules for sender vs mentions vs explicit @ continuation |
+| Modify | `src/bub_im_bridge/feishu/tools.py` | Tighten `user.lookup`, `user.create`, `user.update` semantics |
+| Modify | `tests/test_profiles.py` | Persistence and patch semantics tests |
+| Create/Modify | `tests/test_feishu_*.py` or existing Feishu tests | Structured payload and prompt-context tests |
+
+---
+
+## Phase 1: Identity Patch Semantics
+
+**Intent:** Replace the vague `auto-enrich` behavior with explicit sender identity patch semantics.
+
+- [ ] Add a dedicated `ProfileStore` method for identity patching existing profiles instead of overloading generic `upsert` semantics
+- [ ] Ensure Feishu sender patch only uses `open_id` for lookup
+- [ ] Preserve `union_id` and `user_id` as auxiliary fields only
+- [ ] Allow patching only these fields through identity patch:
+  - `name`
+  - `im_ids.feishu.{open_id, union_id, user_id}`
+  - `department`
+  - `title`
+  - `avatar_url`
+  - `first_seen / last_seen / updated_at / source`
+- [ ] Forbid identity patch from mutating:
+  - `aliases`
+  - `personality`
+  - `interests`
+  - `relationships`
+  - `body`
+
+**Acceptance criteria:**
+
+- sender bootstrap no longer relies on ambiguous generic write semantics
+- a repeated sender event performs field-scoped identity patch only
+- no knowledge fields are touched by automatic sender handling
+
+---
+
+## Phase 2: `profile.name` Repair and Upgrade Rules
+
+**Intent:** Make `profile.name` reliably mean display name rather than `open_id`.
+
+- [ ] Treat `name == im_ids.feishu.open_id` as placeholder/dirty state
+- [ ] Upgrade placeholder `name` when a real display name is later observed from:
+  - Feishu event `sender_name`
+  - Feishu Contact API `name`
+- [ ] Avoid writing weaker identity information over a valid existing display name
+- [ ] Keep `open_id` only as runtime fallback, not a steady-state semantic name
+
+**Acceptance criteria:**
+
+- existing dirty profiles self-heal on subsequent sender encounters
+- newly created or patched profiles converge toward real display names
+- `open_id` remains in `im_ids.feishu.open_id`, not as the intended human-facing `name`
+
+---
+
+## Phase 3: Tool Boundary Tightening
+
+**Intent:** Make tool semantics match the approved spec.
+
+### `user.lookup`
+
+- [ ] Keep Feishu ID lookup restricted to `open_id`
+- [ ] Keep name lookup as convenience search only
+- [ ] Document clearly that name lookup is not canonical identity resolution
+
+### `user.create`
+
+- [ ] Keep Feishu create requiring `open_id`
+- [ ] If profile exists, treat create as identity completion / repair only
+- [ ] Do not let `user.create` rewrite knowledge fields
+
+### `user.update`
+
+- [ ] Restrict updates to knowledge fields only:
+  - `aliases`
+  - `personality`
+  - `interests`
+  - `relationships`
+  - `body`
+- [ ] Keep updates field-scoped
+- [ ] Preserve explicit `append=True` vs `append=False` behavior
+- [ ] Tighten tool docs/prompt guidance so agents use `append=True` by default when adding observations
+
+**Acceptance criteria:**
+
+- no tool can accidentally rewrite Feishu canonical identity
+- `user.update` remains field-level patch, not profile rewrite
+- knowledge additions are append-safe by protocol, not by guesswork
+
+---
+
+## Phase 4: Structured Actor Context for Group Chats
+
+**Intent:** Stop the model from confusing sender, mentioned users, and reply target.
+
+- [ ] Extend Feishu inbound payload to include structured actor data:
+  - `sender`
+  - `mentions[]`
+  - `reply_target`
+- [ ] Keep flattened text for normal conversation, but do not rely on it as the only actor source
+- [ ] Define `reply_target` default as current sender
+- [ ] Ensure a mention in the body does not automatically replace the reply target
+
+**Acceptance criteria:**
+
+- downstream model sees sender and mentions as separate structured objects
+- reply logic no longer depends on parsing raw text names alone
+
+---
+
+## Phase 5: Prompt Rules for Reply Target and Mentions
+
+**Intent:** Reduce incorrect human-facing addressing before implementing full precise mention rendering.
+
+- [ ] Update `feishu_prompts.py` with explicit rules:
+  - default reply to sender
+  - do not switch addressee because multiple names appear in the text
+  - do not emit explicit `@name` unless continuation requires it
+  - if explicit addressing is needed, prefer structured actor context rather than free-form guessing
+- [ ] Add a rule that if sender display name is already present in structured context or profile, the model must not claim it is unknown
+
+**Acceptance criteria:**
+
+- fewer “I don’t know your name” hallucinations when name is already available
+- fewer wrong-person replies in group chats
+
+---
+
+## Phase 6: Outbound Mention Rendering Foundation
+
+**Intent:** Prepare the path toward exact Feishu mentions without mixing it into prompt logic.
+
+- [ ] Keep the decision of whether to continue `@someone` in prompt/build-hook logic
+- [ ] Reserve actual mention rendering for Feishu channel logic
+- [ ] Ensure future exact mention rendering uses `open_id`, not `lookup_by_name()`
+- [ ] Do not attempt free-form name-to-identity guessing in the outbound renderer
+
+**Acceptance criteria:**
+
+- channel rendering layer has a clean future extension point
+- exact mentions can later be added without redefining profile semantics again
+
+---
+
+## Phase 7: Test Coverage
+
+- [ ] Add tests for Feishu canonical lookup using only `open_id`
+- [ ] Add tests proving `union_id` and `user_id` persist but are not lookup keys
+- [ ] Add tests proving placeholder `name == open_id` upgrades on later sender identity patch
+- [ ] Add tests proving identity patch never mutates knowledge fields
+- [ ] Add tests proving `user.update` only changes the requested field
+- [ ] Add tests proving structured `sender / mentions / reply_target` are present in the built payload
+- [ ] Add tests for prompt rules that guard against wrong reply targets
+
+---
+
+## Recommended Execution Order
+
+1. Phase 1 — identity patch semantics
+2. Phase 2 — `profile.name` repair and upgrade
+3. Phase 3 — tool boundary tightening
+4. Phase 4 — structured actor context
+5. Phase 5 — prompt rules
+6. Phase 7 — tests
+7. Phase 6 — outbound mention rendering foundation
+
+Rationale:
+
+- phases 1-3 fix the data contract first
+- phases 4-5 fix the model-input contract next
+- tests lock both down before extending mention rendering
+- phase 6 can stay minimal now and evolve later
+
+---
+
+## Suggested Task Split
+
+### Forger
+
+- implement phases 1-3
+- add tests for persistence/tool semantics
+
+### Razor
+
+- review phases 4-5 behavior from the perspective of group-chat correctness
+- add or validate tests around sender vs mentions vs reply target confusion
+
+### Weaver
+
+- review interface boundaries and acceptance criteria
+- confirm that implementation matches the approved spec before merge
+
+---
+
+## Done Criteria
+
+This plan is complete when:
+
+- Feishu sender identity is always keyed by `open_id`
+- `profile.name` converges to display name rather than `open_id`
+- automatic sender handling never mutates knowledge fields
+- manual profile tools have explicit and non-overlapping semantics
+- structured actor context prevents sender/mention confusion
+- the approved spec and the implementation behavior are aligned

--- a/docs/superpowers/specs/2026-04-29-user-profile-logic-refinement-design.md
+++ b/docs/superpowers/specs/2026-04-29-user-profile-logic-refinement-design.md
@@ -1,0 +1,402 @@
+# User Profile Logic Refinement — Design Spec
+
+**Date:** 2026-04-29  
+**Status:** Approved  
+**Scope:** Refine the existing user profile system semantics without changing the top-level storage shape.
+
+---
+
+## 1. Overview
+
+The current user profile system already persists per-user Markdown files with YAML frontmatter, but several responsibilities are mixed together:
+
+- Feishu canonical identity and display name semantics are not clearly separated
+- automatic sender bootstrap and manual knowledge updates share overlapping write paths
+- sender / mentioned users / reply target are not injected into the model as explicit structured context
+- placeholder values such as `ou_xxx` can incorrectly persist in `profile.name`
+
+This spec refines the behavior while keeping the current one-file-per-user storage model.
+
+The goal is not to redesign profiles from scratch. The goal is to make the current model predictable:
+
+- Feishu canonical identity must be `im_ids.feishu.open_id`
+- `profile.name` must mean display name, not ID
+- automatic writes must only patch identity fields
+- manual `user.update` writes must only patch knowledge fields
+- outbound group replies must not confuse sender and mentioned users
+
+---
+
+## 2. Core Decisions
+
+| Decision | Choice | Rationale |
+|:---------|:-------|:----------|
+| Feishu canonical identity | `im_ids.feishu.open_id` only | Stable app-scoped user identity; already adopted in runtime logic |
+| Feishu auxiliary IDs | `union_id`, `user_id` stored but never used for lookup | Preserve useful metadata without weakening identity semantics |
+| Meaning of `profile.name` | Display name only | Human-facing field must not be polluted by canonical IDs |
+| Automatic sender write path | Identity patch only | Keep sender bootstrap useful but bounded |
+| Manual update write path | Knowledge patch only | Prevent accidental overwrite of identity fields |
+| Sender / mentions context | Structured payload, not only flattened text | Reduce LLM confusion in group chats |
+| Mention rendering | Based on `open_id`, not name guessing | Avoid wrong-person @mentions |
+| Historical dirty data | Lazy repair on next encounter | Avoid one-shot migration complexity |
+
+---
+
+## 3. Data Model Semantics
+
+The profile document remains a single Markdown file with YAML frontmatter, but fields are treated as two semantic layers.
+
+### 3.1 Identity Layer
+
+These fields represent who the user is on IM platforms and what the platform currently reports.
+
+- `id`
+  - Internal profile primary key
+  - Random short ID
+  - Never derived from Feishu IDs
+
+- `name`
+  - Human-readable display name
+  - For Feishu, should come from message event `sender.name` or Contact API `name`
+  - Must not be treated as canonical identity
+
+- `im_ids`
+  - Stores platform identity attributes
+  - For Feishu:
+    - `open_id`: canonical identity
+    - `union_id`: auxiliary only
+    - `user_id`: auxiliary only
+
+- `department`
+- `title`
+- `avatar_url`
+- `first_seen`
+- `last_seen`
+- `updated_at`
+- `source`
+
+### 3.2 Knowledge Layer
+
+These fields represent longer-lived understanding of the person rather than platform identity.
+
+- `aliases`
+- `personality`
+- `interests`
+- `relationships`
+- `body`
+
+### 3.3 Hard Rule
+
+`profile.name` should converge to a real display name.
+
+The following state is considered dirty data, not valid steady state:
+
+```yaml
+name: ou_a775e370fb853dd56aa4057b70e7e109
+```
+
+If a Feishu profile has `name == im_ids.feishu.open_id`, that value is a placeholder and must be repaired once a real display name is available.
+
+---
+
+## 4. Lookup Semantics
+
+### 4.1 Feishu Lookup
+
+Feishu identity lookup must only use:
+
+```text
+platform = "feishu"
+id_field = "open_id"
+id_value = "ou_..."
+```
+
+Rules:
+
+- `union_id` must not be used as lookup key
+- `user_id` must not be used as lookup key
+- `name` must not be treated as canonical identity
+
+### 4.2 Name Lookup
+
+`lookup_by_name()` remains available as a convenience search mechanism, but it is not authoritative for identity decisions.
+
+Use cases:
+
+- fuzzy human search
+- resolving a known profile by display name in tools
+
+Non-use cases:
+
+- sender identity resolution
+- mention target resolution
+- outbound Feishu @mention rendering
+
+---
+
+## 5. Write Paths
+
+This spec defines three separate write paths with strict boundaries.
+
+### 5.1 Identity Patch
+
+**Entry point:** Feishu channel receives a sender event.
+
+**Flow:**
+
+1. Lookup by `feishu.open_id`
+2. If missing, create a minimal profile
+3. If present, patch only identity fields
+
+**Allowed fields:**
+
+- `name`
+- `im_ids.feishu.open_id`
+- `im_ids.feishu.union_id`
+- `im_ids.feishu.user_id`
+- `department`
+- `title`
+- `avatar_url`
+- `first_seen`
+- `last_seen`
+- `updated_at`
+- `source`
+
+**Forbidden fields:**
+
+- `aliases`
+- `personality`
+- `interests`
+- `relationships`
+- `body`
+
+This is the refined replacement for the previous broad `auto-enrich` concept. It should be understood as `identity patch`, not general profile enrichment.
+
+### 5.2 Cognitive Patch
+
+**Entry point:** `user.update`
+
+**Purpose:** update human/agent knowledge about the user without touching identity fields.
+
+**Allowed fields:**
+
+- `aliases`
+- `personality`
+- `interests`
+- `relationships`
+- `body`
+
+**Forbidden fields:**
+
+- `name`
+- `im_ids`
+- `department`
+- `title`
+- `avatar_url`
+- canonical identity of any platform
+
+### 5.3 Manual Create / Repair
+
+**Entry point:** `user.create`
+
+Behavior:
+
+- If the profile does not exist, create it
+- If the profile already exists, do not rebuild it
+- Existing profile case may only fill missing identity fields
+- It must not overwrite knowledge fields
+
+This keeps `user.create` useful for manual repair while avoiding destructive semantics.
+
+---
+
+## 6. Name Maintenance Rules
+
+### 6.1 Priority Order
+
+For Feishu sender identity patch, name candidates are ranked:
+
+1. current message event `sender_name`
+2. Feishu Contact API `name`
+3. existing `profile.name`
+4. temporary in-memory fallback to `open_id`
+
+### 6.2 Persistence Rule
+
+`open_id` may be used as a temporary runtime fallback to avoid null handling, but it must not be treated as a correct persisted display name.
+
+That means:
+
+- creating a new profile with `name = open_id` is tolerated only as placeholder behavior when no real name is available
+- once a real display name is later observed, the profile must be upgraded automatically
+- identity patch logic should avoid rewriting a good existing display name with weaker information
+
+### 6.3 Upgrade Rule
+
+If a stored profile satisfies:
+
+- `profile.name == profile.im_ids.feishu.open_id`
+
+and a new event or API response contains a real display name, then `profile.name` must be upgraded during identity patch.
+
+---
+
+## 7. Sender, Mentions, and Reply Target
+
+Group chat errors showed that flattened plain text is insufficient context. The model needs structured actor information.
+
+### 7.1 Required Structured Input
+
+Feishu inbound payload passed downstream should include:
+
+```json
+{
+  "sender": {
+    "open_id": "ou_xxx",
+    "name": "Zhang Yaodong",
+    "user_id": "zhangyaodong",
+    "union_id": "on_xxx"
+  },
+  "mentions": [
+    {
+      "open_id": "ou_yyy",
+      "name": "Philip"
+    }
+  ],
+  "reply_target": {
+    "kind": "sender",
+    "open_id": "ou_xxx",
+    "name": "Zhang Yaodong"
+  }
+}
+```
+
+### 7.2 Behavioral Rules
+
+- default reply target is the current sender
+- a mention in the message body must not automatically replace the sender as the reply target
+- the model should not output `@someone` unless it explicitly intends to continue addressing that person
+
+This separates:
+
+- who sent the message
+- who was mentioned in the message
+- who the assistant is replying to
+
+---
+
+## 8. Outbound Mention Rules
+
+Mention rendering must be split into two layers.
+
+### 8.1 Prompt / Decision Layer
+
+The prompt layer decides whether the assistant should continue mentioning someone.
+
+This belongs in prompt-building logic or a `build_prompt`-style hook.
+
+Rules:
+
+- default: reply to sender without emitting any explicit @mention
+- only continue `@someone` when the conversation requires explicit addressing
+- if choosing to continue `@someone`, the decision must be based on structured actor data, not name guessing
+
+### 8.2 Rendering Layer
+
+The Feishu channel layer is responsible for actual mention rendering.
+
+Rules:
+
+- rendering must use `open_id`
+- rendering must not infer target identity from free-form `@Name` text
+- sender and mentions must never be resolved through `lookup_by_name()` when producing Feishu mentions
+
+This prevents cases like “replying to 张耀东 but accidentally emitting @Philip”.
+
+---
+
+## 9. Tool Semantics
+
+### 9.1 `user.lookup`
+
+- Feishu ID lookup only accepts `open_id`
+- name lookup remains a convenience search, not identity resolution
+- if future mention resolution needs exact identity, it must use structured `open_id`
+
+### 9.2 `user.update`
+
+`user.update` is already field-scoped, but its list semantics need explicit protocol guidance.
+
+Rules:
+
+- the tool updates exactly one field at a time
+- list fields support append or replace
+- agent protocol should default to `append=True` when adding new observations
+- `append=False` should be used only for deliberate replacement
+
+This avoids accidental knowledge loss without changing the core tool shape.
+
+### 9.3 `user.create`
+
+- Feishu create path must still require `open_id`
+- if profile exists, treat call as identity repair / completion, not full rewrite
+
+---
+
+## 10. Dirty Data Repair Strategy
+
+Historical profiles may already contain placeholder names equal to Feishu `open_id`.
+
+This spec adopts lazy repair, not an eager migration.
+
+### 10.1 Dirty Data Definition
+
+A profile is dirty if:
+
+- `profile.name == im_ids.feishu.open_id`
+
+### 10.2 Repair Trigger
+
+Repair happens when the user appears again and a real display name becomes available from:
+
+- event `sender_name`, or
+- Contact API
+
+### 10.3 Repair Action
+
+- replace placeholder `name` with real display name
+- keep all other fields unchanged
+
+No bulk migration job is required in this phase.
+
+---
+
+## 11. Testing Requirements
+
+At minimum, add or preserve tests for:
+
+1. Feishu canonical lookup uses only `open_id`
+2. `union_id` and `user_id` persist but are not lookup keys
+3. placeholder `name == open_id` upgrades to real display name on later identity patch
+4. identity patch never modifies knowledge fields
+5. `user.update` modifies only the requested field
+6. list-field append does not overwrite unrelated knowledge
+7. sender / mentions / reply target are injected as structured context
+8. outbound mention rendering uses `open_id`, not guessed name resolution
+
+---
+
+## 12. Implementation Notes
+
+This spec intentionally avoids introducing a new storage format or splitting identity and knowledge into separate files. That would be a larger redesign than the current issue requires.
+
+The preferred implementation strategy is:
+
+1. keep `UserProfile` file shape stable
+2. refine semantics in `profiles.py`
+3. tighten Feishu channel sender patch behavior
+4. tighten tool boundaries in `feishu/tools.py`
+5. add structured actor payload for prompts
+6. add exact-identity outbound mention rendering later if needed
+
+This keeps the change set proportional while making the profile system much more predictable.

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -431,7 +431,16 @@ class FeishuChannel(Channel):
             if sender_id and message.sender_type != "bot":
                 profile = self._profile_store.lookup("feishu", "open_id", sender_id)
                 if profile is not None:
-                    self._profile_store.touch(profile.id)
+                    # Upgrade placeholder name if current name is just the open_id
+                    if profile.name == sender_id and message.sender_name:
+                        self._profile_store.upsert(
+                            platform="feishu",
+                            id_field="open_id",
+                            id_value=sender_id,
+                            name=message.sender_name,
+                        )
+                    else:
+                        self._profile_store.touch(profile.id)
                 else:
                     extra_ids: dict[str, str] = {}
                     if message.sender_union_id:

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -549,12 +549,35 @@ class FeishuChannel(Channel):
         sender_profile = self._profile_store.lookup("feishu", "open_id", sender_id) if sender_id else None
         user_context_hint = build_user_context_hint(sender_profile)
 
+        # Structured actor context (phase 4)
+        sender_obj: dict[str, Any] = {
+            "open_id": message.sender_open_id or "",
+            "name": message.sender_name or "",
+        }
+        if message.sender_user_id:
+            sender_obj["user_id"] = message.sender_user_id
+        if message.sender_union_id:
+            sender_obj["union_id"] = message.sender_union_id
+
+        mentions_list: list[dict[str, str]] = [
+            {"open_id": m.open_id or "", "name": m.name or ""}
+            for m in message.mentions
+            if m.open_id  # skip mentions without open_id
+        ]
+
+        # reply_target defaults to sender; if quoting, still default to sender
+        # (the model should decide whether to address the quoted person)
+        reply_target = sender_id
+
         payload: dict[str, Any] = {
             "message": message.text + FEISHU_OUTPUT_INSTRUCTION + history_hint + user_context_hint,
             "message_id": message.message_id,
             "chat_type": message.chat_type,
             "sender_id": sender_id,
             "sender_name": message.sender_display,
+            "sender": sender_obj,
+            "mentions": mentions_list,
+            "reply_target": reply_target,
             "create_time": format_feishu_timestamp(message.create_time),
         }
 

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -567,7 +567,11 @@ class FeishuChannel(Channel):
 
         # reply_target defaults to sender; if quoting, still default to sender
         # (the model should decide whether to address the quoted person)
-        reply_target = sender_id
+        reply_target: dict[str, Any] = {
+            "kind": "sender",
+            "open_id": message.sender_open_id or "",
+            "name": message.sender_name or "",
+        }
 
         payload: dict[str, Any] = {
             "message": message.text + FEISHU_OUTPUT_INSTRUCTION + history_hint + user_context_hint,

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -426,43 +426,36 @@ class FeishuChannel(Channel):
         # Record start time for elapsed time calculation
         self._message_start_time[message.message_id] = time.time()
 
-        # Best-effort profile enrichment (must not block message dispatch)
+        # Best-effort sender identity patch (must not block message dispatch)
         try:
             if sender_id and message.sender_type != "bot":
-                profile = self._profile_store.lookup("feishu", "open_id", sender_id)
-                if profile is not None:
-                    # Upgrade placeholder name if current name is just the open_id
-                    if profile.name == sender_id and message.sender_name:
-                        self._profile_store.upsert(
-                            platform="feishu",
-                            id_field="open_id",
-                            id_value=sender_id,
-                            name=message.sender_name,
-                        )
-                    else:
-                        self._profile_store.touch(profile.id)
-                else:
-                    extra_ids: dict[str, str] = {}
-                    if message.sender_union_id:
-                        extra_ids["union_id"] = message.sender_union_id
-                    if message.sender_user_id:
-                        extra_ids["user_id"] = message.sender_user_id
+                extra_ids: dict[str, str] = {}
+                if message.sender_union_id:
+                    extra_ids["union_id"] = message.sender_union_id
+                if message.sender_user_id:
+                    extra_ids["user_id"] = message.sender_user_id
 
-                    info = {"name": message.sender_name or sender_id}
-                    if self._api_client is not None:
-                        from bub_im_bridge.feishu.api import fetch_user_info
-                        info = fetch_user_info(self._api_client, sender_id)
+                # Try to get richer info from Contact API for new senders
+                # or when existing profile has placeholder name (name == open_id)
+                existing = self._profile_store.lookup("feishu", "open_id", sender_id)
+                needs_api = existing is None or (
+                    not message.sender_name and existing.name.startswith("ou_")
+                )
+                info: dict[str, Any] = {}
+                if needs_api and self._api_client is not None:
+                    from bub_im_bridge.feishu.api import fetch_user_info
+                    info = fetch_user_info(self._api_client, sender_id)
 
-                    self._profile_store.upsert(
-                        platform="feishu",
-                        id_field="open_id",
-                        id_value=sender_id,
-                        name=info.get("name", sender_id),
-                        extra_ids=extra_ids,
-                        department=info.get("department_id", ""),
-                        title=info.get("job_title", ""),
-                        avatar_url=info.get("avatar_url", ""),
-                    )
+                self._profile_store.identity_patch(
+                    platform="feishu",
+                    id_field="open_id",
+                    id_value=sender_id,
+                    name=message.sender_name or info.get("name", ""),
+                    extra_ids=extra_ids if extra_ids else None,
+                    department=info.get("department_id", ""),
+                    title=info.get("job_title", ""),
+                    avatar_url=info.get("avatar_url", ""),
+                )
         except Exception:
             logger.warning("feishu.profile_enrichment failed sender={}", sender_id, exc_info=True)
 

--- a/src/bub_im_bridge/feishu/feishu_prompts.py
+++ b/src/bub_im_bridge/feishu/feishu_prompts.py
@@ -25,8 +25,17 @@ def build_user_context_hint(profile: UserProfile | None) -> str:
         "- 不要把内部实现细节输出给终端用户"
     )
 
+    reply_rules = (
+        "回复规则：\n"
+        "- 默认回复当前消息的发送者（sender），不要擅自切换称呼对象\n"
+        "- 正文中出现多个名字不代表需要切换回复对象；只有明确需要继续 @某个 mention 时才切换\n"
+        "- 如果发送者的名字已经在上下文中（sender.name 或 profile.name），"
+        "不要说「我不知道你的名字」「你是谁」之类的话\n"
+        "- 不要主动输出 @名字 除非确实需要继续点名某个 mention"
+    )
+
     if profile is None:
-        return f"\n\n<user_context>\n{tool_hints}\n</user_context>"
+        return f"\n\n<user_context>\n{tool_hints}\n\n{reply_rules}\n</user_context>"
 
     parts = [f"\n\n<user_context>\n发送者: {profile.name}"]
     if profile.department or profile.title:
@@ -37,6 +46,8 @@ def build_user_context_hint(profile: UserProfile | None) -> str:
         parts.append(f"兴趣爱好: {', '.join(profile.interests)}")
     parts.append("")
     parts.append(tool_hints)
+    parts.append("")
+    parts.append(reply_rules)
     parts.append("</user_context>")
     return "\n".join(parts)
 

--- a/src/bub_im_bridge/feishu/tools.py
+++ b/src/bub_im_bridge/feishu/tools.py
@@ -144,6 +144,9 @@ async def user_lookup(params: UserLookupInput, *, context: ToolContext) -> str:
     当消息中提及某个用户（如 @某某），或需要了解某人的信息时使用此工具。
     按名字查找时使用 name 参数，按 IM ID 查找时使用 platform + id_field + id_value。
     Feishu 用户只能用 open_id (ou_ 开头) 查找。
+
+    注意：按名字查找是便捷搜索，不是 canonical identity 解析。
+    sender 身份确认应使用 open_id，不依赖名字匹配。
     """
     store = _get_profile_store(context)
 
@@ -204,11 +207,14 @@ class UserUpdateInput(BaseModel):
 
 @tool(name="user.update", model=UserUpdateInput, context=True)
 async def user_update(params: UserUpdateInput, *, context: ToolContext) -> str:
-    """更新用户 profile 的字段。
+    """更新用户 profile 的认知字段（knowledge fields）。
 
     当观察到用户的行为特征、兴趣爱好、人际关系等信息时，使用此工具记录到对应 profile。
-    支持更新: personality（个性特征）, interests（兴趣爱好）, aliases（别名）,
+    仅支持更新: personality（个性特征）, interests（兴趣爱好）, aliases（别名）,
     relationships（人际关系）, body（自由文本，如评价、观察日志）。
+
+    不允许更新身份字段（name, im_ids, department, title 等），这些由系统自动维护。
+    追加新观察时需显式传 append=True，默认行为是替换当前字段值。
     """
     store = _get_profile_store(context)
 
@@ -268,7 +274,7 @@ async def user_create(params: UserCreateInput, *, context: ToolContext) -> str:
     """创建新用户 profile。
 
     当需要手动创建一个新的用户 profile 时使用此工具。
-    如果用户已存在（相同 platform + id_field + id_value），会更新已有 profile。
+    如果用户已存在（相同 platform + id_field + id_value），只补缺 identity 字段，不覆盖已有数据。
     Feishu 用户必须用 open_id (ou_ 开头) 创建。
     """
     if params.platform == "feishu":
@@ -279,7 +285,8 @@ async def user_create(params: UserCreateInput, *, context: ToolContext) -> str:
 
     store = _get_profile_store(context)
 
-    profile = store.upsert(
+    # identity_patch: create if missing, only fill identity fields if exists
+    profile = store.identity_patch(
         platform=params.platform,
         id_field=params.id_field,
         id_value=params.id_value,

--- a/src/bub_im_bridge/profiles.py
+++ b/src/bub_im_bridge/profiles.py
@@ -244,7 +244,7 @@ class ProfileStore:
             im_ids[platform].update(extra_ids)
 
         profile = UserProfile.create(
-            name=name or id_value,
+            name=name,
             im_ids=im_ids,
             department=department,
             title=title,

--- a/src/bub_im_bridge/profiles.py
+++ b/src/bub_im_bridge/profiles.py
@@ -187,6 +187,118 @@ class ProfileStore:
         self._write(profile)
         return profile
 
+    # Identity fields that can be patched by automatic sender handling
+    _IDENTITY_FIELDS = frozenset({
+        "name", "im_ids", "department", "title", "avatar_url",
+        "first_seen", "last_seen", "updated_at", "source",
+    })
+
+    # Knowledge fields that must never be touched by identity patch
+    _KNOWLEDGE_FIELDS = frozenset({
+        "aliases", "personality", "interests", "relationships", "body",
+    })
+
+    def identity_patch(
+        self,
+        *,
+        platform: str,
+        id_field: str,
+        id_value: str,
+        name: str = "",
+        extra_ids: dict[str, str] | None = None,
+        department: str = "",
+        title: str = "",
+        avatar_url: str = "",
+    ) -> UserProfile:
+        """Patch identity fields only. Never touches knowledge fields.
+
+        This is the canonical write path for automatic sender handling.
+        - If profile does not exist, creates a minimal profile.
+        - If profile exists, patches identity fields only.
+        - Handles name == open_id placeholder upgrade.
+        - Never writes: aliases, personality, interests, relationships, body.
+        """
+        if platform == "feishu" and not _is_valid_feishu_user_id(id_field, id_value):
+            raise ValueError(
+                f"Feishu canonical identity must be open_id with ou_ prefix, "
+                f"got id_field={id_field!r}, id_value={id_value!r}"
+            )
+
+        existing = self.lookup(platform, id_field, id_value)
+        if existing is not None:
+            return self._patch_existing_identity(
+                existing,
+                platform=platform,
+                id_field=id_field,
+                id_value=id_value,
+                name=name,
+                extra_ids=extra_ids,
+                department=department,
+                title=title,
+                avatar_url=avatar_url,
+            )
+
+        # Create minimal profile with identity fields only
+        im_ids: dict[str, dict[str, str]] = {platform: {id_field: id_value}}
+        if extra_ids:
+            im_ids[platform].update(extra_ids)
+
+        profile = UserProfile.create(
+            name=name or id_value,
+            im_ids=im_ids,
+            department=department,
+            title=title,
+            avatar_url=avatar_url,
+        )
+        self._profiles[profile.id] = profile
+        self._build_index(profile)
+        self._write(profile)
+        return profile
+
+    def _patch_existing_identity(
+        self,
+        existing: UserProfile,
+        *,
+        platform: str,
+        id_field: str,
+        id_value: str,
+        name: str = "",
+        extra_ids: dict[str, str] | None = None,
+        department: str = "",
+        title: str = "",
+        avatar_url: str = "",
+    ) -> UserProfile:
+        """Apply identity-only patches to an existing profile."""
+        changes: dict[str, Any] = {"updated_at": _now_iso(), "last_seen": _now_iso()}
+
+        # Merge im_ids
+        merged_im_ids = dict(existing.im_ids)
+        merged_im_ids.setdefault(platform, {})[id_field] = id_value
+        if extra_ids:
+            merged_im_ids[platform].update(extra_ids)
+        changes["im_ids"] = merged_im_ids
+
+        # Name upgrade: replace placeholder (name == open_id) with real display name
+        if name and name != existing.name:
+            is_placeholder = existing.name == id_value or existing.name.startswith("ou_")
+            if is_placeholder:
+                changes["name"] = name
+            # else: keep existing name (don't overwrite a valid display name with weaker info)
+
+        # Fill missing identity fields (don't overwrite existing values)
+        if department and not existing.department:
+            changes["department"] = department
+        if title and not existing.title:
+            changes["title"] = title
+        if avatar_url and not existing.avatar_url:
+            changes["avatar_url"] = avatar_url
+
+        updated = replace(existing, **changes)
+        self._profiles[existing.id] = updated
+        self._build_index(updated)
+        self._write(updated)
+        return updated
+
     def update_field(self, profile_id: str, field_name: str, value: Any) -> UserProfile | None:
         """Update a single field on an existing profile."""
         profile = self._profiles.get(profile_id)

--- a/tests/test_feishu_actor_context.py
+++ b/tests/test_feishu_actor_context.py
@@ -1,0 +1,343 @@
+"""Tests for Feishu structured actor context (phase 4) and prompt rules (phase 5).
+
+These tests validate that:
+- Phase 4: sender, mentions[], and reply_target are passed as structured data
+- Phase 5: prompt rules prevent wrong-person replies and "I don't know your name" hallucinations
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bub_im_bridge.feishu.channel import (
+    FeishuInboundMessage,
+    FeishuMention,
+    _parse_event,
+)
+from bub_im_bridge.feishu.feishu_prompts import build_user_context_hint
+from bub_im_bridge.profiles import ProfileStore, UserProfile
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_raw_event(
+    *,
+    sender_open_id: str = "ou_sender",
+    sender_name: str = "张三",
+    mentions: list[dict] | None = None,
+    text: str = "hello",
+    chat_type: str = "group",
+    parent_id: str | None = None,
+) -> dict:
+    """Build a minimal raw Feishu event dict for testing."""
+    mention_list = []
+    for m in (mentions or []):
+        mention_list.append({
+            "key": m.get("key", "@_user"),
+            "name": m.get("name", ""),
+            "id": {"open_id": m.get("open_id", "")},
+        })
+
+    content = json.dumps({"text": text})
+
+    return {
+        "event": {
+            "sender": {
+                "sender_id": {
+                    "open_id": sender_open_id,
+                    "union_id": "on_sender",
+                    "user_id": "sender_uid",
+                },
+                "sender_type": "user",
+                "name": sender_name,
+                "tenant_key": "tenant",
+            },
+            "message": {
+                "message_id": "msg_001",
+                "chat_id": "chat_001",
+                "chat_type": chat_type,
+                "message_type": "text",
+                "content": content,
+                "mentions": mention_list,
+                "parent_id": parent_id,
+                "create_time": "1714000000000",
+            },
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# Phase 4: Structured Actor Context Tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseEventStructuredSender:
+    """Verify _parse_event extracts structured sender data."""
+
+    def test_sender_fields_extracted(self):
+        raw = _make_raw_event(sender_open_id="ou_alice", sender_name="Alice")
+        msg = _parse_event(raw)
+        assert msg is not None
+        assert msg.sender_open_id == "ou_alice"
+        assert msg.sender_name == "Alice"
+        assert msg.sender_union_id == "on_sender"
+        assert msg.sender_user_id == "sender_uid"
+
+    def test_mentions_extracted_as_structured_objects(self):
+        raw = _make_raw_event(
+            mentions=[
+                {"open_id": "ou_bob", "name": "Bob", "key": "@_user1"},
+                {"open_id": "ou_charlie", "name": "Charlie", "key": "@_user2"},
+            ]
+        )
+        msg = _parse_event(raw)
+        assert msg is not None
+        assert len(msg.mentions) == 2
+        assert msg.mentions[0].open_id == "ou_bob"
+        assert msg.mentions[0].name == "Bob"
+        assert msg.mentions[1].open_id == "ou_charlie"
+        assert msg.mentions[1].name == "Charlie"
+
+    def test_mentions_in_text_are_replaced_with_display_names(self):
+        raw = _make_raw_event(
+            text="@_user1 你好",
+            mentions=[{"open_id": "ou_bob", "name": "Bob", "key": "@_user1"}],
+        )
+        msg = _parse_event(raw)
+        assert msg is not None
+        assert "@Bob" in msg.text
+
+    def test_no_mentions_results_in_empty_tuple(self):
+        raw = _make_raw_event(mentions=[])
+        msg = _parse_event(raw)
+        assert msg is not None
+        assert msg.mentions == ()
+
+
+class TestStructuredPayloadInChannelMessage:
+    """Verify that the payload sent to the model includes structured actor data.
+
+    CURRENT GAP: _build_channel_message() only includes sender_id and sender_name,
+    but does NOT include structured mentions[] or reply_target.
+    These tests document the expected behavior per phase 4 spec.
+    """
+
+    def test_payload_includes_sender_as_structured_object(self):
+        """Payload should include sender as {open_id, name, user_id, union_id}."""
+        raw = _make_raw_event(sender_open_id="ou_alice", sender_name="Alice")
+        msg = _parse_event(raw)
+        assert msg is not None
+
+        # The payload currently only has sender_id and sender_name as flat fields.
+        # Phase 4 requires sender as a structured object.
+        # This test documents the expected structure.
+        expected_sender = {
+            "open_id": "ou_alice",
+            "name": "Alice",
+            "user_id": "sender_uid",
+            "union_id": "on_sender",
+        }
+        # This assertion will FAIL until phase 4 is implemented.
+        # It documents the target behavior.
+        # For now, verify the current flat fields exist:
+        # payload = ...  # would need to call _build_channel_message
+        # assert payload.get("sender") == expected_sender
+
+    def test_payload_includes_mentions_as_structured_list(self):
+        """Payload should include mentions[] with {open_id, name} per mention."""
+        raw = _make_raw_event(
+            mentions=[{"open_id": "ou_bob", "name": "Bob", "key": "@_user1"}]
+        )
+        msg = _parse_event(raw)
+        assert msg is not None
+        assert len(msg.mentions) == 1
+        assert msg.mentions[0].open_id == "ou_bob"
+        assert msg.mentions[0].name == "Bob"
+
+        # Phase 4: the payload should include a "mentions" key with structured data.
+        # This will FAIL until implemented.
+
+    def test_reply_target_defaults_to_sender(self):
+        """When no parent_id, reply_target should default to current sender."""
+        raw = _make_raw_event(sender_open_id="ou_alice", sender_name="Alice")
+        msg = _parse_event(raw)
+        assert msg is not None
+        assert msg.parent_id is None  # no quoted message
+
+        # Phase 4: payload should include reply_target = sender when no parent_id
+        # This will FAIL until implemented.
+
+    def test_reply_target_preserved_when_quoting(self):
+        """When parent_id exists, reply_target should reflect the quoted context."""
+        raw = _make_raw_event(
+            sender_open_id="ou_alice",
+            sender_name="Alice",
+            parent_id="msg_parent",
+        )
+        msg = _parse_event(raw)
+        assert msg is not None
+        assert msg.parent_id == "msg_parent"
+
+        # Phase 4: reply_target should be derived from the quoted message context,
+        # not automatically switched to a mentioned person.
+
+
+# ---------------------------------------------------------------------------
+# Phase 5: Prompt Rules Tests
+# ---------------------------------------------------------------------------
+
+
+class TestPromptRulesForGroupChat:
+    """Verify prompt rules prevent wrong-person replies and name hallucinations."""
+
+    def test_prompt_includes_sender_name_when_available(self, tmp_path: Path):
+        """When sender profile exists with a name, prompt should include it."""
+        store = ProfileStore(tmp_path / "profiles")
+        store.load()
+
+        profile = store.upsert(
+            platform="feishu",
+            id_field="open_id",
+            id_value="ou_alice",
+            name="Alice Wang",
+            department="Engineering",
+        )
+
+        hint = build_user_context_hint(profile)
+        assert "Alice Wang" in hint
+
+    def test_prompt_does_not_say_unknown_when_name_is_available(self, tmp_path: Path):
+        """Prompt should NOT say 'I don't know the name' when sender_name is in context.
+
+        This tests the build_user_context_hint output — if the profile has a name,
+        the prompt must include it, and downstream rules should prevent the model
+        from claiming ignorance.
+        """
+        store = ProfileStore(tmp_path / "profiles")
+        store.load()
+
+        profile = store.upsert(
+            platform="feishu",
+            id_field="open_id",
+            id_value="ou_alice",
+            name="Alice Wang",
+        )
+
+        hint = build_user_context_hint(profile)
+        # The hint includes the sender name
+        assert "Alice Wang" in hint
+        # Phase 5: should also include a rule like "不要说不知道发送者的名字"
+        # This will FAIL until prompt rules are added.
+
+    def test_prompt_includes_reply_target_rules(self, tmp_path: Path):
+        """Prompt should include rules about default reply to sender.
+
+        Phase 5 requires:
+        - Default reply to current sender
+        - Do not switch addressee because multiple names appear in text
+        - Do not emit explicit @name unless continuation requires it
+        """
+        store = ProfileStore(tmp_path / "profiles")
+        store.load()
+
+        profile = store.upsert(
+            platform="feishu",
+            id_field="open_id",
+            id_value="ou_alice",
+            name="Alice",
+        )
+
+        hint = build_user_context_hint(profile)
+        # Phase 5: hint should contain reply target rules
+        # This will FAIL until prompt rules are added.
+        # Expected: some mention of "默认回复发送者" or similar rule
+
+    def test_prompt_rules_for_group_chat_mentions(self, tmp_path: Path):
+        """Prompt should tell model not to confuse sender with mentioned users.
+
+        In the failing case: bot replies to 张耀东 but uses @Philip name.
+        Root cause: model conflates sender and mentions in text.
+        Prompt should include rules to separate them.
+        """
+        store = ProfileStore(tmp_path / "profiles")
+        store.load()
+
+        profile = store.upsert(
+            platform="feishu",
+            id_field="open_id",
+            id_value="ou_sender",
+            name="张耀东",
+        )
+
+        hint = build_user_context_hint(profile)
+        # Phase 5: should include rules about not switching addressee
+        # This will FAIL until implemented.
+
+
+# ---------------------------------------------------------------------------
+# Integration: parse -> payload -> prompt chain
+# ---------------------------------------------------------------------------
+
+
+class TestActorContextIntegration:
+    """End-to-end tests for the parse -> payload -> prompt chain."""
+
+    def test_parse_preserves_multiple_mentions_ordering(self):
+        """Mentions should preserve their order from the raw event."""
+        raw = _make_raw_event(
+            mentions=[
+                {"open_id": "ou_first", "name": "First", "key": "@_u1"},
+                {"open_id": "ou_second", "name": "Second", "key": "@_u2"},
+                {"open_id": "ou_third", "name": "Third", "key": "@_u3"},
+            ]
+        )
+        msg = _parse_event(raw)
+        assert msg is not None
+        assert len(msg.mentions) == 3
+        assert msg.mentions[0].name == "First"
+        assert msg.mentions[1].name == "Second"
+        assert msg.mentions[2].name == "Third"
+
+    def test_parse_handles_missing_sender_gracefully(self):
+        """Event with missing sender should return None."""
+        raw = {"event": {"message": {"message_id": "m1", "chat_id": "c1"}}}
+        msg = _parse_event(raw)
+        assert msg is None
+
+    def test_parse_handles_empty_mentions(self):
+        """Event with no mentions should have empty tuple."""
+        raw = _make_raw_event(mentions=None)
+        msg = _parse_event(raw)
+        assert msg is not None
+        assert msg.mentions == ()
+
+    def test_sender_display_fallback_to_open_id(self):
+        """When sender_name is empty, sender_display should fallback to open_id."""
+        msg = FeishuInboundMessage(
+            message_id="m1",
+            chat_id="c1",
+            chat_type="group",
+            message_type="text",
+            text="hello",
+            sender_open_id="ou_fallback",
+            sender_name="",
+        )
+        assert msg.sender_display == "ou_fallback"
+
+    def test_sender_display_prefers_name(self):
+        """When sender_name is available, sender_display should use it."""
+        msg = FeishuInboundMessage(
+            message_id="m1",
+            chat_id="c1",
+            chat_type="group",
+            message_type="text",
+            text="hello",
+            sender_open_id="ou_alice",
+            sender_name="Alice",
+        )
+        assert msg.sender_display == "Alice"

--- a/tests/test_feishu_actor_context.py
+++ b/tests/test_feishu_actor_context.py
@@ -9,10 +9,12 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from bub_im_bridge.feishu.channel import (
+    FeishuChannel,
     FeishuInboundMessage,
     FeishuMention,
     _parse_event,
@@ -71,6 +73,14 @@ def _make_raw_event(
     }
 
 
+def _make_channel(tmp_path: Path) -> FeishuChannel:
+    """Create a minimal FeishuChannel for testing (no real WS connection)."""
+    framework = MagicMock()
+    framework.workspace = tmp_path
+    channel = FeishuChannel(on_receive=AsyncMock(), framework=framework)
+    return channel
+
+
 # ---------------------------------------------------------------------------
 # Phase 4: Structured Actor Context Tests
 # ---------------------------------------------------------------------------
@@ -119,61 +129,68 @@ class TestParseEventStructuredSender:
         assert msg.mentions == ()
 
 
+@pytest.mark.asyncio
 class TestStructuredPayloadInChannelMessage:
-    """Verify that the payload sent to the model includes structured actor data.
+    """Verify that the payload sent to the model includes structured actor data."""
 
-    CURRENT GAP: _build_channel_message() only includes sender_id and sender_name,
-    but does NOT include structured mentions[] or reply_target.
-    These tests document the expected behavior per phase 4 spec.
-    """
-
-    def test_payload_includes_sender_as_structured_object(self):
+    async def test_payload_includes_sender_as_structured_object(self, tmp_path: Path):
         """Payload should include sender as {open_id, name, user_id, union_id}."""
+        channel = _make_channel(tmp_path)
         raw = _make_raw_event(sender_open_id="ou_alice", sender_name="Alice")
         msg = _parse_event(raw)
         assert msg is not None
 
-        # The payload currently only has sender_id and sender_name as flat fields.
-        # Phase 4 requires sender as a structured object.
-        # This test documents the expected structure.
-        expected_sender = {
-            "open_id": "ou_alice",
-            "name": "Alice",
-            "user_id": "sender_uid",
-            "union_id": "on_sender",
-        }
-        # This assertion will FAIL until phase 4 is implemented.
-        # It documents the target behavior.
-        # For now, verify the current flat fields exist:
-        # payload = ...  # would need to call _build_channel_message
-        # assert payload.get("sender") == expected_sender
+        channel_msg = await channel._build_channel_message(
+            msg, msg.text.strip(), "ou_alice", "feishu:chat_001"
+        )
+        payload = json.loads(channel_msg.content)
 
-    def test_payload_includes_mentions_as_structured_list(self):
+        assert "sender" in payload
+        assert payload["sender"]["open_id"] == "ou_alice"
+        assert payload["sender"]["name"] == "Alice"
+        assert payload["sender"]["user_id"] == "sender_uid"
+        assert payload["sender"]["union_id"] == "on_sender"
+
+    async def test_payload_includes_mentions_as_structured_list(self, tmp_path: Path):
         """Payload should include mentions[] with {open_id, name} per mention."""
+        channel = _make_channel(tmp_path)
         raw = _make_raw_event(
-            mentions=[{"open_id": "ou_bob", "name": "Bob", "key": "@_user1"}]
+            mentions=[
+                {"open_id": "ou_bob", "name": "Bob", "key": "@_user1"},
+                {"open_id": "ou_charlie", "name": "Charlie", "key": "@_user2"},
+            ]
         )
         msg = _parse_event(raw)
         assert msg is not None
-        assert len(msg.mentions) == 1
-        assert msg.mentions[0].open_id == "ou_bob"
-        assert msg.mentions[0].name == "Bob"
 
-        # Phase 4: the payload should include a "mentions" key with structured data.
-        # This will FAIL until implemented.
+        channel_msg = await channel._build_channel_message(
+            msg, msg.text.strip(), "ou_sender", "feishu:chat_001"
+        )
+        payload = json.loads(channel_msg.content)
 
-    def test_reply_target_defaults_to_sender(self):
+        assert "mentions" in payload
+        assert len(payload["mentions"]) == 2
+        assert payload["mentions"][0] == {"open_id": "ou_bob", "name": "Bob"}
+        assert payload["mentions"][1] == {"open_id": "ou_charlie", "name": "Charlie"}
+
+    async def test_reply_target_defaults_to_sender(self, tmp_path: Path):
         """When no parent_id, reply_target should default to current sender."""
+        channel = _make_channel(tmp_path)
         raw = _make_raw_event(sender_open_id="ou_alice", sender_name="Alice")
         msg = _parse_event(raw)
         assert msg is not None
-        assert msg.parent_id is None  # no quoted message
 
-        # Phase 4: payload should include reply_target = sender when no parent_id
-        # This will FAIL until implemented.
+        channel_msg = await channel._build_channel_message(
+            msg, msg.text.strip(), "ou_alice", "feishu:chat_001"
+        )
+        payload = json.loads(channel_msg.content)
 
-    def test_reply_target_preserved_when_quoting(self):
-        """When parent_id exists, reply_target should reflect the quoted context."""
+        assert "reply_target" in payload
+        assert payload["reply_target"] == "ou_alice"
+
+    async def test_reply_target_still_sender_when_quoting(self, tmp_path: Path):
+        """Even when quoting, reply_target defaults to current sender."""
+        channel = _make_channel(tmp_path)
         raw = _make_raw_event(
             sender_open_id="ou_alice",
             sender_name="Alice",
@@ -181,10 +198,42 @@ class TestStructuredPayloadInChannelMessage:
         )
         msg = _parse_event(raw)
         assert msg is not None
-        assert msg.parent_id == "msg_parent"
 
-        # Phase 4: reply_target should be derived from the quoted message context,
-        # not automatically switched to a mentioned person.
+        channel_msg = await channel._build_channel_message(
+            msg, msg.text.strip(), "ou_alice", "feishu:chat_001"
+        )
+        payload = json.loads(channel_msg.content)
+
+        # reply_target is the current sender, not the quoted message author
+        assert payload["reply_target"] == "ou_alice"
+
+    async def test_payload_preserves_flat_sender_fields(self, tmp_path: Path):
+        """Flat sender_id and sender_name should still be present for backward compat."""
+        channel = _make_channel(tmp_path)
+        raw = _make_raw_event(sender_open_id="ou_alice", sender_name="Alice")
+        msg = _parse_event(raw)
+
+        channel_msg = await channel._build_channel_message(
+            msg, msg.text.strip(), "ou_alice", "feishu:chat_001"
+        )
+        payload = json.loads(channel_msg.content)
+
+        # Backward compat: flat fields still present
+        assert payload["sender_id"] == "ou_alice"
+        assert payload["sender_name"] == "Alice"
+
+    async def test_empty_mentions_produces_empty_list(self, tmp_path: Path):
+        """No mentions should produce an empty list in payload."""
+        channel = _make_channel(tmp_path)
+        raw = _make_raw_event(mentions=[])
+        msg = _parse_event(raw)
+
+        channel_msg = await channel._build_channel_message(
+            msg, msg.text.strip(), "ou_sender", "feishu:chat_001"
+        )
+        payload = json.loads(channel_msg.content)
+
+        assert payload["mentions"] == []
 
 
 # ---------------------------------------------------------------------------
@@ -211,37 +260,8 @@ class TestPromptRulesForGroupChat:
         hint = build_user_context_hint(profile)
         assert "Alice Wang" in hint
 
-    def test_prompt_does_not_say_unknown_when_name_is_available(self, tmp_path: Path):
-        """Prompt should NOT say 'I don't know the name' when sender_name is in context.
-
-        This tests the build_user_context_hint output — if the profile has a name,
-        the prompt must include it, and downstream rules should prevent the model
-        from claiming ignorance.
-        """
-        store = ProfileStore(tmp_path / "profiles")
-        store.load()
-
-        profile = store.upsert(
-            platform="feishu",
-            id_field="open_id",
-            id_value="ou_alice",
-            name="Alice Wang",
-        )
-
-        hint = build_user_context_hint(profile)
-        # The hint includes the sender name
-        assert "Alice Wang" in hint
-        # Phase 5: should also include a rule like "不要说不知道发送者的名字"
-        # This will FAIL until prompt rules are added.
-
-    def test_prompt_includes_reply_target_rules(self, tmp_path: Path):
-        """Prompt should include rules about default reply to sender.
-
-        Phase 5 requires:
-        - Default reply to current sender
-        - Do not switch addressee because multiple names appear in text
-        - Do not emit explicit @name unless continuation requires it
-        """
+    def test_prompt_includes_reply_rule_default_to_sender(self, tmp_path: Path):
+        """Prompt should include rule: default reply to sender."""
         store = ProfileStore(tmp_path / "profiles")
         store.load()
 
@@ -253,30 +273,58 @@ class TestPromptRulesForGroupChat:
         )
 
         hint = build_user_context_hint(profile)
-        # Phase 5: hint should contain reply target rules
-        # This will FAIL until prompt rules are added.
-        # Expected: some mention of "默认回复发送者" or similar rule
+        assert "默认回复" in hint or "默认" in hint
+        assert "发送者" in hint
 
-    def test_prompt_rules_for_group_chat_mentions(self, tmp_path: Path):
-        """Prompt should tell model not to confuse sender with mentioned users.
-
-        In the failing case: bot replies to 张耀东 but uses @Philip name.
-        Root cause: model conflates sender and mentions in text.
-        Prompt should include rules to separate them.
-        """
+    def test_prompt_includes_rule_not_switch_addressee(self, tmp_path: Path):
+        """Prompt should include rule: don't switch addressee because of multiple names."""
         store = ProfileStore(tmp_path / "profiles")
         store.load()
 
         profile = store.upsert(
             platform="feishu",
             id_field="open_id",
-            id_value="ou_sender",
-            name="张耀东",
+            id_value="ou_alice",
+            name="Alice",
         )
 
         hint = build_user_context_hint(profile)
-        # Phase 5: should include rules about not switching addressee
-        # This will FAIL until implemented.
+        assert "不要擅自切换" in hint or "切换" in hint
+
+    def test_prompt_includes_rule_not_say_unknown_name(self, tmp_path: Path):
+        """Prompt should include rule: don't say 'I don't know your name' when name is available."""
+        store = ProfileStore(tmp_path / "profiles")
+        store.load()
+
+        profile = store.upsert(
+            platform="feishu",
+            id_field="open_id",
+            id_value="ou_alice",
+            name="Alice Wang",
+        )
+
+        hint = build_user_context_hint(profile)
+        assert "不知道" in hint or "你的名字" in hint or "是谁" in hint
+
+    def test_prompt_includes_rule_not_emit_at_name(self, tmp_path: Path):
+        """Prompt should include rule: don't output @name unless needed."""
+        store = ProfileStore(tmp_path / "profiles")
+        store.load()
+
+        profile = store.upsert(
+            platform="feishu",
+            id_field="open_id",
+            id_value="ou_alice",
+            name="Alice",
+        )
+
+        hint = build_user_context_hint(profile)
+        assert "@" in hint  # mentions the @ symbol in the rule
+
+    def test_prompt_rules_present_even_without_profile(self):
+        """Reply rules should be present even when no sender profile exists."""
+        hint = build_user_context_hint(None)
+        assert "回复规则" in hint or "默认回复" in hint
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_feishu_actor_context.py
+++ b/tests/test_feishu_actor_context.py
@@ -174,7 +174,7 @@ class TestStructuredPayloadInChannelMessage:
         assert payload["mentions"][1] == {"open_id": "ou_charlie", "name": "Charlie"}
 
     async def test_reply_target_defaults_to_sender(self, tmp_path: Path):
-        """When no parent_id, reply_target should default to current sender."""
+        """When no parent_id, reply_target should default to current sender as structured object."""
         channel = _make_channel(tmp_path)
         raw = _make_raw_event(sender_open_id="ou_alice", sender_name="Alice")
         msg = _parse_event(raw)
@@ -186,7 +186,11 @@ class TestStructuredPayloadInChannelMessage:
         payload = json.loads(channel_msg.content)
 
         assert "reply_target" in payload
-        assert payload["reply_target"] == "ou_alice"
+        assert payload["reply_target"] == {
+            "kind": "sender",
+            "open_id": "ou_alice",
+            "name": "Alice",
+        }
 
     async def test_reply_target_still_sender_when_quoting(self, tmp_path: Path):
         """Even when quoting, reply_target defaults to current sender."""
@@ -205,7 +209,9 @@ class TestStructuredPayloadInChannelMessage:
         payload = json.loads(channel_msg.content)
 
         # reply_target is the current sender, not the quoted message author
-        assert payload["reply_target"] == "ou_alice"
+        assert payload["reply_target"]["kind"] == "sender"
+        assert payload["reply_target"]["open_id"] == "ou_alice"
+        assert payload["reply_target"]["name"] == "Alice"
 
     async def test_payload_preserves_flat_sender_fields(self, tmp_path: Path):
         """Flat sender_id and sender_name should still be present for backward compat."""

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -343,3 +343,325 @@ def test_feishu_reload_extras_not_indexed(tmp_path: Path):
 
     assert store2.lookup("feishu", "open_id", "ou_reload") is not None
     assert store2.lookup("feishu", "union_id", "on_reload") is None
+
+
+# ---------------------------------------------------------------------------
+# Phase 1: identity_patch tests
+# ---------------------------------------------------------------------------
+
+
+def test_identity_patch_creates_new_profile(tmp_path: Path):
+    """identity_patch creates a minimal profile when none exists."""
+    store = ProfileStore(tmp_path / "profiles")
+    store.load()
+
+    p = store.identity_patch(
+        platform="feishu",
+        id_field="open_id",
+        id_value="ou_new",
+        name="Alice",
+        extra_ids={"union_id": "on_alice"},
+    )
+    assert p.name == "Alice"
+    assert p.im_ids["feishu"]["open_id"] == "ou_new"
+    assert p.im_ids["feishu"]["union_id"] == "on_alice"
+    assert p.department == ""
+    assert p.personality == []  # knowledge field stays empty
+
+
+def test_identity_patch_patches_existing_identity_fields(tmp_path: Path):
+    """identity_patch fills missing identity fields on existing profile."""
+    store = ProfileStore(tmp_path / "profiles")
+    store.load()
+
+    # Create initial profile
+    store.upsert(
+        platform="feishu", id_field="open_id", id_value="ou_xxx",
+        name="Alice", extra_ids={"union_id": "on_xxx"},
+    )
+
+    # Patch with new identity data
+    patched = store.identity_patch(
+        platform="feishu",
+        id_field="open_id",
+        id_value="ou_xxx",
+        extra_ids={"user_id": "alice.wang"},
+        department="Engineering",
+    )
+    assert patched.im_ids["feishu"]["user_id"] == "alice.wang"
+    assert patched.department == "Engineering"
+
+
+def test_identity_patch_never_mutates_knowledge_fields(tmp_path: Path):
+    """identity_patch must not touch aliases, personality, interests, relationships, body."""
+    store = ProfileStore(tmp_path / "profiles")
+    store.load()
+
+    # Create profile with knowledge fields set
+    p = store.upsert(
+        platform="feishu", id_field="open_id", id_value="ou_know",
+        name="Knower",
+    )
+    store.update_field(p.id, "personality", ["严谨"])
+    store.update_field(p.id, "interests", ["编程"])
+    store.update_field(p.id, "aliases", ["小K"])
+
+    # Identity patch should not touch knowledge fields
+    patched = store.identity_patch(
+        platform="feishu",
+        id_field="open_id",
+        id_value="ou_know",
+        name="Knower",
+        department="OLAP",
+    )
+    assert patched.personality == ["严谨"]
+    assert patched.interests == ["编程"]
+    assert patched.aliases == ["小K"]
+    assert patched.department == "OLAP"
+
+
+def test_identity_patch_upgrades_placeholder_name(tmp_path: Path):
+    """identity_patch upgrades name when current name == open_id (placeholder)."""
+    store = ProfileStore(tmp_path / "profiles")
+    store.load()
+
+    # Create with placeholder name (open_id as name)
+    store.upsert(
+        platform="feishu", id_field="open_id", id_value="ou_ph",
+        name="ou_ph",
+    )
+
+    # Patch with real name
+    patched = store.identity_patch(
+        platform="feishu",
+        id_field="open_id",
+        id_value="ou_ph",
+        name="Alice Wang",
+    )
+    assert patched.name == "Alice Wang"
+
+
+def test_identity_patch_upgrades_placeholder_from_api_name(tmp_path: Path):
+    """Regression: dirty profile (name == open_id) upgrades when API provides real name,
+    even when sender_name is empty (simulates channel.py calling Contact API for dirty profiles)."""
+    store = ProfileStore(tmp_path / "profiles")
+    store.load()
+
+    # Create dirty profile (name == open_id)
+    store.upsert(
+        platform="feishu", id_field="open_id", id_value="ou_dirty",
+        name="ou_dirty",
+    )
+
+    # sender_name is empty, but API returns real name
+    patched = store.identity_patch(
+        platform="feishu",
+        id_field="open_id",
+        id_value="ou_dirty",
+        name="",  # no sender_name
+    )
+    # With empty name, placeholder stays (no upgrade source)
+    assert patched.name == "ou_dirty"
+
+    # But when API provides name (simulated by passing it), placeholder upgrades
+    patched2 = store.identity_patch(
+        platform="feishu",
+        id_field="open_id",
+        id_value="ou_dirty",
+        name="Real Name From API",
+    )
+    assert patched2.name == "Real Name From API"
+
+
+def test_identity_patch_does_not_overwrite_valid_name(tmp_path: Path):
+    """identity_patch keeps existing valid name, doesn't overwrite with weaker info."""
+    store = ProfileStore(tmp_path / "profiles")
+    store.load()
+
+    # Create with real name
+    store.upsert(
+        platform="feishu", id_field="open_id", id_value="ou_valid",
+        name="Alice Wang",
+    )
+
+    # Patch with no name — should keep existing
+    patched = store.identity_patch(
+        platform="feishu",
+        id_field="open_id",
+        id_value="ou_valid",
+    )
+    assert patched.name == "Alice Wang"
+
+    # Patch with different name — should also keep existing (not a placeholder)
+    patched2 = store.identity_patch(
+        platform="feishu",
+        id_field="open_id",
+        id_value="ou_valid",
+        name="Someone Else",
+    )
+    assert patched2.name == "Alice Wang"
+
+
+def test_identity_patch_upgrades_ou_prefix_name(tmp_path: Path):
+    """identity_patch upgrades name that starts with ou_ even if not exactly open_id."""
+    store = ProfileStore(tmp_path / "profiles")
+    store.load()
+
+    # Simulate dirty data: name is ou_ prefixed but not exactly open_id
+    store.upsert(
+        platform="feishu", id_field="open_id", id_value="ou_abc",
+        name="ou_abc_dirty",
+    )
+
+    patched = store.identity_patch(
+        platform="feishu",
+        id_field="open_id",
+        id_value="ou_abc",
+        name="Real Name",
+    )
+    assert patched.name == "Real Name"
+
+
+def test_identity_patch_updates_timestamps(tmp_path: Path):
+    """identity_patch always updates last_seen and updated_at."""
+    store = ProfileStore(tmp_path / "profiles")
+    store.load()
+
+    p = store.upsert(
+        platform="feishu", id_field="open_id", id_value="ou_ts",
+        name="Timer",
+    )
+    old_last_seen = p.last_seen
+
+    import time
+    time.sleep(0.01)
+
+    patched = store.identity_patch(
+        platform="feishu",
+        id_field="open_id",
+        id_value="ou_ts",
+    )
+    assert patched.last_seen >= old_last_seen
+    assert patched.updated_at >= old_last_seen
+
+
+def test_identity_patch_persists_to_disk(tmp_path: Path):
+    """identity_patch writes changes to disk and survives reload."""
+    store = ProfileStore(tmp_path / "profiles")
+    store.load()
+
+    store.identity_patch(
+        platform="feishu",
+        id_field="open_id",
+        id_value="ou_persist",
+        name="Persistent",
+        department="OLAP",
+    )
+
+    # Reload
+    store2 = ProfileStore(tmp_path / "profiles")
+    store2.load()
+    p = store2.lookup("feishu", "open_id", "ou_persist")
+    assert p is not None
+    assert p.name == "Persistent"
+    assert p.department == "OLAP"
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: update_field knowledge-only tests
+# ---------------------------------------------------------------------------
+
+
+def test_update_field_only_changes_requested_field(tmp_path: Path):
+    """update_field only modifies the specified field, not others."""
+    store = ProfileStore(tmp_path / "profiles")
+    store.load()
+
+    p = store.upsert(
+        platform="feishu", id_field="open_id", id_value="ou_upd2",
+        name="Updater",
+    )
+    store.update_field(p.id, "personality", ["严谨"])
+
+    updated = store.get(p.id)
+    assert updated is not None
+    assert updated.personality == ["严谨"]
+    assert updated.name == "Updater"  # unchanged
+    assert updated.department == ""  # unchanged
+
+
+def test_update_field_append_preserves_existing(tmp_path: Path):
+    """update_field with append=True adds to existing list."""
+    store = ProfileStore(tmp_path / "profiles")
+    store.load()
+
+    p = store.upsert(
+        platform="feishu", id_field="open_id", id_value="ou_app",
+        name="Appender",
+    )
+    store.update_field(p.id, "interests", ["编程"])
+    store.update_field(p.id, "interests", ["音乐"])  # replaces
+
+    updated = store.get(p.id)
+    assert updated is not None
+    # update_field replaces, not appends — append logic is in tools.py
+    assert updated.interests == ["音乐"]
+
+
+def test_update_field_rejects_identity_fields(tmp_path: Path):
+    """update_field rejects modifying protected identity fields."""
+    store = ProfileStore(tmp_path / "profiles")
+    store.load()
+
+    p = store.upsert(
+        platform="feishu", id_field="open_id", id_value="ou_prot",
+        name="Protected",
+    )
+
+    # id and schema_version are protected
+    result = store.update_field(p.id, "id", "newid")
+    assert result is None
+
+    result = store.update_field(p.id, "schema_version", "2.0")
+    assert result is None
+
+    result = store.update_field(p.id, "first_seen", "2020-01-01")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Combined flow: simulate FeishuChannel identity patch + user.update
+# ---------------------------------------------------------------------------
+
+
+def test_feishu_channel_identity_patch_flow(tmp_path: Path):
+    """Simulate the full FeishuChannel flow: identity_patch then user.update."""
+    store = ProfileStore(tmp_path / "profiles")
+    store.load()
+
+    # 1. First message from new sender — identity_patch creates profile
+    p = store.identity_patch(
+        platform="feishu",
+        id_field="open_id",
+        id_value="ou_flow",
+        name="Alice",
+        extra_ids={"union_id": "on_flow", "user_id": "alice"},
+    )
+    assert p.name == "Alice"
+    assert p.department == ""
+
+    # 2. Agent observes personality — user.update (knowledge field)
+    store.update_field(p.id, "personality", ["逻辑严谨"])
+    updated = store.get(p.id)
+    assert updated.personality == ["逻辑严谨"]
+
+    # 3. Second message from same sender — identity_patch patches missing fields
+    p2 = store.identity_patch(
+        platform="feishu",
+        id_field="open_id",
+        id_value="ou_flow",
+        department="Engineering",
+    )
+    assert p2.department == "Engineering"
+    assert p2.personality == ["逻辑严谨"]  # knowledge field preserved
+    assert p2.name == "Alice"  # valid name preserved


### PR DESCRIPTION
## Summary
- Phase 1-3 (@Forger): identity patch semantics and tool boundary tightening — automatic sender identity fields (name, department, title, avatar_url) merged on every message; knowledge fields (aliases, personality, interests, relationships) only via `user.update` tool
- Phase 4 (@Razor): structured actor context in payload — `sender` as `{open_id, name, user_id?, union_id?}`, `mentions` as `[{open_id, name}]`, `reply_target` as `{kind, open_id, name}`
- Phase 5 (@Razor): prompt rules for group chat — default reply to sender, no spontaneous address switching, no "I don't know your name" when sender context exists, no emitting @name unless needed
- Fix: `identity_patch` no longer uses open_id as profile name fallback — empty name is preferred over wrong name, upgraded when real name becomes available

## Test plan
- [x] 21 new tests for phase 4-5 (actor context + prompt rules)
- [x] 76 total tests pass
- [ ] Manual verification in Feishu group chat: bot correctly addresses sender, doesn't switch to mentioned users spontaneously
- [ ] Manual verification: bot uses sender name from context, doesn't say "I don't know your name"
- [ ] Verify profile creation: new profiles no longer store open_id as display name

🤖 Generated with [Claude Code](https://claude.com/claude-code)