### PR TITLE
docs: add recommended bub plugins and pre-install in run-host.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,19 @@ uv run bub gateway
 
 </details>
 
+## 推荐插件
+
+```bash
+# Web 搜索能力
+uv run bub install bub-web-search@main
+
+# 定时任务
+uv run bub install bub-schedule@main
+
+# Bubseek Marimo 集成
+uv pip install "git+https://github.com/ob-labs/bubseek.git#subdirectory=contrib/bubseek-marimo"
+```
+
 ## 沙箱部署
 
 通过 [boxsh](https://github.com/xicilion/boxsh) 沙箱运行，Agent 对工作空间的写入通过 COW（写时复制）隔离到独立目录，原始工作空间不受影响。支持两种部署模式：

--- a/run-host.sh
+++ b/run-host.sh
@@ -156,9 +156,14 @@ run_supervised() {
     exit 0
 }
 
-# If no arguments, start the gateway
+# Recommended plugins — installed before gateway starts (idempotent)
+INSTALL_PLUGINS="uv run bub -w $BUB_BOXSH_HOST install bub-web-search@main && \
+  uv run bub -w $BUB_BOXSH_HOST install bub-schedule@main && \
+  uv pip install 'git+https://github.com/ob-labs/bubseek.git#subdirectory=contrib/bubseek-marimo'"
+
+# If no arguments, install plugins then start the gateway
 if [ $# -eq 0 ]; then
-    run_supervised "$SANDBOX_INIT && cd $SCRIPT_DIR && uv run bub -w $BUB_BOXSH_HOST gateway"
+    run_supervised "$SANDBOX_INIT && cd $SCRIPT_DIR && $INSTALL_PLUGINS && uv run bub -w $BUB_BOXSH_HOST gateway"
 fi
 
 # If first argument is "shell" or "sh", launch boxsh native interactive shell

--- a/run-host.sh
+++ b/run-host.sh
@@ -156,19 +156,8 @@ run_supervised() {
     exit 0
 }
 
-# Install recommended plugins on the host (before sandbox, since .venv is read-only inside)
-install_plugins() {
-    echo "Installing recommended plugins..."
-    cd "$SCRIPT_DIR"
-    uv run bub install bub-web-search@main 2>/dev/null || true
-    uv run bub install bub-schedule@main 2>/dev/null || true
-    uv pip install "git+https://github.com/ob-labs/bubseek.git#subdirectory=contrib/bubseek-marimo" 2>/dev/null || true
-    echo "Plugins installed."
-}
-
-# If no arguments, install plugins then start the gateway
+# If no arguments, start the gateway
 if [ $# -eq 0 ]; then
-    install_plugins
     run_supervised "$SANDBOX_INIT && cd $SCRIPT_DIR && uv run bub -w $BUB_BOXSH_HOST gateway"
 fi
 

--- a/run-host.sh
+++ b/run-host.sh
@@ -156,14 +156,20 @@ run_supervised() {
     exit 0
 }
 
-# Recommended plugins — installed before gateway starts (idempotent)
-INSTALL_PLUGINS="uv run bub -w $BUB_BOXSH_HOST install bub-web-search@main && \
-  uv run bub -w $BUB_BOXSH_HOST install bub-schedule@main && \
-  uv pip install 'git+https://github.com/ob-labs/bubseek.git#subdirectory=contrib/bubseek-marimo'"
+# Install recommended plugins on the host (before sandbox, since .venv is read-only inside)
+install_plugins() {
+    echo "Installing recommended plugins..."
+    cd "$SCRIPT_DIR"
+    uv run bub install bub-web-search@main 2>/dev/null || true
+    uv run bub install bub-schedule@main 2>/dev/null || true
+    uv pip install "git+https://github.com/ob-labs/bubseek.git#subdirectory=contrib/bubseek-marimo" 2>/dev/null || true
+    echo "Plugins installed."
+}
 
 # If no arguments, install plugins then start the gateway
 if [ $# -eq 0 ]; then
-    run_supervised "$SANDBOX_INIT && cd $SCRIPT_DIR && $INSTALL_PLUGINS && uv run bub -w $BUB_BOXSH_HOST gateway"
+    install_plugins
+    run_supervised "$SANDBOX_INIT && cd $SCRIPT_DIR && uv run bub -w $BUB_BOXSH_HOST gateway"
 fi
 
 # If first argument is "shell" or "sh", launch boxsh native interactive shell


### PR DESCRIPTION
## Summary
- Add recommended bub plugins section to README (bub-web-search, bub-schedule, bubseek-marimo)
- Pre-install plugins in `run-host.sh` before gateway starts (idempotent)

## Test plan
- [x] README renders correctly
- [ ] `./run-host.sh` installs plugins before starting gateway

🤖 Generated with [Claude Code](https://claude.com/claude-code)