### PR TITLE
fix: use writable workspace in host mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,19 +25,20 @@ BUB_FEISHU_HOME=~/.feishu
 #   Docker 模式:  docker compose up    (使用 entrypoint.sh)
 #   宿主机模式:   ./run-host.sh        (直接用 boxsh >= 2.1.0，不需要 Docker)
 #
-# 两种模式共用以上路径变量，COW 语义说明：
+# 两种模式共用以上路径变量。当前语义：
 #
-#   BUB_WORKSPACE   - 工作区基础目录（COW lower 层，只读，agent 不可修改）
+#   BUB_WORKSPACE   - 真实工作区路径
+#                     Docker 模式下作为 COW lower 层
+#                     宿主机模式下直接以读写方式暴露给 agent
 #   BUB_BOXSH       - Docker 模式 COW upper 层（映射为容器内 /workspace）
-#   BUB_BOXSH_HOST  - 宿主机模式 COW upper 层 + runtime workspace
-#                     必须和 BUB_BOXSH 不同，避免两种模式的 COW 产物混在一起
+#   BUB_BOXSH_HOST  - 宿主机模式旧的 COW upper 路径（已不再使用，保留仅为兼容）
 #   BUB_SKILLS      - skills 目录（沙箱内只读）
 #   BUB_WEIXIN_DATA - 微信数据目录（沙箱内可写，可选，含登录凭据和同步状态）
 #   BUB_FEISHU_HOME - feishu CLI 认证目录（沙箱内可写，可选，token 刷新需要）
 #   BUB_HOME        - bub 主目录（固定为 ~/.bub，不可配置）
 #
-# 注意：app 代码通过 framework.workspace（来自 bub -w 参数）动态获取路径，
-# 不会硬编码 /workspace。两种模式下 app 行为完全一致。
+# 注意：app 代码通过 framework.workspace（来自 bub -w 参数）动态获取路径。
+# Docker 模式 runtime workspace 是 /workspace；宿主机模式 runtime workspace 是 BUB_WORKSPACE 本身。
 
 # ---------------------------------------------------------------------------
 # Agent runtime（可选）

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ docker-compose logs -f
 | 目录 | 权限 | 说明 |
 |------|------|------|
 | workspace | 宿主机模式可写 / Docker 模式 COW | Agent 工作空间 |
+| project repo | 宿主机模式可写 | `run-host.sh` 所在仓库；`uv run` 需要写 repo-local `.venv` |
 | skills | 只读 | Bub 技能目录 |
 | weixin data | 可写 | 微信登录凭据 + 同步状态 |
 | feishu auth | 可写 | feishu CLI 登录凭据（`~/.feishu`，token 刷新需要写权限） |

--- a/README.md
+++ b/README.md
@@ -90,7 +90,10 @@ uv run bub gateway
 
 ## 沙箱部署
 
