### PR TITLE
fix: add quoted message sender schema and self-identity

### DIFF
--- a/src/bub_im_bridge/feishu/api.py
+++ b/src/bub_im_bridge/feishu/api.py
@@ -24,6 +24,18 @@ async def fetch_message_content(client: lark.Client, message_id: str) -> str | N
     Uses ``GET /open-apis/im/v1/messages/:message_id``.
     Requires ``im:message`` or ``im:message:readonly`` permission.
     """
+    result = await fetch_quoted_message(client, message_id)
+    return result["content"] if result else None
+
+
+async def fetch_quoted_message(
+    client: lark.Client, message_id: str
+) -> dict[str, str] | None:
+    """Fetch a quoted message with its content and sender info.
+
+    Returns a dict with keys: ``content``, ``sender_id``, ``sender_type``,
+    ``msg_type``.  Returns ``None`` on failure.
+    """
     api = _get_message_api(client)
     if api is None or not message_id:
         return None
@@ -74,7 +86,21 @@ async def fetch_message_content(client: lark.Client, message_id: str) -> str | N
             name = getattr(mention, "name", None)
             if key and name:
                 text = text.replace(key, f"@{name}")
-        return text
+
+        # Extract sender info from the quoted message
+        sender = getattr(item, "sender", None)
+        sender_id = ""
+        sender_type = ""
+        if sender:
+            sender_id = getattr(sender, "id", "") or ""
+            sender_type = getattr(sender, "sender_type", "") or ""
+
+        return {
+            "content": text,
+            "sender_id": sender_id,
+            "sender_type": sender_type,
+            "msg_type": msg_type,
+        }
 
     except Exception:
         logger.exception("feishu.api.fetch_message error message_id={}", message_id)

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -32,6 +32,7 @@ from bub.types import MessageHandler
 
 from bub_im_bridge.feishu.api import (
     fetch_message_content,
+    fetch_quoted_message,
     format_feishu_timestamp,
     _normalize_text,
 )
@@ -532,10 +533,12 @@ class FeishuChannel(Channel):
         # Fetch quoted message content if this is a reply
         quoted_message = None
         if message.parent_id and self._api_client is not None:
-            quoted_message = await fetch_message_content(
+            quoted_result = await fetch_quoted_message(
                 self._api_client, message.parent_id
             )
-            if not quoted_message:
+            if quoted_result:
+                quoted_message = quoted_result
+            else:
                 logger.warning(
                     "feishu.dispatch quoted message fetch returned empty parent_id={}",
                     message.parent_id,
@@ -573,6 +576,13 @@ class FeishuChannel(Channel):
             "name": message.sender_name or "",
         }
 
+        # Self-identity: tell the model who it is
+        self_identity: dict[str, str] = {}
+        if self._bot_name:
+            self_identity["name"] = self._bot_name
+        if self._bot_open_id:
+            self_identity["open_id"] = self._bot_open_id
+
         payload: dict[str, Any] = {
             "message": message.text + FEISHU_OUTPUT_INSTRUCTION + history_hint + user_context_hint,
             "message_id": message.message_id,
@@ -584,6 +594,9 @@ class FeishuChannel(Channel):
             "reply_target": reply_target,
             "create_time": format_feishu_timestamp(message.create_time),
         }
+
+        if self_identity:
+            payload["self_identity"] = self_identity
 
         if quoted_message:
             payload["quoted_message"] = quoted_message

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from bub_im_bridge.feishu.api import _normalize_text, fetch_message_content, fetch_user_info
+from bub_im_bridge.feishu.api import _normalize_text, fetch_message_content, fetch_quoted_message, fetch_user_info
 
 
 def test_fetch_user_info_returns_dict():
@@ -91,10 +91,15 @@ async def test_fetch_message_content_sets_card_msg_content_type_user_card_conten
     mock_builder.message_id.return_value = mock_builder
     mock_builder.build.return_value = mock_req
 
+    mock_sender = MagicMock()
+    mock_sender.id = "ou_bot123"
+    mock_sender.sender_type = "bot"
+
     mock_item = MagicMock()
     mock_item.msg_type = "interactive"
     mock_item.body.content = json.dumps({"schema": "2.0", "body": {}})
     mock_item.mentions = []
+    mock_item.sender = mock_sender
 
     mock_data = MagicMock()
     mock_data.items = [mock_item]
@@ -114,3 +119,88 @@ async def test_fetch_message_content_sets_card_msg_content_type_user_card_conten
 
     assert "[interactive message]" in result
     mock_req.add_query.assert_called_once_with("card_msg_content_type", "user_card_content")
+
+
+async def test_fetch_quoted_message_returns_sender_info():
+    """fetch_quoted_message returns structured dict with content, sender_id,
+    sender_type, and msg_type."""
+
+    mock_req = MagicMock()
+
+    mock_builder = MagicMock()
+    mock_builder.message_id.return_value = mock_builder
+    mock_builder.build.return_value = mock_req
+
+    mock_sender = MagicMock()
+    mock_sender.id = "ou_sender456"
+    mock_sender.sender_type = "user"
+
+    mock_item = MagicMock()
+    mock_item.msg_type = "text"
+    mock_item.body.content = json.dumps({"text": "hello world"})
+    mock_item.mentions = []
+    mock_item.sender = mock_sender
+
+    mock_data = MagicMock()
+    mock_data.items = [mock_item]
+
+    mock_resp = MagicMock()
+    mock_resp.success.return_value = True
+    mock_resp.data = mock_data
+
+    mock_client = MagicMock()
+    mock_client.im.v1.message.get.return_value = mock_resp
+
+    with patch(
+        "lark_oapi.api.im.v1.GetMessageRequest"
+    ) as MockReq:
+        MockReq.builder.return_value = mock_builder
+        result = await fetch_quoted_message(mock_client, "om_quoted")
+
+    assert result is not None
+    assert result["content"] == "hello world"
+    assert result["sender_id"] == "ou_sender456"
+    assert result["sender_type"] == "user"
+    assert result["msg_type"] == "text"
+
+
+async def test_fetch_quoted_message_bot_sender():
+    """fetch_quoted_message correctly identifies bot senders."""
+
+    mock_req = MagicMock()
+
+    mock_builder = MagicMock()
+    mock_builder.message_id.return_value = mock_builder
+    mock_builder.build.return_value = mock_req
+
+    mock_sender = MagicMock()
+    mock_sender.id = "ou_96f06d22c01e55dd7b8706fe2e314508"
+    mock_sender.sender_type = "app"
+
+    mock_item = MagicMock()
+    mock_item.msg_type = "interactive"
+    mock_item.body.content = json.dumps({"schema": "2.0", "body": {"elements": []}})
+    mock_item.mentions = []
+    mock_item.sender = mock_sender
+
+    mock_data = MagicMock()
+    mock_data.items = [mock_item]
+
+    mock_resp = MagicMock()
+    mock_resp.success.return_value = True
+    mock_resp.data = mock_data
+
+    mock_client = MagicMock()
+    mock_client.im.v1.message.get.return_value = mock_resp
+
+    with patch(
+        "lark_oapi.api.im.v1.GetMessageRequest"
+    ) as MockReq:
+        MockReq.builder.return_value = mock_builder
+        result = await fetch_quoted_message(mock_client, "om_card")
+
+    assert result is not None
+    assert "[interactive message]" in result["content"]
+    assert result["sender_id"] == "ou_96f06d22c01e55dd7b8706fe2e314508"
+    assert result["sender_type"] == "app"
+    assert result["msg_type"] == "interactive"


### PR DESCRIPTION
## Summary
- Add `fetch_quoted_message()` that returns structured dict with `content`, `sender_id`, `sender_type`, `msg_type`
- `fetch_message_content()` now delegates to `fetch_quoted_message()` (backward compatible)
- Channel injects `self_identity` (`bot_name`, `bot_open_id`) into payload so the model always knows which agent it is
- Quoted messages now include sender info to distinguish between bots in multi-bot group chats

## Changes
- `src/bub_im_bridge/feishu/api.py`: New `fetch_quoted_message()` function; `fetch_message_content()` delegates to it
- `src/bub_im_bridge/feishu/channel.py`: Use `fetch_quoted_message()` for quoted messages; inject `self_identity` into payload
- `tests/test_api.py`: 2 new tests for `fetch_quoted_message()` sender info extraction

## Schema
Payload now includes:
```json
{
  "self_identity": {"name": "philip", "open_id": "ou_96f06d22c01e55dd7b8706fe2e314508"},
  "quoted_message": {
    "content": "...",
    "sender_id": "ou_xxx",
    "sender_type": "user|app",
    "msg_type": "text|interactive"
  }
}
```

## Test plan
- [x] All 6 tests pass
- [ ] Verify in multi-bot group chat that Philip can distinguish its own messages from other bots