### PR TITLE
fix: extract readable text from interactive card messages

### DIFF
--- a/src/bub_im_bridge/feishu/api.py
+++ b/src/bub_im_bridge/feishu/api.py
@@ -332,57 +332,7 @@ def _normalize_text(message_type: str, content: str) -> str:
         return str(parsed.get("text", "")).strip() if parsed else content.strip()
     if parsed is None:
         return f"[{message_type} message]"
-    # For interactive (card) messages, extract readable text instead of raw JSON
-    if message_type in ("interactive", "card"):
-        card_text = _extract_card_text(parsed)
-        if card_text:
-            return card_text
     return f"[{message_type} message] {json.dumps(parsed, ensure_ascii=False)}"
-
-
-def _extract_card_text(parsed: dict[str, Any]) -> str:
-    """Extract human-readable text from an interactive card JSON.
-
-    Handles both schema 2.0 (``body.elements``) and legacy (``elements``)
-    card formats.  Returns a best-effort plain-text representation of the
-    card content so it can be included in the agent context.
-    """
-    parts: list[str] = []
-
-    # Header
-    header = parsed.get("header") or {}
-    title = header.get("title") or {}
-    if title.get("content"):
-        parts.append(str(title["content"]))
-
-    # Body elements — schema 2.0 uses body.elements, legacy uses top-level elements
-    body = parsed.get("body") or {}
-    elements = body.get("elements") or parsed.get("elements") or []
-
-    for el in elements:
-        if isinstance(el, dict):
-            tag = el.get("tag")
-            if tag == "markdown":
-                parts.append(str(el.get("content", "")))
-            elif tag == "text":
-                t = el.get("text", "")
-                if t:
-                    parts.append(str(t))
-            elif tag == "plain_text":
-                t = el.get("content", "")
-                if t:
-                    parts.append(str(t))
-        elif isinstance(el, list):
-            # Nested list of elements (legacy format)
-            for sub in el:
-                if isinstance(sub, dict):
-                    tag = sub.get("tag")
-                    if tag in ("text", "markdown"):
-                        t = sub.get("text") or sub.get("content") or ""
-                        if t:
-                            parts.append(str(t))
-
-    return "\n".join(parts).strip() if parts else ""
 
 
 def parse_time_range(time_str: str | None) -> float | None:

--- a/src/bub_im_bridge/feishu/api.py
+++ b/src/bub_im_bridge/feishu/api.py
@@ -31,7 +31,7 @@ async def fetch_message_content(client: lark.Client, message_id: str) -> str | N
     try:
         from lark_oapi.api.im.v1 import GetMessageRequest
 
-        req = GetMessageRequest.builder().message_id(message_id).build()
+        req = GetMessageRequest.builder().message_id(message_id).card_msg_content_type("raw").build()
         resp = api.get(req)
 
         if not resp.success():
@@ -332,7 +332,57 @@ def _normalize_text(message_type: str, content: str) -> str:
         return str(parsed.get("text", "")).strip() if parsed else content.strip()
     if parsed is None:
         return f"[{message_type} message]"
+    # For interactive (card) messages, extract readable text instead of raw JSON
+    if message_type in ("interactive", "card"):
+        card_text = _extract_card_text(parsed)
+        if card_text:
+            return card_text
     return f"[{message_type} message] {json.dumps(parsed, ensure_ascii=False)}"
+
+
+def _extract_card_text(parsed: dict[str, Any]) -> str:
+    """Extract human-readable text from an interactive card JSON.
+
+    Handles both schema 2.0 (``body.elements``) and legacy (``elements``)
+    card formats.  Returns a best-effort plain-text representation of the
+    card content so it can be included in the agent context.
+    """
+    parts: list[str] = []
+
+    # Header
+    header = parsed.get("header") or {}
+    title = header.get("title") or {}
+    if title.get("content"):
+        parts.append(str(title["content"]))
+
+    # Body elements — schema 2.0 uses body.elements, legacy uses top-level elements
+    body = parsed.get("body") or {}
+    elements = body.get("elements") or parsed.get("elements") or []
+
+    for el in elements:
+        if isinstance(el, dict):
+            tag = el.get("tag")
+            if tag == "markdown":
+                parts.append(str(el.get("content", "")))
+            elif tag == "text":
+                t = el.get("text", "")
+                if t:
+                    parts.append(str(t))
+            elif tag == "plain_text":
+                t = el.get("content", "")
+                if t:
+                    parts.append(str(t))
+        elif isinstance(el, list):
+            # Nested list of elements (legacy format)
+            for sub in el:
+                if isinstance(sub, dict):
+                    tag = sub.get("tag")
+                    if tag in ("text", "markdown"):
+                        t = sub.get("text") or sub.get("content") or ""
+                        if t:
+                            parts.append(str(t))
+
+    return "\n".join(parts).strip() if parts else ""
 
 
 def parse_time_range(time_str: str | None) -> float | None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock
 
-from bub_im_bridge.feishu.api import fetch_user_info
+from bub_im_bridge.feishu.api import _normalize_text, fetch_user_info
 
 
 def test_fetch_user_info_returns_dict():
@@ -43,3 +44,38 @@ def test_fetch_user_info_fallback_on_failure():
 
     info = fetch_user_info(mock_client, "ou_bbb")
     assert info["name"] == "ou_bbb"
+
+
+def test_normalize_text_keeps_interactive_card_as_raw_json_context():
+    content = json.dumps(
+        {
+            "schema": "2.0",
+            "body": {
+                "elements": [
+                    {
+                        "tag": "column_set",
+                        "columns": [
+                            {
+                                "elements": [
+                                    {
+                                        "tag": "div",
+                                        "text": {
+                                            "tag": "lark_md",
+                                            "content": "指标\\n**<font color='blue'>1,200</font>**",
+                                        },
+                                    }
+                                ]
+                            }
+                        ],
+                    }
+                ]
+            },
+        },
+        ensure_ascii=False,
+    )
+
+    text = _normalize_text("interactive", content)
+
+    assert text.startswith("[interactive message] ")
+    assert '"column_set"' in text
+    assert '"lark_md"' in text


### PR DESCRIPTION
## Problem

Interactive card messages (飞书卡片) show as "请升级至最新版本客户端" placeholder when quoted in group chats. The `_normalize_text()` function dumps raw JSON for non-text message types, and `fetch_message_content()` doesn't request the original card JSON.

## Changes

1. **`fetch_message_content()`**: Add `card_msg_content_type="raw"` to `GetMessageRequest` so the API returns the original card JSON instead of the degraded elements format.

2. **`_extract_card_text()`**: New function that parses both schema 2.0 (`body.elements`) and legacy (`elements`) card formats into plain text. Extracts header title, markdown content, and text elements.

3. **`_normalize_text()`**: For `interactive`/`card` message types, use `_extract_card_text()` to produce readable text instead of dumping raw JSON.

## Test

Card messages fetched via `fetch_message_content()` will now return the card's readable text content instead of `[interactive message] {"title":null,"elements":[...]}`.