### PR TITLE
fix: make Feishu reply targets explicit per turn

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bub-im-bridge"
-version = "0.6.3"
+version = "0.6.4"
 description = "WeChat and Feishu channel plugins for Bub framework"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -149,10 +149,6 @@ class FeishuChannel(Channel):
         self._ws_thread: threading.Thread | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
 
-        # Track last inbound message_id per chat so ``send`` can reply.
-        # (The bub framework does not forward ``context`` to outbound messages.)
-        self._last_message_id: dict[str, str] = {}
-        
         # Track message start time for elapsed time calculation
         self._message_start_time: dict[str, float] = {}
 
@@ -428,9 +424,6 @@ class FeishuChannel(Channel):
         session_id = f"feishu:{message.chat_id}"
         sender_id = message.sender_open_id or ""
 
-        # Remember for reply
-        self._last_message_id[message.chat_id] = message.message_id
-
         # Send random reaction to acknowledge message received
         self._add_random_reaction(message.message_id)
 
@@ -537,7 +530,10 @@ class FeishuChannel(Channel):
                 chat_id=message.chat_id,
                 kind="command",
                 is_active=True,
-                context={"sender_id": sender_id},
+                context={
+                    "sender_id": sender_id,
+                    "reply_to_message_id": message.message_id,
+                },
             )
 
         # Fetch quoted message content if this is a reply
@@ -614,7 +610,10 @@ class FeishuChannel(Channel):
         local_time = format_feishu_timestamp(message.create_time)
 
         # Inject API client and profile store into context for tool access
-        context: dict[str, Any] = {"sender_id": sender_id}
+        context: dict[str, Any] = {
+            "sender_id": sender_id,
+            "reply_to_message_id": message.message_id,
+        }
         if local_time:
             context["date"] = local_time
         if self._api_client is not None:
@@ -746,7 +745,7 @@ class FeishuChannel(Channel):
         return data, mime_type
 
     def _send_queue_full_notification(self, message: FeishuInboundMessage) -> None:
