### PR TITLE
fix: use GetMessageResourceRequest for user-sent image download

### DIFF
--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -20,7 +20,7 @@ from lark_oapi.api.im.v1 import (
     CreateMessageReactionRequestBody,
     CreateMessageRequest,
     CreateMessageRequestBody,
-    GetImageRequest,
+    GetMessageResourceRequest,
     ReplyMessageRequest,
     ReplyMessageRequestBody,
 )
@@ -623,6 +623,7 @@ class FeishuChannel(Channel):
             for image_key in message.image_keys:
                 cached: dict[str, bytes] = {}
                 ik = image_key  # capture for closure
+                mid = message.message_id  # capture for closure
 
                 _item = MediaItem(
                     type="image",
@@ -631,10 +632,10 @@ class FeishuChannel(Channel):
                 )
 
                 async def _fetch_image_data(
-                    ikey: str = ik, _c: dict = cached, _mi: MediaItem = _item
+                    ikey: str = ik, _mid: str = mid, _c: dict = cached, _mi: MediaItem = _item
                 ) -> bytes:
                     if "data" not in _c:
-                        data, detected_mime = await self._download_image(client, ikey)
+                        data, detected_mime = await self._download_image(client, _mid, ikey)
                         _c["data"] = data
                         _mi.mime_type = detected_mime
                     return _c["data"]
@@ -645,6 +646,7 @@ class FeishuChannel(Channel):
             # Quoted message images (from the replied-to message)
             if quoted_message and quoted_message.get("image_keys"):
                 quoted_keys = quoted_message["image_keys"]
+                quoted_mid = message.parent_id  # the quoted message's ID
                 for image_key in quoted_keys:
                     cached: dict[str, bytes] = {}
                     ik = image_key
@@ -656,10 +658,10 @@ class FeishuChannel(Channel):
                     )
 
                     async def _fetch_quoted_data(
-                        ikey: str = ik, _c: dict = cached, _mi: MediaItem = _qi
+                        ikey: str = ik, _mid: str = quoted_mid, _c: dict = cached, _mi: MediaItem = _qi
                     ) -> bytes:
                         if "data" not in _c:
-                            data, detected_mime = await self._download_image(client, ikey)
+                            data, detected_mime = await self._download_image(client, _mid, ikey)
                             _c["data"] = data
                             _mi.mime_type = detected_mime
                         return _c["data"]
@@ -692,33 +694,33 @@ class FeishuChannel(Channel):
     }
 
     async def _download_image(
-        self, client: lark.Client, image_key: str
+        self, client: lark.Client, message_id: str, image_key: str
     ) -> tuple[bytes, str]:
