### PR TITLE
docs: restore missing plugin config vars in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,23 +45,6 @@ BUB_TELEGRAM_PROXY=http://127.0.0.1:1087  # 国内网络需要
 | `BUB_API_KEY` | API 密钥 | ✅ |
 | `BUB_API_BASE` | API 端点（自定义模型时使用） | ❌ |
 
-### Agent 运行时
-
-| 配置项 | 说明 | 默认值 |
-|--------|------|--------|
-| `BUB_MAX_STEPS` | Agent 最大执行步数 | 50 |
-| `BUB_MAX_TOKENS` | 最大 token 数 | 16384 |
-| `BUB_MODEL_TIMEOUT_SECONDS` | 模型调用超时（秒） | 300 |
-
-### Channel Manager
-
-| 配置项 | 说明 | 默认值 |
-|--------|------|--------|
-| `BUB_ENABLED_CHANNELS` | 启用的渠道，逗号分隔或 `all` | `all` |
-| `BUB_DEBOUNCE_SECONDS` | 消息防抖间隔（秒） | 1.0 |
-| `BUB_MAX_WAIT_SECONDS` | 最大等待时间（秒） | 10.0 |
-| `BUB_ACTIVE_TIME_WINDOW` | 活跃时间窗口（秒） | 60.0 |
-
 ### 飞书
 
 | 配置项 | 说明 | 必需 |

--- a/README.md
+++ b/README.md
@@ -45,17 +45,37 @@ BUB_TELEGRAM_PROXY=http://127.0.0.1:1087  # 国内网络需要
 | `BUB_API_KEY` | API 密钥 | ✅ |
 | `BUB_API_BASE` | API 端点（自定义模型时使用） | ❌ |
 
+### Agent 运行时
+
+| 配置项 | 说明 | 默认值 |
+|--------|------|--------|
+| `BUB_MAX_STEPS` | Agent 最大执行步数 | 50 |
+| `BUB_MAX_TOKENS` | 最大 token 数 | 16384 |
+| `BUB_MODEL_TIMEOUT_SECONDS` | 模型调用超时（秒） | 300 |
+
+### Channel Manager
+
+| 配置项 | 说明 | 默认值 |
+|--------|------|--------|
+| `BUB_ENABLED_CHANNELS` | 启用的渠道，逗号分隔或 `all` | `all` |
+| `BUB_DEBOUNCE_SECONDS` | 消息防抖间隔（秒） | 1.0 |
+| `BUB_MAX_WAIT_SECONDS` | 最大等待时间（秒） | 10.0 |
+| `BUB_ACTIVE_TIME_WINDOW` | 活跃时间窗口（秒） | 60.0 |
+
 ### 飞书
 
 | 配置项 | 说明 | 必需 |
 |--------|------|:----:|
 | `BUB_FEISHU_APP_ID` | 应用 App ID | ✅ |
 | `BUB_FEISHU_APP_SECRET` | 应用 App Secret | ✅ |
-| `BUB_FEISHU_VERIFICATION_TOKEN` | Webhook 验证 Token（可选） | ❌ |
-| `BUB_FEISHU_ENCRYPT_KEY` | Webhook 事件加密密钥（可选） | ❌ |
+| `BUB_FEISHU_VERIFICATION_TOKEN` | Webhook 验证 Token | ❌ |
+| `BUB_FEISHU_ENCRYPT_KEY` | Webhook 事件加密密钥 | ❌ |
 | `BUB_FEISHU_ALLOW_USERS` | 允许的用户 open_id，逗号分隔 | ❌ |
 | `BUB_FEISHU_ALLOW_CHATS` | 允许的 Chat ID，逗号分隔 | ❌ |
 | `BUB_FEISHU_BOT_OPEN_ID` | 机器人 open_id，用于群聊 @检测 | ❌ |
+| `BUB_FEISHU_BOT_NAME` | 机器人显示名称，用于 @名称 匹配（大小写不敏感） | ❌ |
+| `BUB_FEISHU_QUEUE_MAX_LENGTH` | 消息队列最大长度，0=不限制 | 0 |
+| `BUB_FEISHU_ADMIN_USERS` | 管理员 open_id，逗号分隔；管理员消息绕过排队，可发送 `,cancel` 取消任务 | ❌ |
 
 > **获取机器人 open_id 的方式**：
 >
@@ -75,6 +95,13 @@ BUB_TELEGRAM_PROXY=http://127.0.0.1:1087  # 国内网络需要
 | `BUB_TELEGRAM_ALLOW_USERS` | 允许的用户 ID，逗号分隔 | ❌ |
 | `BUB_TELEGRAM_ALLOW_CHATS` | 允许的 Chat ID，逗号分隔 | ❌ |
 | `BUB_TELEGRAM_PROXY` | HTTP 代理地址 | ❌ |
+
+### 微信
+
+| 配置项 | 说明 | 必需 |
+|--------|------|:----:|
+| `WEIXIN_BASE_URL` | 微信 API 基础地址 | ❌ |
+| `WEIXIN_ACCOUNT_ID` | 微信账号 ID | ❌ |
 
 ## 消息类型
 


### PR DESCRIPTION
## Summary

Restore plugin-domain config vars that were dropped when entrypoint assets were removed in PR #49.

## Changes

Added back to README config reference:

**Feishu:**
- `BUB_FEISHU_BOT_NAME` — 机器人显示名称，用于 @名称 匹配
- `BUB_FEISHU_QUEUE_MAX_LENGTH` — 消息队列最大长度
- `BUB_FEISHU_ADMIN_USERS` — 管理员 open_id，绕过排队 + 可取消任务

**Weixin:**
- `WEIXIN_BASE_URL` — 微信 API 基础地址
- `WEIXIN_ACCOUNT_ID` — 微信账号 ID

**Agent 运行时 (new section):**
- `BUB_MAX_STEPS`, `BUB_MAX_TOKENS`, `BUB_MODEL_TIMEOUT_SECONDS`

**Channel Manager (new section):**
- `BUB_ENABLED_CHANNELS`, `BUB_DEBOUNCE_SECONDS`, `BUB_MAX_WAIT_SECONDS`, `BUB_ACTIVE_TIME_WINDOW`

## Notes

- Only plugin config vars added — no main entrypoint/部署 parameters restored
- All values from pre-philip-entrypoint-split `.env.example`, filtered to plugin domain only

🤖 Generated with [Claude Code](https://claude.com/claude-code)