### PR TITLE
feat: Feishu image messages produce MediaItem for vision pipeline

### DIFF
--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -619,18 +619,22 @@ class FeishuChannel(Channel):
         if message.image_key and self._api_client is not None:
             image_key = message.image_key
             client = self._api_client
+            cached: dict[str, bytes] = {}
 
             async def _fetch_image_data() -> bytes:
-                return await self._download_image(client, image_key)
+                if "data" not in cached:
+                    data, detected_mime = await self._download_image(client, image_key)
+                    cached["data"] = data
+                    item.mime_type = detected_mime
+                return cached["data"]
 
-            media_items.append(
-                MediaItem(
-                    type="image",
-                    mime_type="image/jpeg",
-                    filename=f"{image_key}.jpg",
-                    data_fetcher=_fetch_image_data,
-                )
+            item = MediaItem(
+                type="image",
+                mime_type="image/jpeg",  # placeholder, updated on first download
+                filename=f"{image_key}.jpg",
+                data_fetcher=_fetch_image_data,
             )
+            media_items.append(item)
 
         return ChannelMessage(
             session_id=session_id,
@@ -642,10 +646,25 @@ class FeishuChannel(Channel):
             media=media_items,
         )
 
+    # Extension → MIME type mapping for Feishu image responses
+    _IMAGE_MIME_MAP: dict[str, str] = {
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".png": "image/png",
+        ".gif": "image/gif",
+        ".webp": "image/webp",
+        ".bmp": "image/bmp",
+    }
+
     async def _download_image(
         self, client: lark.Client, image_key: str
-    ) -> bytes:
-        """Download an image from Feishu by image_key via Lark API."""
+    ) -> tuple[bytes, str]:
+        """Download an image from Feishu by image_key via Lark API.
+
+        Returns (image_bytes, mime_type).  The mime type is derived from
+        the ``file_name`` in the API response when possible; falls back
+        to ``image/jpeg`` only when the extension is unrecognised.
+        """
         request = GetImageRequest.builder().image_key(image_key).build()
         response = await client.im.v1.image.aget(request)
         if not response.success():
@@ -658,7 +677,16 @@ class FeishuChannel(Channel):
             raise RuntimeError(
                 f"Feishu image download returned no file data for {image_key}"
             )
-        return file_obj.read()
+        data = file_obj.read()
+
+        # Detect mime type from response file_name
+        mime_type = "image/jpeg"  # conservative default
+        file_name: str | None = getattr(response, "file_name", None)
+        if file_name:
+            ext = Path(file_name).suffix.lower()
+            mime_type = self._IMAGE_MIME_MAP.get(ext, mime_type)
+
+        return data, mime_type
 
     def _send_queue_full_notification(self, message: FeishuInboundMessage) -> None:
         """Reply directly to the dropped message without touching ``_last_message_id``."""

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -20,13 +20,14 @@ from lark_oapi.api.im.v1 import (
     CreateMessageReactionRequestBody,
     CreateMessageRequest,
     CreateMessageRequestBody,
+    GetImageRequest,
     ReplyMessageRequest,
     ReplyMessageRequestBody,
 )
 from loguru import logger
 
 from bub.channels.base import Channel
-from bub.channels.message import ChannelMessage
+from bub.channels.message import ChannelMessage, MediaItem
 from bub.framework import BubFramework
 from bub.types import MessageHandler
 
@@ -83,6 +84,8 @@ class FeishuInboundMessage:
     mentions: tuple[FeishuMention, ...] = ()
     parent_id: str | None = None
     root_id: str | None = None
+
+    image_key: str | None = None
 
     sender_open_id: str | None = None
     sender_union_id: str | None = None
@@ -611,6 +614,24 @@ class FeishuChannel(Channel):
             context["_feishu_api_client"] = self._api_client
         context["_profile_store"] = self._profile_store
 
+        # Build media list for image messages
+        media_items: list[MediaItem] = []
+        if message.image_key and self._api_client is not None:
+            image_key = message.image_key
+            client = self._api_client
+
+            async def _fetch_image_data() -> bytes:
+                return await self._download_image(client, image_key)
+
+            media_items.append(
+                MediaItem(
+                    type="image",
+                    mime_type="image/jpeg",
+                    filename=f"{image_key}.jpg",
+                    data_fetcher=_fetch_image_data,
+                )
+            )
+
         return ChannelMessage(
             session_id=session_id,
             channel=self.name,
@@ -618,7 +639,26 @@ class FeishuChannel(Channel):
             content=json.dumps(payload, ensure_ascii=False),
             is_active=True,
             context=context,
+            media=media_items,
         )