-通过 [boxsh](https://github.com/xicilion/boxsh) 沙箱运行，Agent 对工作空间的写入通过 COW（写时复制）隔离到独立目录，原始工作空间不受影响。支持两种部署模式：
+通过 [boxsh](https://github.com/xicilion/boxsh) 沙箱运行。当前两种部署模式的工作区策略不同：
+
+- 宿主机模式：直接读写真实 `BUB_WORKSPACE`
+- Docker 模式：继续使用 COW（写时复制）隔离工作区
 
 ### 宿主机模式（推荐开发调试）
 
@@ -127,23 +130,21 @@ docker-compose up -d
 docker-compose logs -f
 ```
 
-### COW 路径映射
-
-两种模式使用独立的 upper 目录，避免 COW 产物互相干扰：
+### Workspace 路径映射
 
 | 角色 | Docker 模式 | 宿主机模式 |
 |------|-------------|------------|
-| Lower（只读基座） | `/workspace-base`（来自 `$BUB_WORKSPACE`） | `$BUB_WORKSPACE` |
-| Upper（持久化写入） | `/workspace`（来自 `$BUB_BOXSH`） | `$BUB_BOXSH_HOST` |
-| Runtime workspace | `/workspace` | `$BUB_BOXSH_HOST` |
+| 基座 workspace | `/workspace-base`（来自 `$BUB_WORKSPACE`） | `$BUB_WORKSPACE` |
+| 写入层 | `/workspace`（来自 `$BUB_BOXSH`，COW upper） | `$BUB_WORKSPACE`（直接读写） |
+| Runtime workspace | `/workspace` | `$BUB_WORKSPACE` |
 
-> **重要：** Docker 模式使用 `BUB_BOXSH`，宿主机模式使用 `BUB_BOXSH_HOST`，两者不可混用。App 代码通过 `bub -w` 参数动态获取 workspace 路径，不硬编码任何路径。
+> **重要：** Docker 模式仍使用 `BUB_BOXSH` 作为 COW upper；宿主机模式不再使用 `BUB_BOXSH_HOST` 作为 runtime workspace。App 代码通过 `bub -w` 参数动态获取路径，不硬编码任何路径。
 
 ### 沙箱保护
 
 | 目录 | 权限 | 说明 |
 |------|------|------|
-| workspace | COW | Agent 工作空间（COW merged view，基座来自 `$BUB_WORKSPACE`） |
+| workspace | 宿主机模式可写 / Docker 模式 COW | Agent 工作空间 |
 | skills | 只读 | Bub 技能目录 |
 | weixin data | 可写 | 微信登录凭据 + 同步状态 |
 | feishu auth | 可写 | feishu CLI 登录凭据（`~/.feishu`，token 刷新需要写权限） |

--- a/run-host.sh
+++ b/run-host.sh
@@ -78,10 +78,11 @@ UV_DATA_DIR="$(expand_path "${XDG_DATA_HOME:-$HOME/.local/share}/uv")"
 # HOME is the real user home — no remapping. Path protection via selective binds.
 BOXSH_ARGS="--sandbox --bind wr:$BUB_WORKSPACE --bind wr:$BUB_HOME"
 
-# If the script itself is outside the workspace, expose it read-only as well.
+# If the project repo itself is outside BUB_WORKSPACE, it still needs to be
+# writable in host mode because `uv run` may update the repo-local `.venv`.
 case "$SCRIPT_DIR" in
   "$BUB_WORKSPACE"|"$BUB_WORKSPACE"/*) ;;
-  *) BOXSH_ARGS="$BOXSH_ARGS --bind ro:$SCRIPT_DIR" ;;
+  *) BOXSH_ARGS="$BOXSH_ARGS --bind wr:$SCRIPT_DIR" ;;
 esac
 
 # uv binary and toolchain (Python installs, caches)

--- a/run-host.sh
+++ b/run-host.sh
@@ -12,27 +12,20 @@
 #   - .env file with required configuration
 #
 # Environment variables (loaded from .env):
-#   BUB_WORKSPACE   - Workspace base directory (COW lower layer, read-only)
-#   BUB_BOXSH_HOST  - Host mode COW upper layer + runtime workspace (MUST differ from BUB_BOXSH)
+#   BUB_WORKSPACE   - Host mode runtime workspace (read-write bind inside sandbox)
+#   BUB_BOXSH_HOST  - Legacy host mode COW path (no longer used, kept for backward compatibility)
 #   BUB_SKILLS      - Skills directory (read-only in sandbox)
 #   BUB_WEIXIN_DATA - WeChat data directory (read-write, optional)
 #   BUB_FEISHU_HOME - Feishu CLI auth directory (read-write, optional, default ~/.feishu)
 #
-# COW path mapping (Host mode vs Docker mode):
+# Workspace mapping:
 #
-#   Role                  Docker mode                    Host mode
-#   ----                  -----------                    ---------
-#   Lower (read-only)     /workspace-base ($BUB_WORKSPACE)  $BUB_WORKSPACE
-#   Upper (writes)        /workspace ($BUB_BOXSH)            $BUB_BOXSH_HOST
-#   Runtime workspace     /workspace                         $BUB_BOXSH_HOST
-#   bub -w flag           /workspace                         $BUB_BOXSH_HOST
+#   Docker mode: entrypoint.sh still uses boxsh COW (`cow:/workspace-base:/workspace`)
+#   Host mode:   run-host.sh exposes the real BUB_WORKSPACE as read-write
 #
-#   IMPORTANT: Host and Docker modes use SEPARATE upper directories to avoid
-#   mixing COW artifacts. Docker uses BUB_BOXSH, Host uses BUB_BOXSH_HOST.
-#
-#   boxsh cow:SRC:DST mounts an overlayfs at DST with SRC as read-only base.
-#   Writes go to DST. App code uses framework.workspace (from -w flag),
-#   never hardcodes paths.
+# Host mode intentionally does NOT use COW anymore. Several tools expect the
+# real workspace path to exist and be writable, and the overlay path caused
+# behavior drift versus running directly on the host.
 #
 # HOME strategy (plan B):
 #   HOME is set to the real user home directory (not BUB_HOME).
@@ -65,7 +58,7 @@ expand_path() {
 }
 
 BUB_WORKSPACE="$(expand_path "${BUB_WORKSPACE:?BUB_WORKSPACE not set}")"
-BUB_BOXSH_HOST="$(expand_path "${BUB_BOXSH_HOST:?BUB_BOXSH_HOST not set}")"
+BUB_BOXSH_HOST="$(expand_path "${BUB_BOXSH_HOST:-}")"
 BUB_SKILLS="$(expand_path "${BUB_SKILLS:-$HOME/.agents/skills}")"
 BUB_WEIXIN_DATA="$(expand_path "${BUB_WEIXIN_DATA:-$HOME/.openclaw/openclaw-weixin}")"
 BUB_FEISHU_HOME="$(expand_path "${BUB_FEISHU_HOME:-$HOME/.feishu}")"
@@ -74,13 +67,8 @@ BUB_FEISHU_HOME="$(expand_path "${BUB_FEISHU_HOME:-$HOME/.feishu}")"
 BUB_HOME="$HOME/.bub"
 
 # Ensure required directories exist
-# NOTE: BUB_BOXSH_HOST must be empty (or non-existent) for boxsh cow:SRC:DST —
-# boxsh rmdir's DST before mounting overlay. Do NOT create files inside it here.
-mkdir -p "$BUB_WORKSPACE" "$BUB_BOXSH_HOST" "$BUB_HOME" "$BUB_HOME/tmp"
-
-# Pre-create profiles in lower layer only (BUB_WORKSPACE).
-# Upper layer profiles is created inside the sandbox after boxsh mounts COW.
 mkdir -p "$BUB_WORKSPACE/profiles"
+mkdir -p "$BUB_HOME" "$BUB_HOME/tmp"
 
 # Resolve uv toolchain paths for sandbox bind
 UV_BIN_DIR="$(cd "$(dirname "$(command -v uv)")" && pwd)"
@@ -88,10 +76,13 @@ UV_DATA_DIR="$(expand_path "${XDG_DATA_HOME:-$HOME/.local/share}/uv")"
 
 # Build boxsh arguments
 # HOME is the real user home — no remapping. Path protection via selective binds.
-BOXSH_ARGS="--sandbox \
-  --bind ro:$SCRIPT_DIR \
-  --bind cow:$BUB_WORKSPACE:$BUB_BOXSH_HOST \
-  --bind wr:$BUB_HOME"
+BOXSH_ARGS="--sandbox --bind wr:$BUB_WORKSPACE --bind wr:$BUB_HOME"
+
+# If the script itself is outside the workspace, expose it read-only as well.
+case "$SCRIPT_DIR" in
+  "$BUB_WORKSPACE"|"$BUB_WORKSPACE"/*) ;;
+  *) BOXSH_ARGS="$BOXSH_ARGS --bind ro:$SCRIPT_DIR" ;;
+esac
 
 # uv binary and toolchain (Python installs, caches)
 [ -d "$UV_BIN_DIR" ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:$UV_BIN_DIR"
@@ -121,7 +112,7 @@ SANDBOX_INIT="export HOME=$HOME \
   OPENCLAW_STATE_DIR=$BUB_WEIXIN_STATE_DIR \
   CLAWDBOT_STATE_DIR=$BUB_WEIXIN_STATE_DIR \
   PATH=$UV_BIN_DIR:\$PATH \
-  && mkdir -p $BUB_HOME/tmp $BUB_BOXSH_HOST/profiles"
+  && mkdir -p $BUB_HOME/tmp $BUB_WORKSPACE/profiles"
 
 # Run boxsh with signal forwarding for clean Ctrl+C.
 #
@@ -158,7 +149,7 @@ run_supervised() {
 
 # If no arguments, start the gateway
 if [ $# -eq 0 ]; then
-    run_supervised "$SANDBOX_INIT && cd $SCRIPT_DIR && uv run bub -w $BUB_BOXSH_HOST gateway"
+    run_supervised "$SANDBOX_INIT && cd $SCRIPT_DIR && uv run bub -w $BUB_WORKSPACE gateway"
 fi
 
 # If first argument is "shell" or "sh", launch boxsh native interactive shell

--- a/run-host.sh
+++ b/run-host.sh
@@ -88,6 +88,15 @@ esac
 # uv binary and toolchain (Python installs, caches)
 [ -d "$UV_BIN_DIR" ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:$UV_BIN_DIR"
 [ -d "$UV_DATA_DIR" ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:$UV_DATA_DIR"
+# Homebrew global bins and Node-installed CLI payloads (e.g. llm-wiki)
+[ -d /opt/homebrew/bin ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:/opt/homebrew/bin"
+[ -d /opt/homebrew/lib/node_modules ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:/opt/homebrew/lib/node_modules"
+# Some globally installed Node CLIs are linked to local source checkouts.
+# Expose the resolved source tree when present so the CLI remains runnable.
+if [ -L /opt/homebrew/lib/node_modules/@jackwener/llm-wiki ]; then
+    LLM_WIKI_SRC="$(cd "$(dirname /opt/homebrew/lib/node_modules/@jackwener/llm-wiki)" && pwd)/$(readlink /opt/homebrew/lib/node_modules/@jackwener/llm-wiki)"
+    [ -d "$LLM_WIKI_SRC" ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:$LLM_WIKI_SRC"
+fi
 # pipx venvs (for tools installed via pipx, e.g. kyuubi)
 PIPX_HOME="${PIPX_HOME:-$HOME/.local/pipx}"
 [ -d "$PIPX_HOME" ] && BOXSH_ARGS="$BOXSH_ARGS --bind ro:$PIPX_HOME"


### PR DESCRIPTION
## Summary
- make `run-host.sh` expose the real `BUB_WORKSPACE` as writable in host mode instead of using a boxsh COW overlay
- point `bub -w` at `BUB_WORKSPACE` in host mode so runtime path matches the real workspace
- update `.env.example` and `README.md` to document that Docker mode still uses COW while host mode now writes the real workspace directly

## Why
Host mode COW introduced behavior drift and tool failures. The immediate user decision was to stop using COW for `/workspace` in host mode and keep Docker mode unchanged.

## Validation
- `sh -n run-host.sh`
- `./run-host.sh "test -w '$BUB_WORKSPACE' && echo WORKSPACE_WRITABLE && printf '%s\n' '$BUB_WORKSPACE'"`

## Notes
- `/opt/homebrew/bin/llm-wiki` exists on the host; the earlier `127` came from a generated typo `llm-wik`, not from this repo hardcoding a bad path