-        """Download an image from Feishu by image_key via Lark API.
+        """Download an image from a Feishu message via the message resource API.
+
+        Uses ``GET /open-apis/im/v1/messages/:message_id/resources/:file_key``
+        which is the correct endpoint for user-sent images (not the bot-upload
+        ``/images/:image_key`` endpoint).
 
         Returns (image_bytes, mime_type).  The mime type is derived from
         the ``file_name`` in the API response when possible; falls back
         to ``image/jpeg`` only when the extension is unrecognised.
         """
-        request = GetImageRequest.builder().image_key(image_key).build()
-        response = await client.im.v1.image.aget(request)
+        request = (
+            GetMessageResourceRequest.builder()
+            .message_id(message_id)
+            .file_key(image_key)
+            .type("image")
+            .build()
+        )
+        response = await client.im.v1.message_resource.aget(request)
         if not response.success():
             raw = response.raw
             status = getattr(raw, "status_code", "?") if raw else "?"
-            file_obj = response.file
-            file_size = len(file_obj.getvalue()) if file_obj is not None else -1
-            raw_body = ""
-            if raw and hasattr(raw, "content") and raw.content:
-                raw_body = str(raw.content[:500], errors="replace")
-            logger.warning(
-                "feishu.image_download_failed image_key={} http_status={} "
-                "code={} msg={} log_id={} file_size={} raw_body_preview={}",
-                image_key, status, response.code, response.msg,
-                response.get_log_id(), file_size, raw_body,
-            )
             raise RuntimeError(
                 f"Feishu image download failed: http_status={status}, "
-                f"code={response.code}, msg={response.msg}, image_key={image_key}"
+                f"code={response.code}, msg={response.msg}, "
+                f"message_id={message_id}, image_key={image_key}"
             )
         file_obj = response.file
         if file_obj is None:

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -703,9 +703,19 @@ class FeishuChannel(Channel):
         request = GetImageRequest.builder().image_key(image_key).build()
         response = await client.im.v1.image.aget(request)
         if not response.success():
+            raw = response.raw
+            status = getattr(raw, "status_code", "?") if raw else "?"
+            logger.warning(
+                "feishu.image_download_failed image_key={} http_status={} "
+                "code={} msg={} log_id={} has_file={} has_raw={} response_type={}",
+                image_key, status, response.code, response.msg,
+                response.get_log_id(),
+                hasattr(response, "file"), raw is not None,
+                type(response).__name__,
+            )
             raise RuntimeError(
-                f"Feishu image download failed: code={response.code}, "
-                f"msg={response.msg}, log_id={response.get_log_id()}"
+                f"Feishu image download failed: http_status={status}, "
+                f"code={response.code}, msg={response.msg}, image_key={image_key}"
             )
         file_obj = response.file
         if file_obj is None:

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -705,13 +705,16 @@ class FeishuChannel(Channel):
         if not response.success():
             raw = response.raw
             status = getattr(raw, "status_code", "?") if raw else "?"
+            file_obj = response.file
+            file_size = len(file_obj.getvalue()) if file_obj is not None else -1
+            raw_body = ""
+            if raw and hasattr(raw, "content") and raw.content:
+                raw_body = str(raw.content[:500], errors="replace")
             logger.warning(
                 "feishu.image_download_failed image_key={} http_status={} "
-                "code={} msg={} log_id={} has_file={} has_raw={} response_type={}",
+                "code={} msg={} log_id={} file_size={} raw_body_preview={}",
                 image_key, status, response.code, response.msg,
-                response.get_log_id(),
-                hasattr(response, "file"), raw is not None,
-                type(response).__name__,
+                response.get_log_id(), file_size, raw_body,
             )
             raise RuntimeError(
                 f"Feishu image download failed: http_status={status}, "

--- a/tests/test_feishu_image_media.py
+++ b/tests/test_feishu_image_media.py
@@ -497,7 +497,7 @@ class TestQuotedMessageImages:
                 resp.file_name = "second.webp"
             return resp
 
-        mock_client.im.v1.image.aget = mock_aget
+        mock_client.im.v1.message_resource.aget = mock_aget
 
         raw = _make_raw_post_event(elements=[
             [{"tag": "img", "image_key": "img_png"}],
@@ -550,7 +550,7 @@ class TestMediaItemGetUrl:
         mock_response.file = mock_file
         mock_response.file_name = "test.jpg"
 
-        mock_client.im.v1.image.aget = AsyncMock(return_value=mock_response)
+        mock_client.im.v1.message_resource.aget = AsyncMock(return_value=mock_response)
 
         raw = _make_raw_image_event(image_key="img_v3_fetch_test")
         msg = _parse_event(raw)
@@ -568,7 +568,7 @@ class TestMediaItemGetUrl:
         assert url is not None
         assert url.startswith("data:image/jpeg;base64,")
         assert item.mime_type == "image/jpeg"
-        mock_client.im.v1.image.aget.assert_called_once()
+        mock_client.im.v1.message_resource.aget.assert_called_once()
 
     async def test_png_response_produces_correct_data_uri(self, tmp_path: Path):
         """Regression: a PNG response must NOT produce data:image/jpeg prefix."""
@@ -585,7 +585,7 @@ class TestMediaItemGetUrl:
         mock_response.file = mock_file
         mock_response.file_name = "screenshot.png"
 
-        mock_client.im.v1.image.aget = AsyncMock(return_value=mock_response)
+        mock_client.im.v1.message_resource.aget = AsyncMock(return_value=mock_response)
 
         raw = _make_raw_image_event(image_key="img_v3_png")
         msg = _parse_event(raw)
@@ -615,7 +615,7 @@ class TestMediaItemGetUrl:
         mock_response.file = mock_file
         mock_response.file_name = "photo.webp"
 
-        mock_client.im.v1.image.aget = AsyncMock(return_value=mock_response)
+        mock_client.im.v1.message_resource.aget = AsyncMock(return_value=mock_response)
 
         raw = _make_raw_image_event(image_key="img_v3_webp")
         msg = _parse_event(raw)
@@ -645,7 +645,7 @@ class TestMediaItemGetUrl:
         mock_response.file = mock_file
         mock_response.file_name = "image.xyz"
 
-        mock_client.im.v1.image.aget = AsyncMock(return_value=mock_response)
+        mock_client.im.v1.message_resource.aget = AsyncMock(return_value=mock_response)
 
         raw = _make_raw_image_event(image_key="img_v3_unknown")
         msg = _parse_event(raw)
@@ -673,7 +673,7 @@ class TestMediaItemGetUrl:
         mock_response.msg = "image not found"
         mock_response.get_log_id.return_value = "log_abc"
 
-        mock_client.im.v1.image.aget = AsyncMock(return_value=mock_response)
+        mock_client.im.v1.message_resource.aget = AsyncMock(return_value=mock_response)
 
         raw = _make_raw_image_event(image_key="img_v3_bad")
         msg = _parse_event(raw)

--- a/uv.lock
+++ b/uv.lock
@@ -228,7 +228,7 @@ wheels = [
 
 [[package]]
 name = "bub-im-bridge"
-version = "0.4.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "bub" },


### PR DESCRIPTION
## Summary

- **根因**：`GET /im/v1/images/:image_key` 只适用于机器人自己上传的图片，用户发送的图片调用此端点返回 HTTP 400
- **修复**：改用 `GET /im/v1/messages/:message_id/resources/:file_key`，这是下载用户发送图片的正确端点
- 当前消息图片：用 `message_id + image_key` 调 `GetMessageResourceRequest`
- 引用图片：用 `parent_id + quoted image_key` 调同一个资源接口
- `type='image'`

## Changes

- `_download_image` 签名改为 `(self, client, message_id, image_key)`
- 闭包 `_fetch_image_data` 传入 `message.message_id`
- 闭包 `_fetch_quoted_data` 传入 `message.parent_id`（被引用消息的 ID）
- 测试 mock 从 `client.im.v1.image.aget` 改为 `client.im.v1.message_resource.aget`
- 移除调查期间添加的诊断日志（f6af4e2, 134a92d）

## Test plan

- [x] 23 个图片相关测试全部通过
- [x] 全量 103 个测试通过
- [ ] Meta42 实测：纯图片消息、post 图文混合消息、引用回复图片消息

🤖 Generated with [Claude Code](https://claude.com/claude-code)