### PR TITLE
chore: bump version to 0.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bub-im-bridge"
-version = "0.6.5"
+version = "0.7.0"
 description = "WeChat and Feishu channel plugins for Bub framework"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary
- bump `bub-im-bridge` package version to `0.7.0`
- normalize package metadata and release numbering to match the intended tag line

## Testing
- uv run --with pytest --with pytest-asyncio --project /Users/mi/.slock/agents/52d2be1e-d971-47d9-b08e-21b8b96db486/tmp/bub-im-bridge-v070 pytest /Users/mi/.slock/agents/52d2be1e-d971-47d9-b08e-21b8b96db486/tmp/bub-im-bridge-v070/tests/test_feishu_actor_context.py -q