+
+    async def _download_image(
+        self, client: lark.Client, image_key: str
+    ) -> bytes:
+        """Download an image from Feishu by image_key via Lark API."""
+        request = GetImageRequest.builder().image_key(image_key).build()
+        response = await client.im.v1.image.aget(request)
+        if not response.success():
+            raise RuntimeError(
+                f"Feishu image download failed: code={response.code}, "
+                f"msg={response.msg}, log_id={response.get_log_id()}"
+            )
+        file_obj = response.file
+        if file_obj is None:
+            raise RuntimeError(
+                f"Feishu image download returned no file data for {image_key}"
+            )
+        return file_obj.read()
 
     def _send_queue_full_notification(self, message: FeishuInboundMessage) -> None:
         """Reply directly to the dropped message without touching ``_last_message_id``."""
@@ -897,6 +937,16 @@ def _parse_event(payload: dict[str, Any]) -> FeishuInboundMessage | None:
     raw_content = str(raw_message.get("content") or "")
     text = _normalize_text(msg_type, raw_content)
 
+    # Extract image_key for image messages before normalization loses it
+    image_key: str | None = None
+    if msg_type == "image":
+        try:
+            content_obj = json.loads(raw_content)
+            if isinstance(content_obj, dict):
+                image_key = content_obj.get("image_key")
+        except (json.JSONDecodeError, AttributeError):
+            pass
+
     # Replace mention placeholder keys with display names
     for m in mentions:
         if m.key and m.name:
@@ -923,6 +973,7 @@ def _parse_event(payload: dict[str, Any]) -> FeishuInboundMessage | None:
         sender_type=raw_sender.get("sender_type"),
         tenant_key=raw_sender.get("tenant_key"),
         create_time=str(raw_message.get("create_time") or ""),
+        image_key=image_key,
     )
 
 

--- a/tests/test_feishu_image_media.py
+++ b/tests/test_feishu_image_media.py
@@ -218,12 +218,10 @@ class TestMediaItemGetUrl:
         """MediaItem.get_url() should call data_fetcher and return a data: URI."""
         channel = _make_channel(tmp_path)
 
-        # Create a mock API client
         mock_client = MagicMock()
         channel._api_client = mock_client
 
-        # Mock the image download response
-        fake_image_bytes = b"\xff\xd8\xff\xe0" + b"\x00" * 100  # fake JPEG header
+        fake_image_bytes = b"\xff\xd8\xff\xe0" + b"\x00" * 100  # fake JPEG bytes
         mock_file = io.BytesIO(fake_image_bytes)
 
         mock_response = MagicMock()
@@ -233,7 +231,6 @@ class TestMediaItemGetUrl:
 
         mock_client.im.v1.image.aget = AsyncMock(return_value=mock_response)
 
-        # Build message with image
         raw = _make_raw_image_event(image_key="img_v3_fetch_test")
         msg = _parse_event(raw)
         assert msg is not None
@@ -245,12 +242,102 @@ class TestMediaItemGetUrl:
         assert len(channel_msg.media) == 1
         item = channel_msg.media[0]
 
-        # Call get_url — this should trigger the lazy download
         url = await item.get_url()
 
         assert url is not None
         assert url.startswith("data:image/jpeg;base64,")
+        assert item.mime_type == "image/jpeg"
         mock_client.im.v1.image.aget.assert_called_once()
