### PR TITLE
chore: bump version to 0.6.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bub-im-bridge"
-version = "0.6.4"
+version = "0.6.5"
 description = "WeChat and Feishu channel plugins for Bub framework"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary
- bump package version metadata from `0.6.4` to `0.6.5`
- align the published package version with the already-shipped Feishu prompt fix

## Testing
- uv run --project /Users/mi/work/system-weaver/projects/bub-im-bridge pytest /Users/mi/work/system-weaver/projects/bub-im-bridge/tests/test_feishu_actor_context.py -q