-        """Reply directly to the dropped message without touching ``_last_message_id``."""
+        """Reply directly to the dropped message without going through outbound routing."""
         self._reply_message(
             message.message_id,
             "text",
@@ -792,7 +791,6 @@ class FeishuChannel(Channel):
 
         # Confirm to admin
         session_id = f"feishu:{message.chat_id}"
-        self._last_message_id[message.chat_id] = message.message_id
         await self.send(
             ChannelMessage(
                 session_id=session_id,
@@ -800,6 +798,7 @@ class FeishuChannel(Channel):
                 chat_id=message.chat_id,
                 content=f"已全局取消 {len(drained)} 条排队消息，影响 {len(affected_sessions)} 个会话。",
                 is_active=True,
+                context={"reply_to_message_id": message.message_id},
             )
         )
 
@@ -829,8 +828,9 @@ class FeishuChannel(Channel):
         if not text:
             return
 
-        # Calculate elapsed time and collect tool stats if we have start time
-        reply_to = self._last_message_id.get(chat_id)
+        # Reply targets must be carried on the outbound message itself.
+        # Chat-global caches misroute replies under concurrent turns and schedule triggers.
+        reply_to = _extract_reply_to_message_id(message)
         elapsed_seconds = None
         stats: ToolStats | None = None
         if reply_to and reply_to in self._message_start_time:
@@ -846,8 +846,8 @@ class FeishuChannel(Channel):
         if reply_to:
             self._reply_message(reply_to, msg_type, content_json)
         else:
-            logger.warning(
-                "feishu.send no message_id to reply, sending as new message chat_id={}",
+            logger.info(
+                "feishu.send outbound has no reply target, sending as new message chat_id={}",
                 chat_id,
             )
             self._create_message(chat_id, msg_type, content_json)
@@ -1106,6 +1106,14 @@ def _extract_outbound_text(message: ChannelMessage) -> str:
             if isinstance(text, str) and text.strip():
                 return text
     return content.strip() if isinstance(content, str) else ""
+
+
+def _extract_reply_to_message_id(message: ChannelMessage) -> str | None:
+    context = getattr(message, "context", None)
+    if not isinstance(context, dict):
+        return None
+    reply_to = context.get("reply_to_message_id")
+    return reply_to if isinstance(reply_to, str) and reply_to else None
 
 
 # Patterns that indicate rich content needing card rendering

--- a/src/bub_im_bridge/feishu/plugin.py
+++ b/src/bub_im_bridge/feishu/plugin.py
@@ -2,14 +2,22 @@
 
 from __future__ import annotations
 
+from contextvars import ContextVar
 from typing import Any
 
+from bub.channels.message import ChannelMessage
+from bub.envelope import field_of
 from bub.framework import BubFramework
 from bub.hookspecs import hookimpl
 from bub.types import MessageHandler
 
 from bub_im_bridge.feishu.channel import FeishuChannel
 from bub_im_bridge.feishu import tools  # noqa: F401 - import to register tools
+
+_CURRENT_FEISHU_REPLY_TO: ContextVar[str | None] = ContextVar(
+    "bub_im_bridge_current_feishu_reply_to",
+    default=None,
+)
 
 
 class FeishPlugin:
@@ -22,3 +30,38 @@ class FeishPlugin:
     def provide_channels(self, message_handler: MessageHandler) -> list[Any]:
         """Provide Feishu channel to Bub."""
         return [FeishuChannel(on_receive=message_handler, framework=self.framework)]
+
+    @hookimpl
+    async def load_state(self, message: Any, session_id: str) -> dict[str, str | None]:
+        reply_to = None
+        if field_of(message, "channel") == "feishu":
+            reply_to = _extract_reply_to_message_id(message)
+        _CURRENT_FEISHU_REPLY_TO.set(reply_to)
+        return {"feishu_reply_to_message_id": reply_to}
+
+    @hookimpl(tryfirst=True)
+    async def dispatch_outbound(self, message: Any) -> bool:
+        channel_name = field_of(message, "output_channel", field_of(message, "channel"))
+        if channel_name != "feishu":
+            return False
+
+        reply_to = _CURRENT_FEISHU_REPLY_TO.get()
+        if not reply_to:
+            return False
+
+        context = field_of(message, "context")
+        if isinstance(context, dict):
+            context.setdefault("reply_to_message_id", reply_to)
+        elif isinstance(message, ChannelMessage):
+            message.context = {"reply_to_message_id": reply_to}
+        elif isinstance(message, dict):
+            message["context"] = {"reply_to_message_id": reply_to}
+        return False
+
+
+def _extract_reply_to_message_id(message: Any) -> str | None:
+    context = field_of(message, "context", {})
+    if not isinstance(context, dict):
+        return None
+    reply_to = context.get("reply_to_message_id")
+    return reply_to if isinstance(reply_to, str) and reply_to else None

--- a/tests/test_feishu_actor_context.py
+++ b/tests/test_feishu_actor_context.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from bub.channels.message import ChannelMessage
 from bub_im_bridge.feishu.channel import (
     FeishuChannel,
     FeishuInboundMessage,
@@ -240,6 +241,67 @@ class TestStructuredPayloadInChannelMessage:
         payload = json.loads(channel_msg.content)
 
         assert payload["mentions"] == []
+
+    async def test_channel_message_context_includes_reply_target(self, tmp_path: Path):
+        channel = _make_channel(tmp_path)
+        raw = _make_raw_event()
+        msg = _parse_event(raw)
+        assert msg is not None
+
+        channel_msg = await channel._build_channel_message(
+            msg, msg.text.strip(), "ou_sender", "feishu:chat_001"
+        )
+
+        assert channel_msg.context["reply_to_message_id"] == "msg_001"
+
+
+@pytest.mark.asyncio
+class TestFeishuOutboundReplyRouting:
+    async def test_send_replies_to_explicit_message_id(self, tmp_path: Path):
+        channel = _make_channel(tmp_path)
+        channel._api_client = object()
+        channel._message_start_time["msg_001"] = 100.0
+        reply_calls: list[tuple[str, str, str]] = []
+        create_calls: list[tuple[str, str, str]] = []
+
+        channel._reply_message = lambda mid, msg_type, content: reply_calls.append((mid, msg_type, content))
+        channel._create_message = lambda cid, msg_type, content: create_calls.append((cid, msg_type, content))
+
+        with patch("bub_im_bridge.feishu.channel.time.time", return_value=103.0):
+            await channel.send(
+                ChannelMessage(
+                    session_id="feishu:chat_001",
+                    channel="feishu",
+                    chat_id="chat_001",
+                    content="hello",
+                    context={"reply_to_message_id": "msg_001"},
+                )
+            )
+
+        assert [call[0] for call in reply_calls] == ["msg_001"]
+        assert create_calls == []
+        assert "msg_001" not in channel._message_start_time
+
+    async def test_send_creates_new_message_without_reply_target(self, tmp_path: Path):
+        channel = _make_channel(tmp_path)
+        channel._api_client = object()
+        reply_calls: list[tuple[str, str, str]] = []
+        create_calls: list[tuple[str, str, str]] = []
+
+        channel._reply_message = lambda mid, msg_type, content: reply_calls.append((mid, msg_type, content))
+        channel._create_message = lambda cid, msg_type, content: create_calls.append((cid, msg_type, content))
+
+        await channel.send(
+            ChannelMessage(
+                session_id="feishu:chat_001",
+                channel="feishu",
+                chat_id="chat_001",
+                content="hello",
+            )
+        )
+
+        assert reply_calls == []
+        assert [call[0] for call in create_calls] == ["chat_001"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_feishu_plugin.py
+++ b/tests/test_feishu_plugin.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from bub.channels.message import ChannelMessage
+
+from bub_im_bridge.feishu.plugin import FeishPlugin
+
+
+@pytest.mark.asyncio
+async def test_dispatch_outbound_injects_reply_target_for_current_feishu_turn() -> None:
+    plugin = FeishPlugin(framework=MagicMock())
+    inbound = ChannelMessage(
+        session_id="feishu:chat-1",
+        channel="feishu",
+        chat_id="chat-1",
+        content="hello",
+        context={"reply_to_message_id": "msg-1"},
+    )
+    outbound = ChannelMessage(
+        session_id="feishu:chat-1",
+        channel="feishu",
+        chat_id="chat-1",
+        content="reply",
+    )
+
+    await plugin.load_state(inbound, "feishu:chat-1")
+    result = await plugin.dispatch_outbound(outbound)
+
+    assert result is False
+    assert outbound.context["reply_to_message_id"] == "msg-1"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_outbound_does_not_override_explicit_reply_target() -> None:
+    plugin = FeishPlugin(framework=MagicMock())
+    inbound = ChannelMessage(
+        session_id="feishu:chat-1",
+        channel="feishu",
+        chat_id="chat-1",
+        content="hello",
+        context={"reply_to_message_id": "msg-1"},
+    )
+    outbound = ChannelMessage(
+        session_id="feishu:chat-1",
+        channel="feishu",
+        chat_id="chat-1",
+        content="reply",
+        context={"reply_to_message_id": "msg-explicit"},
+    )
+
+    await plugin.load_state(inbound, "feishu:chat-1")
+    await plugin.dispatch_outbound(outbound)
+
+    assert outbound.context["reply_to_message_id"] == "msg-explicit"
+
+
+@pytest.mark.asyncio
+async def test_schedule_like_feishu_turn_without_reply_target_stays_unreplied() -> None:
+    plugin = FeishPlugin(framework=MagicMock())
+    inbound = ChannelMessage(
+        session_id="feishu:chat-1",
+        channel="feishu",
+        chat_id="chat-1",
+        content="scheduled reminder",
+    )
+    outbound = ChannelMessage(
+        session_id="feishu:chat-1",
+        channel="feishu",
+        chat_id="chat-1",
+        content="reply",
+    )
+
+    await plugin.load_state(inbound, "feishu:chat-1")
+    await plugin.dispatch_outbound(outbound)
+
+    assert "reply_to_message_id" not in outbound.context
+
+
+@pytest.mark.asyncio
+async def test_dispatch_outbound_ignores_non_feishu_channels() -> None:
+    plugin = FeishPlugin(framework=MagicMock())
+    inbound = ChannelMessage(
+        session_id="jsonrpc:chat-1",
+        channel="jsonrpc",
+        chat_id="chat-1",
+        content="hello",
+        context={"reply_to_message_id": "msg-1"},
+    )
+    outbound = ChannelMessage(
+        session_id="jsonrpc:chat-1",
+        channel="jsonrpc",
+        chat_id="chat-1",
+        content="reply",
+    )
+
+    await plugin.load_state(inbound, "jsonrpc:chat-1")
+    await plugin.dispatch_outbound(outbound)
+
+    assert "reply_to_message_id" not in outbound.context
+
+
+@pytest.mark.asyncio
+async def test_reply_target_is_isolated_per_concurrent_turn() -> None:
+    plugin = FeishPlugin(framework=MagicMock())
+
+    async def run_turn(message_id: str, delay: float) -> str | None:
+        inbound = ChannelMessage(
+            session_id=f"feishu:{message_id}",
+            channel="feishu",
+            chat_id=message_id,
+            content="hello",
+            context={"reply_to_message_id": message_id},
+        )
+        outbound = ChannelMessage(
+            session_id=f"feishu:{message_id}",
+            channel="feishu",
+            chat_id=message_id,
+            content="reply",
+        )
+        await plugin.load_state(inbound, inbound.session_id)
+        await asyncio.sleep(delay)
+        await plugin.dispatch_outbound(outbound)
+        return outbound.context.get("reply_to_message_id")
+
+    result_a, result_b = await asyncio.gather(
+        run_turn("msg-a", 0.02),
+        run_turn("msg-b", 0.0),
+    )
+
+    assert result_a == "msg-a"
+    assert result_b == "msg-b"

--- a/uv.lock
+++ b/uv.lock
@@ -228,7 +228,7 @@ wheels = [
 
 [[package]]
 name = "bub-im-bridge"
-version = "0.6.1"
+version = "0.6.4"
 source = { editable = "." }
 dependencies = [
     { name = "bub" },


### PR DESCRIPTION
## Summary
- move Feishu reply-target propagation into bub-im-bridge plugin hooks
- make Feishu channel consume only explicit `reply_to_message_id` and otherwise send new messages
- add concurrent and schedule-style regression coverage for reply-target routing

## Testing
- uv run pytest tests/test_feishu_actor_context.py tests/test_feishu_plugin.py -q