+
+    async def test_png_response_produces_correct_data_uri(self, tmp_path: Path):
+        """Regression: a PNG response must NOT produce data:image/jpeg prefix."""
+        channel = _make_channel(tmp_path)
+
+        mock_client = MagicMock()
+        channel._api_client = mock_client
+
+        png_header = b"\x89PNG\r\n\x1a\n" + b"\x00" * 50
+        mock_file = io.BytesIO(png_header)
+
+        mock_response = MagicMock()
+        mock_response.success.return_value = True
+        mock_response.file = mock_file
+        mock_response.file_name = "screenshot.png"
+
+        mock_client.im.v1.image.aget = AsyncMock(return_value=mock_response)
+
+        raw = _make_raw_image_event(image_key="img_v3_png")
+        msg = _parse_event(raw)
+        assert msg is not None
+
+        channel_msg = await channel._build_channel_message(
+            msg, msg.text, "ou_sender", "feishu:chat_001"
+        )
+
+        item = channel_msg.media[0]
+        url = await item.get_url()
+
+        assert url.startswith("data:image/png;base64,")
+        assert item.mime_type == "image/png"
+
+    async def test_webp_response_produces_correct_data_uri(self, tmp_path: Path):
+        """WebP response should produce data:image/webp prefix."""
+        channel = _make_channel(tmp_path)
+
+        mock_client = MagicMock()
+        channel._api_client = mock_client
+
+        mock_file = io.BytesIO(b"RIFF\x00\x00\x00\x00WEBP" + b"\x00" * 20)
+
+        mock_response = MagicMock()
+        mock_response.success.return_value = True
+        mock_response.file = mock_file
+        mock_response.file_name = "photo.webp"
+
+        mock_client.im.v1.image.aget = AsyncMock(return_value=mock_response)
+
+        raw = _make_raw_image_event(image_key="img_v3_webp")
+        msg = _parse_event(raw)
+        assert msg is not None
+
+        channel_msg = await channel._build_channel_message(
+            msg, msg.text, "ou_sender", "feishu:chat_001"
+        )
+
+        item = channel_msg.media[0]
+        url = await item.get_url()
+
+        assert url.startswith("data:image/webp;base64,")
+        assert item.mime_type == "image/webp"
+
+    async def test_unknown_extension_falls_back_to_jpeg(self, tmp_path: Path):
+        """Unknown extension should fall back to image/jpeg."""
+        channel = _make_channel(tmp_path)
+
+        mock_client = MagicMock()
+        channel._api_client = mock_client
+
+        mock_file = io.BytesIO(b"\x00" * 10)
+
+        mock_response = MagicMock()
+        mock_response.success.return_value = True
+        mock_response.file = mock_file
+        mock_response.file_name = "image.xyz"
+
+        mock_client.im.v1.image.aget = AsyncMock(return_value=mock_response)
+
+        raw = _make_raw_image_event(image_key="img_v3_unknown")
+        msg = _parse_event(raw)
+        assert msg is not None
+
+        channel_msg = await channel._build_channel_message(
+            msg, msg.text, "ou_sender", "feishu:chat_001"
+        )
+
+        item = channel_msg.media[0]
+        url = await item.get_url()
+
+        assert url.startswith("data:image/jpeg;base64,")
 
     async def test_get_url_propagates_download_error(self, tmp_path: Path):
         """When download fails, get_url() should propagate the error."""

