### PR TITLE
feat: Feishu post + quoted message image support

### DIFF
--- a/src/bub_im_bridge/feishu/api.py
+++ b/src/bub_im_bridge/feishu/api.py
@@ -95,11 +95,31 @@ async def fetch_quoted_message(
             sender_id = getattr(sender, "id", "") or ""
             sender_type = getattr(sender, "sender_type", "") or ""
 
+        # Extract image keys from the quoted message
+        image_keys: list[str] = []
+        with contextlib.suppress(json.JSONDecodeError, AttributeError, TypeError):
+            content_obj = json.loads(content)
+            if isinstance(content_obj, dict):
+                if msg_type == "image":
+                    ik = content_obj.get("image_key")
+                    if ik:
+                        image_keys.append(ik)
+                elif msg_type == "post":
+                    for paragraph in content_obj.get("content", []):
+                        if not isinstance(paragraph, list):
+                            continue
+                        for element in paragraph:
+                            if isinstance(element, dict) and element.get("tag") == "img":
+                                ik = element.get("image_key")
+                                if ik:
+                                    image_keys.append(ik)
+
         return {
             "content": text,
             "sender_id": sender_id,
             "sender_type": sender_type,
             "msg_type": msg_type,
+            "image_keys": image_keys,
         }
 
     except Exception:

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -616,8 +616,10 @@ class FeishuChannel(Channel):
 
         # Build media list for image messages
         media_items: list[MediaItem] = []
-        if message.image_keys and self._api_client is not None:
+        if self._api_client is not None:
             client = self._api_client
+
+            # Current message images
             for image_key in message.image_keys:
                 cached: dict[str, bytes] = {}
                 ik = image_key  # capture for closure
@@ -636,6 +638,32 @@ class FeishuChannel(Channel):
                     data_fetcher=_fetch_image_data,
                 )
                 media_items.append(_item)
