### PR TITLE
fix(feishu): detect image MIME from magic bytes, not file_name

### DIFF
--- a/src/bub_im_bridge/feishu/channel.py
+++ b/src/bub_im_bridge/feishu/channel.py
@@ -689,7 +689,7 @@ class FeishuChannel(Channel):
             media=media_items,
         )
 
-    # Extension → MIME type mapping for Feishu image responses
+    # Extension → MIME type mapping for Feishu image responses (fallback only)
     _IMAGE_MIME_MAP: dict[str, str] = {
         ".jpg": "image/jpeg",
         ".jpeg": "image/jpeg",
@@ -698,6 +698,32 @@ class FeishuChannel(Channel):
         ".webp": "image/webp",
         ".bmp": "image/bmp",
     }
+
+    @staticmethod
+    def _detect_image_mime_from_bytes(data: bytes) -> str | None:
+        """Detect image MIME type from magic-number signatures at the start
+        of the byte stream.
+
+        Returns the detected MIME type, or ``None`` when no signature matches.
+
+        Reference signatures:
+          * PNG:  ``89 50 4E 47 0D 0A 1A 0A``
+          * JPEG: ``FF D8 FF``
+          * GIF:  ``GIF87a`` / ``GIF89a``
+          * WebP: ``RIFF????WEBP``
+          * BMP:  ``BM``
+        """
+        if data.startswith(b"\x89PNG\r\n\x1a\n"):
+            return "image/png"
+        if data.startswith(b"\xff\xd8\xff"):
+            return "image/jpeg"
+        if data.startswith(b"GIF87a") or data.startswith(b"GIF89a"):
+            return "image/gif"
+        if len(data) >= 12 and data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+            return "image/webp"
+        if data.startswith(b"BM"):
+            return "image/bmp"
+        return None
 
     async def _download_image(
         self, client: lark.Client, message_id: str, image_key: str
@@ -708,9 +734,12 @@ class FeishuChannel(Channel):
         which is the correct endpoint for user-sent images (not the bot-upload
         ``/images/:image_key`` endpoint).
 
-        Returns (image_bytes, mime_type).  The mime type is derived from
-        the ``file_name`` in the API response when possible; falls back
-        to ``image/jpeg`` only when the extension is unrecognised.
+        Returns ``(image_bytes, mime_type)``. The MIME type is detected from
+        the actual image bytes (magic numbers) — Feishu's ``file_name`` is
+        unreliable (often missing or with wrong extension), and downstream
+        LLM APIs (e.g. Anthropic) strictly validate ``media_type`` against
+        the byte content. We fall back to extension-based detection, then to
+        ``image/jpeg``, only when the magic number is unrecognised.
         """
         request = (
             GetMessageResourceRequest.builder()
@@ -735,12 +764,16 @@ class FeishuChannel(Channel):
             )
         data = file_obj.read()
 
-        # Detect mime type from response file_name
-        mime_type = "image/jpeg"  # conservative default
-        file_name: str | None = getattr(response, "file_name", None)
-        if file_name:
-            ext = Path(file_name).suffix.lower()
-            mime_type = self._IMAGE_MIME_MAP.get(ext, mime_type)
+        # Detect MIME from actual bytes first (most reliable).
+        mime_type = self._detect_image_mime_from_bytes(data)
+        if mime_type is None:
+            # Fallback: derive from file_name extension when magic number
+            # is unknown (rare — covers exotic formats not enumerated above).
+            mime_type = "image/jpeg"  # conservative default
+            file_name: str | None = getattr(response, "file_name", None)
+            if file_name:
+                ext = Path(file_name).suffix.lower()
+                mime_type = self._IMAGE_MIME_MAP.get(ext, mime_type)
 
         return data, mime_type
 

--- a/tests/test_feishu_image_media.py
+++ b/tests/test_feishu_image_media.py
@@ -687,3 +687,145 @@ class TestMediaItemGetUrl:
 
         with pytest.raises(RuntimeError, match="image not found"):
             await item.get_url()
+
+    async def test_png_bytes_with_misleading_filename_detected_as_png(
+        self, tmp_path: Path
+    ):
+        """Regression: when Feishu returns ``file_name`` without an extension
+        (e.g. ``"image"``) or with a wrong extension, MIME detection must
+        fall back to magic-number inspection of the actual bytes — not blindly
+        trust the filename and return ``image/jpeg``.
+
+        Reproduces the failure where a PNG screenshot embedded in a Feishu
+        post message was sent to Anthropic as ``image/jpeg`` and rejected:
+        ``messages.N.content.K.image.source.base64: The image was specified
+        using the image/jpeg media type, but the image appears to be a
+        image/png image``.
+        """
+        channel = _make_channel(tmp_path)
+
+        mock_client = MagicMock()
+        channel._api_client = mock_client
+
+        # Real PNG magic header — what Anthropic will see and validate against.
+        png_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 50
+        mock_response = MagicMock()
+        mock_response.success.return_value = True
+        mock_response.file = io.BytesIO(png_bytes)
+        # Feishu sometimes returns a generic / extensionless file_name for
+        # images embedded in post messages (group announcements, quoted
+        # messages). The previous extension-only path would default to
+        # image/jpeg here.
+        mock_response.file_name = "image"
+
+        mock_client.im.v1.message_resource.aget = AsyncMock(return_value=mock_response)
+
+        raw = _make_raw_image_event(image_key="img_v3_misleading_name")
+        msg = _parse_event(raw)
+        assert msg is not None
+
+        channel_msg = await channel._build_channel_message(
+            msg, msg.text, "ou_sender", "feishu:chat_001"
+        )
+
+        item = channel_msg.media[0]
+        url = await item.get_url()
+
+        assert url.startswith("data:image/png;base64,")
+        assert item.mime_type == "image/png"
+
+    async def test_jpeg_bytes_with_png_filename_detected_as_jpeg(
+        self, tmp_path: Path
+    ):
+        """Even if file_name says ``.png``, magic-number inspection wins —
+        the bytes are authoritative because that's what the LLM API validates.
+        """
+        channel = _make_channel(tmp_path)
+
+        mock_client = MagicMock()
+        channel._api_client = mock_client
+
+        # Real JPEG magic, but file_name lies and claims PNG.
+        jpeg_bytes = b"\xff\xd8\xff\xe0" + b"\x00" * 100
+        mock_response = MagicMock()
+        mock_response.success.return_value = True
+        mock_response.file = io.BytesIO(jpeg_bytes)
+        mock_response.file_name = "actually_jpeg.png"
+
+        mock_client.im.v1.message_resource.aget = AsyncMock(return_value=mock_response)
+
+        raw = _make_raw_image_event(image_key="img_v3_lying_name")
+        msg = _parse_event(raw)
+        assert msg is not None
+
+        channel_msg = await channel._build_channel_message(
+            msg, msg.text, "ou_sender", "feishu:chat_001"
+        )
+
+        item = channel_msg.media[0]
+        url = await item.get_url()
+
+        assert url.startswith("data:image/jpeg;base64,")
+        assert item.mime_type == "image/jpeg"
+
+
+# ---------------------------------------------------------------------------
+# MIME magic-number detection helper
+# ---------------------------------------------------------------------------
+
+
+class TestDetectImageMimeFromBytes:
+    """Unit tests for FeishuChannel._detect_image_mime_from_bytes."""
+
+    def test_png_signature(self):
+        assert (
+            FeishuChannel._detect_image_mime_from_bytes(b"\x89PNG\r\n\x1a\n" + b"x" * 8)
+            == "image/png"
+        )
+
+    def test_jpeg_signature(self):
+        assert (
+            FeishuChannel._detect_image_mime_from_bytes(b"\xff\xd8\xff\xe0" + b"x" * 8)
+            == "image/jpeg"
+        )
+
+    def test_gif87_signature(self):
+        assert (
+            FeishuChannel._detect_image_mime_from_bytes(b"GIF87a" + b"x" * 8)
+            == "image/gif"
+        )
+
+    def test_gif89_signature(self):
+        assert (
+            FeishuChannel._detect_image_mime_from_bytes(b"GIF89a" + b"x" * 8)
+            == "image/gif"
+        )
+
+    def test_webp_signature(self):
+        assert (
+            FeishuChannel._detect_image_mime_from_bytes(
+                b"RIFF\x00\x00\x00\x00WEBP" + b"x" * 4
+            )
+            == "image/webp"
+        )
+
+    def test_bmp_signature(self):
+        assert (
+            FeishuChannel._detect_image_mime_from_bytes(b"BM" + b"\x00" * 30)
+            == "image/bmp"
+        )
+
+    def test_unknown_signature_returns_none(self):
+        assert FeishuChannel._detect_image_mime_from_bytes(b"\x00" * 16) is None
+
+    def test_empty_bytes_returns_none(self):
+        assert FeishuChannel._detect_image_mime_from_bytes(b"") is None
+
+    def test_riff_without_webp_marker_returns_none(self):
+        # RIFF is also used by WAV, AVI, etc — only RIFF+WEBP is image/webp.
+        assert (
+            FeishuChannel._detect_image_mime_from_bytes(
+                b"RIFF\x00\x00\x00\x00WAVE" + b"x" * 4
+            )
+            is None
+        )


### PR DESCRIPTION
## Problem

Feishu's `file_name` for images returned by the message resource API is unreliable. In particular, when an image is embedded in a **post message** — e.g. a group announcement, a quoted reply, or a structured rich-text message — the API often returns a generic name like `"image"` without an extension.

Today, `_download_image` derives MIME purely from `file_name`'s extension and silently falls back to `image/jpeg`. As a result, **PNG screenshots get tagged as `image/jpeg`**.

Downstream LLM APIs strictly validate `media_type` against the actual image bytes. Anthropic, for example, rejects mismatched payloads with:

```
messages.N.content.K.image.source.base64:
  The image was specified using the image/jpeg media type,
  but the image appears to be a image/png image
```

This blows up the **entire turn** — the user sees a confusing 400 error every time they paste a PNG into 飞书. The bug is reliably triggered by quoting a 飞书 group announcement (which contains an `img` post-message tag with no usable extension).

## Fix

Detect MIME from magic-number signatures (PNG / JPEG / GIF / WebP / BMP) in the **downloaded bytes** first. Fall back to extension lookup only when no signature matches (covers exotic formats not enumerated above).

Reference signatures used:
- PNG:  `89 50 4E 47 0D 0A 1A 0A`
- JPEG: `FF D8 FF`
- GIF:  `GIF87a` / `GIF89a`
- WebP: `RIFF????WEBP`
- BMP:  `BM`

The new helper is a `@staticmethod` to keep it independently testable.

## Tests

- Two new regression tests in `TestMediaItemGetUrl`:
  - **`test_png_bytes_with_misleading_filename_detected_as_png`** — reproduces the failure: PNG bytes + `file_name="image"` (no extension) must produce `data:image/png;base64,…`. Fails on `main`, passes after the fix.
  - **`test_jpeg_bytes_with_png_filename_detected_as_jpeg`** — guards against the inverse: bytes are authoritative even when `file_name` lies.
- New `TestDetectImageMimeFromBytes` class covering all five formats, the unknown-bytes case, the empty-bytes edge case, and `RIFF` non-WebP (e.g. WAV) to make sure we don't false-positive on the RIFF container.

```
$ uv run pytest tests/test_feishu_image_media.py -q
..................................                                       [100%]
34 passed
```

## Impact

- Fixes a reliable Anthropic API 400 every time a user quotes/forwards a PNG via post message in 飞书.
- Behaviour for "happy path" responses (`file_name="screenshot.png"`, etc.) is unchanged because the magic number wins first and matches the extension.