--- a/tests/test_feishu_image_media.py
+++ b/tests/test_feishu_image_media.py
@@ -1,0 +1,281 @@
+"""Tests for Feishu image message MediaItem creation.
+
+Validates that:
+- _parse_event extracts image_key from image messages
+- _build_channel_message creates MediaItem with data_fetcher for image messages
+- text-only messages produce empty media list
+- MediaItem.get_url() lazily downloads via Feishu API
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bub.channels.message import MediaItem
+
+from bub_im_bridge.feishu.channel import (
+    FeishuChannel,
+    FeishuInboundMessage,
+    _parse_event,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_raw_image_event(
+    *,
+    image_key: str = "img_v3_abc123",
+    sender_open_id: str = "ou_sender",
+    sender_name: str = "张三",
+    chat_type: str = "p2p",
+) -> dict:
+    """Build a minimal raw Feishu event dict for an image message."""
+    content = json.dumps({"image_key": image_key})
+
+    return {
+        "event": {
+            "sender": {
+                "sender_id": {
+                    "open_id": sender_open_id,
+                    "union_id": "on_sender",
+                    "user_id": "sender_uid",
+                },
+                "sender_type": "user",
+                "name": sender_name,
+                "tenant_key": "tenant",
+            },
+            "message": {
+                "message_id": "msg_img_001",
+                "chat_id": "chat_001",
+                "chat_type": chat_type,
+                "message_type": "image",
+                "content": content,
+                "create_time": "1714000000000",
+            },
+        }
+    }
+
+
+def _make_raw_text_event(
+    *,
+    text: str = "hello",
+    sender_open_id: str = "ou_sender",
+    sender_name: str = "张三",
+    chat_type: str = "p2p",
+) -> dict:
+    """Build a minimal raw Feishu event dict for a text message."""
+    content = json.dumps({"text": text})
+
+    return {
+        "event": {
+            "sender": {
+                "sender_id": {
+                    "open_id": sender_open_id,
+                    "union_id": "on_sender",
+                    "user_id": "sender_uid",
+                },
+                "sender_type": "user",
+                "name": sender_name,
+                "tenant_key": "tenant",
+            },
+            "message": {
+                "message_id": "msg_text_001",
+                "chat_id": "chat_001",
+                "chat_type": chat_type,
+                "message_type": "text",
+                "content": content,
+                "create_time": "1714000000000",
+            },
+        }
+    }
+
+
+def _make_channel(tmp_path: Path) -> FeishuChannel:
+    """Create a minimal FeishuChannel for testing (no real WS connection)."""
+    framework = MagicMock()
+    framework.workspace = tmp_path
+    channel = FeishuChannel(on_receive=AsyncMock(), framework=framework)
+    return channel
+
+
+# ---------------------------------------------------------------------------
+# _parse_event: image_key extraction
+# ---------------------------------------------------------------------------
+
+
+class TestParseEventImageKey:
+    """Verify _parse_event extracts image_key from image messages."""
+
+    def test_image_message_extracts_image_key(self):
+        raw = _make_raw_image_event(image_key="img_v3_test_key")
+        msg = _parse_event(raw)
+        assert msg is not None
+        assert msg.image_key == "img_v3_test_key"
+        assert msg.message_type == "image"
+
+    def test_text_message_has_no_image_key(self):
+        raw = _make_raw_text_event()
+        msg = _parse_event(raw)
+        assert msg is not None
+        assert msg.image_key is None
+
+    def test_image_message_with_malformed_content_has_no_image_key(self):
+        """Malformed JSON content should not crash, just leave image_key as None."""
+        raw = _make_raw_image_event()
+        raw["event"]["message"]["content"] = "not-json"
+        msg = _parse_event(raw)
+        assert msg is not None
+        assert msg.image_key is None
+
+    def test_image_message_with_empty_content_has_no_image_key(self):
+        raw = _make_raw_image_event()
+        raw["event"]["message"]["content"] = ""
+        msg = _parse_event(raw)
+        assert msg is not None
+        assert msg.image_key is None
+
+
+# ---------------------------------------------------------------------------
+# _build_channel_message: MediaItem creation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestBuildChannelMessageMedia:
+    """Verify _build_channel_message creates MediaItem for image messages."""
+
+    async def test_image_message_produces_media_item(self, tmp_path: Path):
+        """Image messages should produce a MediaItem with data_fetcher."""
+        channel = _make_channel(tmp_path)
+        channel._api_client = MagicMock()  # simulate initialized client
+
+        raw = _make_raw_image_event(image_key="img_v3_xyz")
+        msg = _parse_event(raw)
+        assert msg is not None
+
+        channel_msg = await channel._build_channel_message(
+            msg, msg.text, "ou_sender", "feishu:chat_001"
+        )
+
+        assert len(channel_msg.media) == 1
+        item = channel_msg.media[0]
+        assert item.type == "image"
+        assert item.mime_type == "image/jpeg"
+        assert item.filename == "img_v3_xyz.jpg"
+        assert item.url is None  # lazy download, no direct URL
+        assert item.data_fetcher is not None
+
+    async def test_text_message_has_empty_media(self, tmp_path: Path):
+        """Text-only messages should have an empty media list."""
+        channel = _make_channel(tmp_path)
+
+        raw = _make_raw_text_event()
+        msg = _parse_event(raw)
+        assert msg is not None
+
+        channel_msg = await channel._build_channel_message(
+            msg, msg.text, "ou_sender", "feishu:chat_001"
+        )
+
+        assert channel_msg.media == []
+
+    async def test_image_message_without_api_client_has_empty_media(
+        self, tmp_path: Path
+    ):
+        """When API client is None, image message should have empty media (no crash)."""
+        channel = _make_channel(tmp_path)
+        channel._api_client = None
+
+        raw = _make_raw_image_event(image_key="img_v3_no_client")
+        msg = _parse_event(raw)
+        assert msg is not None
+
+        channel_msg = await channel._build_channel_message(
+            msg, msg.text, "ou_sender", "feishu:chat_001"
+        )
+
+        assert channel_msg.media == []
+
+
+# ---------------------------------------------------------------------------
+# MediaItem.get_url() lazy download
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestMediaItemGetUrl:
+    """Verify MediaItem.get_url() lazily downloads via Feishu API."""
+
+    async def test_get_url_calls_data_fetcher_and_returns_data_uri(self, tmp_path: Path):
+        """MediaItem.get_url() should call data_fetcher and return a data: URI."""
+        channel = _make_channel(tmp_path)
+
+        # Create a mock API client
+        mock_client = MagicMock()
+        channel._api_client = mock_client
+
+        # Mock the image download response
+        fake_image_bytes = b"\xff\xd8\xff\xe0" + b"\x00" * 100  # fake JPEG header
+        mock_file = io.BytesIO(fake_image_bytes)
+
+        mock_response = MagicMock()
+        mock_response.success.return_value = True
+        mock_response.file = mock_file
+        mock_response.file_name = "test.jpg"
+
+        mock_client.im.v1.image.aget = AsyncMock(return_value=mock_response)
+
+        # Build message with image
+        raw = _make_raw_image_event(image_key="img_v3_fetch_test")
+        msg = _parse_event(raw)
+        assert msg is not None
+
+        channel_msg = await channel._build_channel_message(
+            msg, msg.text, "ou_sender", "feishu:chat_001"
+        )
+
+        assert len(channel_msg.media) == 1
+        item = channel_msg.media[0]
+
+        # Call get_url — this should trigger the lazy download
+        url = await item.get_url()
+
+        assert url is not None
+        assert url.startswith("data:image/jpeg;base64,")
+        mock_client.im.v1.image.aget.assert_called_once()
+
+    async def test_get_url_propagates_download_error(self, tmp_path: Path):
+        """When download fails, get_url() should propagate the error."""
+        channel = _make_channel(tmp_path)
+
+        mock_client = MagicMock()
+        channel._api_client = mock_client
+
+        mock_response = MagicMock()
+        mock_response.success.return_value = False
+        mock_response.code = 230001
+        mock_response.msg = "image not found"
+        mock_response.get_log_id.return_value = "log_abc"
+
+        mock_client.im.v1.image.aget = AsyncMock(return_value=mock_response)
+
+        raw = _make_raw_image_event(image_key="img_v3_bad")
+        msg = _parse_event(raw)
+        assert msg is not None
+
+        channel_msg = await channel._build_channel_message(
+            msg, msg.text, "ou_sender", "feishu:chat_001"
+        )
+
+        item = channel_msg.media[0]
+
+        with pytest.raises(RuntimeError, match="image not found"):
+            await item.get_url()


### PR DESCRIPTION
## Summary

- Feishu image messages now create a standard `MediaItem` on `ChannelMessage.media`, enabling downstream plugins (e.g. philip's vision tool) to inspect image content through the unified bub media interface
- Image bytes are lazily downloaded via Lark API (`client.im.v1.image.aget`) through a `data_fetcher` closure — no eager download on message receipt
- Data URI MIME prefix is derived from the API response `file_name` extension (.png → `image/png`, .webp → `image/webp`, etc.), not hardcoded as `image/jpeg`

## Changes

**`src/bub_im_bridge/feishu/channel.py`:**
- `FeishuInboundMessage`: added `image_key` field
- `_parse_event`: extracts `image_key` from content JSON when `msg_type == "image"`
- `_build_channel_message`: creates `MediaItem(type="image", data_fetcher=...)` when `image_key` is present
- `_download_image`: new method — downloads via Lark API, returns `(bytes, mime_type)` with extension-based MIME detection

**`tests/test_feishu_image_media.py`** (12 tests):
- `_parse_event` image_key extraction (image, text, malformed JSON, empty content)
- `_build_channel_message` MediaItem creation (image message, text message, no API client)
- `MediaItem.get_url()` lazy download (JPEG, PNG, WebP, unknown extension fallback, API error propagation)

## Test plan

- [x] `pytest tests/test_feishu_image_media.py` → 12 passed
- [x] Full suite `pytest` → 92 passed, zero regressions
- [ ] Manual: send image in Feishu → verify model calls `vision.inspect_current_images` instead of `bash feishu fetch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)