+
+            # Quoted message images (from the replied-to message)
+            if quoted_message and quoted_message.get("image_keys"):
+                quoted_keys = quoted_message["image_keys"]
+                for image_key in quoted_keys:
+                    cached: dict[str, bytes] = {}
+                    ik = image_key
+
+                    async def _fetch_quoted_data(ikey: str = ik, _c: dict = cached) -> bytes:
+                        if "data" not in _c:
+                            data, detected_mime = await self._download_image(client, ikey)
+                            _c["data"] = data
+                            _qi.mime_type = detected_mime
+                        return _c["data"]
+
+                    _qi = MediaItem(
+                        type="image",
+                        mime_type="image/jpeg",
+                        filename=f"quoted:{ik}.jpg",
+                        data_fetcher=_fetch_quoted_data,
+                    )
+                    media_items.append(_qi)
+
+                # Signal in payload that quoted images exist
+                payload["has_quoted_images"] = True
+                payload["quoted_image_count"] = len(quoted_keys)
 
         return ChannelMessage(
             session_id=session_id,

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -624,19 +624,22 @@ class FeishuChannel(Channel):
                 cached: dict[str, bytes] = {}
                 ik = image_key  # capture for closure
 
-                async def _fetch_image_data(ikey: str = ik, _c: dict = cached) -> bytes:
-                    if "data" not in _c:
-                        data, detected_mime = await self._download_image(client, ikey)
-                        _c["data"] = data
-                        _item.mime_type = detected_mime
-                    return _c["data"]
-
                 _item = MediaItem(
                     type="image",
                     mime_type="image/jpeg",  # placeholder, updated on first download
                     filename=f"{ik}.jpg",
-                    data_fetcher=_fetch_image_data,
                 )
+
+                async def _fetch_image_data(
+                    ikey: str = ik, _c: dict = cached, _mi: MediaItem = _item
+                ) -> bytes:
+                    if "data" not in _c:
+                        data, detected_mime = await self._download_image(client, ikey)
+                        _c["data"] = data
+                        _mi.mime_type = detected_mime
+                    return _c["data"]
+
+                _item.data_fetcher = _fetch_image_data
                 media_items.append(_item)
 
             # Quoted message images (from the replied-to message)
@@ -646,19 +649,22 @@ class FeishuChannel(Channel):
                     cached: dict[str, bytes] = {}
                     ik = image_key
 
-                    async def _fetch_quoted_data(ikey: str = ik, _c: dict = cached) -> bytes:
-                        if "data" not in _c:
-                            data, detected_mime = await self._download_image(client, ikey)
-                            _c["data"] = data
-                            _qi.mime_type = detected_mime
-                        return _c["data"]
-
                     _qi = MediaItem(
                         type="image",
                         mime_type="image/jpeg",
                         filename=f"quoted:{ik}.jpg",
-                        data_fetcher=_fetch_quoted_data,
                     )
+
+                    async def _fetch_quoted_data(
+                        ikey: str = ik, _c: dict = cached, _mi: MediaItem = _qi
+                    ) -> bytes:
+                        if "data" not in _c:
+                            data, detected_mime = await self._download_image(client, ikey)
+                            _c["data"] = data
+                            _mi.mime_type = detected_mime
+                        return _c["data"]
+
+                    _qi.data_fetcher = _fetch_quoted_data
                     media_items.append(_qi)
 
                 # Signal in payload that quoted images exist

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -85,7 +85,7 @@ class FeishuInboundMessage:
     parent_id: str | None = None
     root_id: str | None = None
 
-    image_key: str | None = None
+    image_keys: list[str] = field(default_factory=list)
 
     sender_open_id: str | None = None
     sender_union_id: str | None = None
@@ -616,25 +616,26 @@ class FeishuChannel(Channel):
 
         # Build media list for image messages
         media_items: list[MediaItem] = []
-        if message.image_key and self._api_client is not None:
-            image_key = message.image_key
+        if message.image_keys and self._api_client is not None:
             client = self._api_client
-            cached: dict[str, bytes] = {}
+            for image_key in message.image_keys:
+                cached: dict[str, bytes] = {}
+                ik = image_key  # capture for closure
 
-            async def _fetch_image_data() -> bytes:
-                if "data" not in cached:
-                    data, detected_mime = await self._download_image(client, image_key)
-                    cached["data"] = data
-                    item.mime_type = detected_mime
-                return cached["data"]
+                async def _fetch_image_data(ikey: str = ik, _c: dict = cached) -> bytes:
+                    if "data" not in _c:
+                        data, detected_mime = await self._download_image(client, ikey)
+                        _c["data"] = data
+                        _item.mime_type = detected_mime
+                    return _c["data"]
 
-            item = MediaItem(
-                type="image",
-                mime_type="image/jpeg",  # placeholder, updated on first download
-                filename=f"{image_key}.jpg",
-                data_fetcher=_fetch_image_data,
-            )
-            media_items.append(item)
+                _item = MediaItem(
+                    type="image",
+                    mime_type="image/jpeg",  # placeholder, updated on first download
+                    filename=f"{ik}.jpg",
+                    data_fetcher=_fetch_image_data,
+                )
+                media_items.append(_item)
 
         return ChannelMessage(
             session_id=session_id,
@@ -965,15 +966,31 @@ def _parse_event(payload: dict[str, Any]) -> FeishuInboundMessage | None:
     raw_content = str(raw_message.get("content") or "")
     text = _normalize_text(msg_type, raw_content)
 
-    # Extract image_key for image messages before normalization loses it
-    image_key: str | None = None
-    if msg_type == "image":
-        try:
-            content_obj = json.loads(raw_content)
-            if isinstance(content_obj, dict):
-                image_key = content_obj.get("image_key")
-        except (json.JSONDecodeError, AttributeError):
-            pass
+    # Extract image keys from message content.
+    # - msg_type "image": top-level image_key
+    # - msg_type "post": scan nested content for {"tag":"img","image_key":...}
+    image_keys: list[str] = []
+    try:
+        content_obj = json.loads(raw_content)
+        if isinstance(content_obj, dict):
+            if msg_type == "image":
+                ik = content_obj.get("image_key")
+                if ik:
+                    image_keys.append(ik)
+            elif msg_type == "post":
+                # post content structure: {"title":"...","content":[[{"tag":"img","image_key":"..."},...]]}
+                for paragraph in content_obj.get("content", []):
+                    if not isinstance(paragraph, list):
+                        continue
+                    for element in paragraph:
+                        if not isinstance(element, dict):
+                            continue
+                        if element.get("tag") == "img":
+                            ik = element.get("image_key")
+                            if ik:
+                                image_keys.append(ik)
+    except (json.JSONDecodeError, AttributeError, TypeError):
+        pass
 
     # Replace mention placeholder keys with display names
     for m in mentions:
@@ -1001,7 +1018,7 @@ def _parse_event(payload: dict[str, Any]) -> FeishuInboundMessage | None:
         sender_type=raw_sender.get("sender_type"),
         tenant_key=raw_sender.get("tenant_key"),
         create_time=str(raw_message.get("create_time") or ""),
-        image_key=image_key,
+        image_keys=image_keys,
     )
 
 

--- a/tests/test_feishu_image_media.py
+++ b/tests/test_feishu_image_media.py
@@ -2,6 +2,7 @@
 
 Validates that:
 - _parse_event extracts image_key from image messages
+- _parse_event extracts embedded image_keys from post messages
 - _build_channel_message creates MediaItem with data_fetcher for image messages
 - text-only messages produce empty media list
 - MediaItem.get_url() lazily downloads via Feishu API
@@ -64,6 +65,49 @@ def _make_raw_image_event(
     }
 
 
+def _make_raw_post_event(
+    *,
+    elements: list[list[dict]] | None = None,
+    sender_open_id: str = "ou_sender",
+    sender_name: str = "张三",
+    chat_type: str = "p2p",
+) -> dict:
+    """Build a minimal raw Feishu event dict for a post (rich text) message."""
+    if elements is None:
+        elements = [[
+            {"tag": "text", "text": "看看这张图 "},
+            {"tag": "img", "image_key": "img_v3_post_001"},
+        ]]
+
+    content = json.dumps({
+        "title": "",
+        "content": elements,
+    })
+
+    return {
+        "event": {
+            "sender": {
+                "sender_id": {
+                    "open_id": sender_open_id,
+                    "union_id": "on_sender",
+                    "user_id": "sender_uid",
+                },
+                "sender_type": "user",
+                "name": sender_name,
+                "tenant_key": "tenant",
+            },
+            "message": {
+                "message_id": "msg_post_001",
+                "chat_id": "chat_001",
+                "chat_type": chat_type,
+                "message_type": "post",
+                "content": content,
+                "create_time": "1714000000000",
+            },
+        }
+    }
+
+
 def _make_raw_text_event(
     *,
     text: str = "hello",
@@ -107,7 +151,7 @@ def _make_channel(tmp_path: Path) -> FeishuChannel:
 
 
 # ---------------------------------------------------------------------------
-# _parse_event: image_key extraction
+# _parse_event: image_key extraction (image messages)
 # ---------------------------------------------------------------------------
 
 
@@ -118,29 +162,90 @@ class TestParseEventImageKey:
         raw = _make_raw_image_event(image_key="img_v3_test_key")
         msg = _parse_event(raw)
         assert msg is not None
-        assert msg.image_key == "img_v3_test_key"
+        assert msg.image_keys == ["img_v3_test_key"]
         assert msg.message_type == "image"
 
-    def test_text_message_has_no_image_key(self):
+    def test_text_message_has_no_image_keys(self):
         raw = _make_raw_text_event()
         msg = _parse_event(raw)
         assert msg is not None
-        assert msg.image_key is None
+        assert msg.image_keys == []
 
-    def test_image_message_with_malformed_content_has_no_image_key(self):
-        """Malformed JSON content should not crash, just leave image_key as None."""
+    def test_image_message_with_malformed_content_has_no_image_keys(self):
+        """Malformed JSON content should not crash, just leave image_keys empty."""
         raw = _make_raw_image_event()
         raw["event"]["message"]["content"] = "not-json"
         msg = _parse_event(raw)
         assert msg is not None
-        assert msg.image_key is None
+        assert msg.image_keys == []
 
-    def test_image_message_with_empty_content_has_no_image_key(self):
+    def test_image_message_with_empty_content_has_no_image_keys(self):
         raw = _make_raw_image_event()
         raw["event"]["message"]["content"] = ""
         msg = _parse_event(raw)
         assert msg is not None
-        assert msg.image_key is None
+        assert msg.image_keys == []
+
+
+# ---------------------------------------------------------------------------
+# _parse_event: image_key extraction (post messages)
+# ---------------------------------------------------------------------------
+
+
+class TestParseEventPostImageKey:
+    """Verify _parse_event extracts embedded image_keys from post messages."""
+
+    def test_post_message_extracts_single_image(self):
+        raw = _make_raw_post_event(elements=[[
+            {"tag": "text", "text": "看看 "},
+            {"tag": "img", "image_key": "img_v3_post_single"},
+        ]])
+        msg = _parse_event(raw)
+        assert msg is not None
+        assert msg.image_keys == ["img_v3_post_single"]
+        assert msg.message_type == "post"
+
+    def test_post_message_extracts_multiple_images(self):
+        raw = _make_raw_post_event(elements=[
+            [
+                {"tag": "text", "text": "第一张 "},
+                {"tag": "img", "image_key": "img_v3_post_001"},
+            ],
+            [
+                {"tag": "text", "text": "第二张 "},
+                {"tag": "img", "image_key": "img_v3_post_002"},
+            ],
+        ])
+        msg = _parse_event(raw)
+        assert msg is not None
+        assert msg.image_keys == ["img_v3_post_001", "img_v3_post_002"]
+
+    def test_post_message_with_no_images_has_empty_keys(self):
+        raw = _make_raw_post_event(elements=[[
+            {"tag": "text", "text": "纯文字，没有图片"},
+        ]])
+        msg = _parse_event(raw)
+        assert msg is not None
+        assert msg.image_keys == []
+
+    def test_post_message_with_mixed_elements(self):
+        """Post with text, at, and img tags in a single paragraph."""
+        raw = _make_raw_post_event(elements=[[
+            {"tag": "text", "text": "分析 "},
+            {"tag": "at", "user_id": "ou_123"},
+            {"tag": "text", "text": " 这张截图 "},
+            {"tag": "img", "image_key": "img_v3_mixed"},
+        ]])
+        msg = _parse_event(raw)
+        assert msg is not None
+        assert msg.image_keys == ["img_v3_mixed"]
+
+    def test_post_message_with_malformed_content_is_safe(self):
+        raw = _make_raw_post_event()
+        raw["event"]["message"]["content"] = "not-json"
+        msg = _parse_event(raw)
+        assert msg is not None
+        assert msg.image_keys == []
 
 
 # ---------------------------------------------------------------------------
@@ -155,7 +260,7 @@ class TestBuildChannelMessageMedia:
     async def test_image_message_produces_media_item(self, tmp_path: Path):
         """Image messages should produce a MediaItem with data_fetcher."""
         channel = _make_channel(tmp_path)
-        channel._api_client = MagicMock()  # simulate initialized client
+        channel._api_client = MagicMock()
 
         raw = _make_raw_image_event(image_key="img_v3_xyz")
         msg = _parse_event(raw)
@@ -170,8 +275,36 @@ class TestBuildChannelMessageMedia:
         assert item.type == "image"
         assert item.mime_type == "image/jpeg"
         assert item.filename == "img_v3_xyz.jpg"
-        assert item.url is None  # lazy download, no direct URL
+        assert item.url is None
         assert item.data_fetcher is not None
+
+    async def test_post_message_produces_media_items(self, tmp_path: Path):
+        """Post messages with embedded images should produce MediaItems."""
+        channel = _make_channel(tmp_path)
+        channel._api_client = MagicMock()
+
+        raw = _make_raw_post_event(elements=[
+            [
+                {"tag": "text", "text": "第一张 "},
+                {"tag": "img", "image_key": "img_v3_aaa"},
+            ],
+            [
+                {"tag": "img", "image_key": "img_v3_bbb"},
+            ],
+        ])
+        msg = _parse_event(raw)
+        assert msg is not None
+
+        channel_msg = await channel._build_channel_message(
+            msg, msg.text, "ou_sender", "feishu:chat_001"
+        )
+
+        assert len(channel_msg.media) == 2
+        assert channel_msg.media[0].filename == "img_v3_aaa.jpg"
+        assert channel_msg.media[1].filename == "img_v3_bbb.jpg"
+        for item in channel_msg.media:
+            assert item.type == "image"
+            assert item.data_fetcher is not None
 
     async def test_text_message_has_empty_media(self, tmp_path: Path):
         """Text-only messages should have an empty media list."""

--- a/tests/test_feishu_image_media.py
+++ b/tests/test_feishu_image_media.py
@@ -470,6 +470,61 @@ class TestQuotedMessageImages:
         assert "img_v3_current.jpg" in filenames
         assert "quoted:img_v3_quoted.jpg" in filenames
 
+    async def test_multi_image_mime_does_not_cross_contaminate(self, tmp_path: Path):
+        """Regression: each image's mime_type must reflect its own download,
+        not the last image downloaded (late-binding closure bug)."""
+        channel = _make_channel(tmp_path)
+
+        mock_client = MagicMock()
+        channel._api_client = mock_client
+
+        # Two images: first is PNG, second is WebP
+        png_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 20
+        webp_bytes = b"RIFF\x00\x00\x00\x00WEBP" + b"\x00" * 20
+
+        call_count = 0
+
+        async def mock_aget(request):
+            nonlocal call_count
+            call_count += 1
+            resp = MagicMock()
+            resp.success.return_value = True
+            if call_count == 1:
+                resp.file = io.BytesIO(png_bytes)
+                resp.file_name = "first.png"
+            else:
+                resp.file = io.BytesIO(webp_bytes)
+                resp.file_name = "second.webp"
+            return resp
+
+        mock_client.im.v1.image.aget = mock_aget
+
+        raw = _make_raw_post_event(elements=[
+            [{"tag": "img", "image_key": "img_png"}],
+            [{"tag": "img", "image_key": "img_webp"}],
+        ])
+        msg = _parse_event(raw)
+        assert msg is not None
+
+        channel_msg = await channel._build_channel_message(
+            msg, msg.text, "ou_sender", "feishu:chat_001"
+        )
+
+        assert len(channel_msg.media) == 2
+
+        # Download first image (PNG)
+        url0 = await channel_msg.media[0].get_url()
+        assert url0.startswith("data:image/png;base64,")
+        assert channel_msg.media[0].mime_type == "image/png"
+
+        # Download second image (WebP) — must NOT affect first image's mime_type
+        url1 = await channel_msg.media[1].get_url()
+        assert url1.startswith("data:image/webp;base64,")
+        assert channel_msg.media[1].mime_type == "image/webp"
+
+        # First image's mime_type must still be correct
+        assert channel_msg.media[0].mime_type == "image/png"
+
 
 # ---------------------------------------------------------------------------
 # MediaItem.get_url() lazy download

--- a/tests/test_feishu_image_media.py
+++ b/tests/test_feishu_image_media.py
@@ -339,6 +339,139 @@ class TestBuildChannelMessageMedia:
 
 
 # ---------------------------------------------------------------------------
+# _build_channel_message: quoted message images
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestQuotedMessageImages:
+    """Verify quoted message images are included in MediaItem list."""
+
+    async def test_quoted_image_message_produces_media_item(self, tmp_path: Path):
+        """When replying to an image message, its image should be in media."""
+        channel = _make_channel(tmp_path)
+        mock_client = MagicMock()
+        channel._api_client = mock_client
+
+        # Mock fetch_quoted_message to return an image message
+        with patch(
+            "bub_im_bridge.feishu.channel.fetch_quoted_message",
+            new_callable=AsyncMock,
+        ) as mock_fetch:
+            mock_fetch.return_value = {
+                "content": "[image message]",
+                "sender_id": "ou_quoted",
+                "sender_type": "user",
+                "msg_type": "image",
+                "image_keys": ["img_v3_quoted_001"],
+            }
+
+            raw = _make_raw_text_event()
+            raw["event"]["message"]["parent_id"] = "msg_parent"
+            msg = _parse_event(raw)
+            assert msg is not None
+
+            channel_msg = await channel._build_channel_message(
+                msg, msg.text, "ou_sender", "feishu:chat_001"
+            )
+
+        assert len(channel_msg.media) == 1
+        item = channel_msg.media[0]
+        assert item.type == "image"
+        assert item.filename == "quoted:img_v3_quoted_001.jpg"
+        assert item.data_fetcher is not None
+
+    async def test_payload_marks_quoted_images(self, tmp_path: Path):
+        """Payload should include has_quoted_images when quoted message has images."""
+        channel = _make_channel(tmp_path)
+        channel._api_client = MagicMock()
+
+        with patch(
+            "bub_im_bridge.feishu.channel.fetch_quoted_message",
+            new_callable=AsyncMock,
+        ) as mock_fetch:
+            mock_fetch.return_value = {
+                "content": "[image message]",
+                "sender_id": "ou_quoted",
+                "sender_type": "user",
+                "msg_type": "image",
+                "image_keys": ["img_v3_q1", "img_v3_q2"],
+            }
+
+            raw = _make_raw_text_event()
+            raw["event"]["message"]["parent_id"] = "msg_parent"
+            msg = _parse_event(raw)
+
+            channel_msg = await channel._build_channel_message(
+                msg, msg.text, "ou_sender", "feishu:chat_001"
+            )
+
+        payload = json.loads(channel_msg.content)
+        assert payload.get("has_quoted_images") is True
+        assert payload.get("quoted_image_count") == 2
+        assert len(channel_msg.media) == 2
+
+    async def test_no_quoted_images_when_quoted_has_none(self, tmp_path: Path):
+        """When quoted message has no images, media should be empty."""
+        channel = _make_channel(tmp_path)
+        channel._api_client = MagicMock()
+
+        with patch(
+            "bub_im_bridge.feishu.channel.fetch_quoted_message",
+            new_callable=AsyncMock,
+        ) as mock_fetch:
+            mock_fetch.return_value = {
+                "content": "just text reply",
+                "sender_id": "ou_quoted",
+                "sender_type": "user",
+                "msg_type": "text",
+                "image_keys": [],
+            }
+
+            raw = _make_raw_text_event()
+            raw["event"]["message"]["parent_id"] = "msg_parent"
+            msg = _parse_event(raw)
+
+            channel_msg = await channel._build_channel_message(
+                msg, msg.text, "ou_sender", "feishu:chat_001"
+            )
+
+        assert channel_msg.media == []
+        payload = json.loads(channel_msg.content)
+        assert "has_quoted_images" not in payload
+
+    async def test_current_and_quoted_images_both_in_media(self, tmp_path: Path):
+        """Both current message images and quoted images should be in media list."""
+        channel = _make_channel(tmp_path)
+        channel._api_client = MagicMock()
+
+        with patch(
+            "bub_im_bridge.feishu.channel.fetch_quoted_message",
+            new_callable=AsyncMock,
+        ) as mock_fetch:
+            mock_fetch.return_value = {
+                "content": "[image message]",
+                "sender_id": "ou_quoted",
+                "sender_type": "user",
+                "msg_type": "image",
+                "image_keys": ["img_v3_quoted"],
+            }
+
+            raw = _make_raw_image_event(image_key="img_v3_current")
+            raw["event"]["message"]["parent_id"] = "msg_parent"
+            msg = _parse_event(raw)
+
+            channel_msg = await channel._build_channel_message(
+                msg, msg.text, "ou_sender", "feishu:chat_001"
+            )
+
+        assert len(channel_msg.media) == 2
+        filenames = {item.filename for item in channel_msg.media}
+        assert "img_v3_current.jpg" in filenames
+        assert "quoted:img_v3_quoted.jpg" in filenames
+
+
+# ---------------------------------------------------------------------------
 # MediaItem.get_url() lazy download
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Extends the Feishu image MediaItem pipeline (PR #54) to cover two additional message types:

1. **Post (rich text) messages**: Extracts embedded `{"tag":"img","image_key":"..."}` elements from Feishu post content. Supports multiple images per message.

2. **Quoted message images**: When replying to a message that contains images, those images are also included in `ChannelMessage.media` with `quoted:` filename prefix for disambiguation.

## Changes

**`src/bub_im_bridge/feishu/api.py`:**
- `fetch_quoted_message` now extracts `image_keys` from quoted message content (both `image` and `post` types)

**`src/bub_im_bridge/feishu/channel.py`:**
- `FeishuInboundMessage.image_key` → `image_keys: list[str]` (supports multiple images)
- `_parse_event` scans post content JSON for all `tag=img` elements
- `_build_channel_message` creates MediaItems for both current and quoted images
- Payload includes `has_quoted_images` / `quoted_image_count` when quoted images exist

**`tests/test_feishu_image_media.py`** (22 tests, 102 total):
- Post message parsing: single image, multiple images, no images, mixed elements, malformed content
- Quoted message images: creates MediaItem, payload marks, no-quoted-images, current+quoted combined
- MIME type detection: JPEG, PNG, WebP, unknown fallback

## Test plan

- [x] `pytest tests/test_feishu_image_media.py` → 22 passed
- [x] Full suite `pytest` → 102 passed, zero regressions
- [ ] Manual: send post with embedded image → verify vision tool processes it
- [ ] Manual: reply to image message → verify quoted image is accessible via vision tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)