### PR TITLE
feat(gitlab): add GitLab webhook channel for MR reviewer auto-review

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,28 @@ BUB_TELEGRAM_PROXY=http://127.0.0.1:1087  # 国内网络需要
 
 微信渠道需要先扫码登录：`uv run -m bub_im_bridge login`
 
+### GitLab Webhook
+
+GitLab webhook 是主动事件源；当前只监听 MR reviewer/assignee 指派给指定人员的事件。内置 review prompt 通过 Bub `build_prompt` hook 注入，处理结果发送到配置的通知渠道。
+
+```env
+BUB_GITLAB_WEBHOOK_HOST=0.0.0.0
+BUB_GITLAB_WEBHOOK_PORT=8765
+BUB_GITLAB_WEBHOOK_PATH=/gitlab/webhook
+BUB_GITLAB_WEBHOOK_TOKEN=your-gitlab-secret-token
+BUB_GITLAB_PROJECT_IDS=123,456
+BUB_GITLAB_REVIEWER_NAME=Meta42
+BUB_GITLAB_NOTIFY_CHANNEL=feishu
+BUB_GITLAB_NOTIFY_CHAT_ID=oc_xxx
+BUB_GITLAB_WEBHOOK_DEDUPE_TTL=600
+```
+
+在 GitLab 项目设置里把 webhook URL 指向：`http://<host>:8765/gitlab/webhook`，并配置相同的 Secret Token，Trigger 勾选 `Merge request events`。
+
+> `BUB_GITLAB_WEBHOOK_HOST` 默认 `127.0.0.1`（仅本机访问）。如果 GitLab 服务器需要远程访问，设为 `0.0.0.0` 并确保网络安全策略允许。
+>
+> GitLab webhook channel 默认开启，配合 `BUB_ENABLED_CHANNELS=all`（Bub 默认）自动启动。设 `BUB_GITLAB_WEBHOOK_DISABLED=true` 可单独关闭。
+
 ## 配置参考
 
 ### 通用配置
@@ -85,6 +107,21 @@ BUB_TELEGRAM_PROXY=http://127.0.0.1:1087  # 国内网络需要
 |--------|------|:----:|
 | `WEIXIN_BASE_URL` | 微信 API 基础地址 | ❌ |
 | `WEIXIN_ACCOUNT_ID` | 微信账号 ID | ❌ |
+
+### GitLab Webhook
+
+| 配置项 | 说明 | 必需 |
+|--------|------|:----:|
+| `BUB_GITLAB_WEBHOOK_DISABLED` | 设为 `true` 可关闭 GitLab webhook channel，默认开启 | ❌ |
+| `BUB_GITLAB_WEBHOOK_HOST` | HTTP listener 绑定地址，默认 `127.0.0.1` | ❌ |
+| `BUB_GITLAB_WEBHOOK_PORT` | HTTP listener 端口，默认 `8765` | ❌ |
+| `BUB_GITLAB_WEBHOOK_PATH` | Webhook 路径，默认 `/gitlab/webhook` | ❌ |
+| `BUB_GITLAB_WEBHOOK_TOKEN` | GitLab Secret Token，用于校验 `X-Gitlab-Token` | ❌ |
+| `BUB_GITLAB_PROJECT_IDS` | 允许处理的 GitLab project id，逗号分隔；空值表示不限制 | ❌ |
+| `BUB_GITLAB_REVIEWER_NAME` | 触发 review 自动处理的 reviewer/assignee 姓名或 username | ✅ |
+| `BUB_GITLAB_NOTIFY_CHANNEL` | 通知渠道，默认 `feishu` | ❌ |
+| `BUB_GITLAB_NOTIFY_CHAT_ID` | 通知目标 chat id | ✅ |
+| `BUB_GITLAB_WEBHOOK_DEDUPE_TTL` | 事件去重 TTL 秒数，默认 `600` | ❌ |
 
 ## 消息类型
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
 [project.entry-points."bub"]
 weixin_channel = "bub_im_bridge.weixin.plugin:WeixinPlugin"
 feishu_channel = "bub_im_bridge.feishu.plugin:FeishPlugin"
+gitlab_webhook = "bub_im_bridge.gitlab.plugin:GitLabWebhookPlugin"
 
 [project.optional-dependencies]
 dev = ["pytest>=8.0", "pytest-asyncio>=0.24"]

--- a/src/bub_im_bridge/gitlab/__init__.py
+++ b/src/bub_im_bridge/gitlab/__init__.py
@@ -1,0 +1,1 @@
+"""GitLab webhook channel plugin."""

--- a/src/bub_im_bridge/gitlab/channel.py
+++ b/src/bub_im_bridge/gitlab/channel.py
@@ -1,0 +1,357 @@
+"""GitLab review-request webhook channel for Bub."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import threading
+import time
+from dataclasses import dataclass
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, ClassVar
+from urllib.parse import urlparse
+
+from bub.channels.base import Channel
+from bub.channels.message import ChannelMessage
+from bub.framework import BubFramework
+from loguru import logger
+
+
+@dataclass(frozen=True)
+class GitLabWebhookConfig:
+    enabled: bool
+    host: str
+    port: int
+    path: str
+    secret_token: str
+    project_ids: frozenset[str]
+    reviewer_name: str
+    notify_channel: str
+    notify_chat_id: str
+    dedupe_ttl_seconds: int
+
+
+class GitLabWebhookChannel(Channel):
+    """Receive GitLab MR reviewer assignment events and inject review tasks."""
+
+    name: ClassVar[str] = "gitlab"
+
+    def __init__(self, *, framework: BubFramework | None = None) -> None:
+        self._framework = framework
+        self._config = load_gitlab_webhook_config()
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._server: ThreadingHTTPServer | None = None
+        self._server_thread: threading.Thread | None = None
+        self._seen_events: dict[str, float] = {}
+
+    @property
+    def enabled(self) -> bool:
+        return self._config.enabled
+
+    async def start(self, stop_event: asyncio.Event) -> None:
+        if not self._config.enabled:
+            logger.info("gitlab_webhook.disabled")
+            return
+        if self._framework is None:
+            raise RuntimeError("gitlab_webhook: framework is required")
+        if not self._config.reviewer_name or not self._config.notify_chat_id:
+            logger.warning(
+                "gitlab_webhook.skip BUB_GITLAB_REVIEWER_NAME or BUB_GITLAB_NOTIFY_CHAT_ID not set"
+            )
+            return
+
+        self._loop = asyncio.get_running_loop()
+        self._server = ThreadingHTTPServer(
+            (self._config.host, self._config.port),
+            self._make_handler(),
+        )
+        self._server_thread = threading.Thread(
+            target=self._server.serve_forever,
+            name="gitlab-webhook-http",
+            daemon=True,
+        )
+        self._server_thread.start()
+        logger.info(
+            "gitlab_webhook.start host={} port={} path={} reviewer={}",
+            self._config.host,
+            self._config.port,
+            self._config.path,
+            self._config.reviewer_name,
+        )
+
+    async def stop(self) -> None:
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+            self._server = None
+        if self._server_thread is not None:
+            self._server_thread.join(timeout=2)
+            self._server_thread = None
+        logger.info("gitlab_webhook.stop complete")
+
+    async def handle_webhook(
+        self,
+        payload: dict[str, Any],
+        *,
+        event_name: str,
+        delivery_id: str | None = None,
+        token: str | None = None,
+    ) -> bool:
+        """Validate, filter, and inject one GitLab review-request event (fire-and-forget)."""
+        self._validate_token(token)
+
+        event = normalize_gitlab_merge_request_event(payload, event_name=event_name)
+        if not should_trigger_review(event, self._config):
+            logger.info(
+                "gitlab_webhook.ignored project_id={} event={} action={} reviewer={}",
+                event["project_id"],
+                event["event_type"],
+                event["action"],
+                self._config.reviewer_name,
+            )
+            return False
+
+        event_key = delivery_id or event_fingerprint(event)
+        if self._is_duplicate(event_key):
+            logger.info("gitlab_webhook.duplicate event_key={}", event_key)
+            return False
+
+        if self._framework is None:
+            raise RuntimeError("gitlab_webhook: no live framework available")
+        message = build_review_message(event, self._config, event_key)
+        asyncio.create_task(self._framework.process_inbound(message))
+        return True
+
+    def _make_handler(self) -> type[BaseHTTPRequestHandler]:
+        channel = self
+        config = self._config
+
+        class GitLabWebhookRequestHandler(BaseHTTPRequestHandler):
+            def do_POST(self) -> None:  # noqa: N802 - stdlib hook name
+                parsed = urlparse(self.path)
+                if parsed.path != config.path:
+                    self._write_json(HTTPStatus.NOT_FOUND, {"error": "not found"})
+                    return
+
+                try:
+                    content_length = int(self.headers.get("Content-Length", "0"))
+                    body = self.rfile.read(content_length)
+                    payload = json.loads(body.decode("utf-8"))
+                    event_name = self.headers.get("X-Gitlab-Event", "")
+                    delivery_id = self.headers.get("X-Gitlab-Event-UUID")
+                    token = self.headers.get("X-Gitlab-Token")
+                except Exception:
+                    logger.warning("gitlab_webhook.bad_request", exc_info=True)
+                    self._write_json(HTTPStatus.BAD_REQUEST, {"error": "bad request"})
+                    return
+
+                future = asyncio.run_coroutine_threadsafe(
+                    channel.handle_webhook(
+                        payload,
+                        event_name=event_name,
+                        delivery_id=delivery_id,
+                        token=token,
+                    ),
+                    channel._require_loop(),
+                )
+                try:
+                    accepted = future.result(timeout=10)
+                except PermissionError:
+                    self._write_json(HTTPStatus.FORBIDDEN, {"error": "invalid token"})
+                    return
+                except TimeoutError:
+                    logger.warning("gitlab_webhook.dispatch_timeout")
+                    self._write_json(HTTPStatus.ACCEPTED, {"accepted": True})
+                    return
+                except Exception:
+                    logger.exception("gitlab_webhook.dispatch_failed")
+                    self._write_json(HTTPStatus.INTERNAL_SERVER_ERROR, {"error": "dispatch failed"})
+                    return
+
+                self._write_json(HTTPStatus.ACCEPTED, {"accepted": accepted})
+
+            def log_message(self, format: str, *args: object) -> None:
+                logger.debug("gitlab_webhook.http {}", format % args if args else format)
+
+            def _write_json(self, status: HTTPStatus, payload: dict[str, Any]) -> None:
+                body = json.dumps(payload).encode("utf-8")
+                self.send_response(status.value)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+        return GitLabWebhookRequestHandler
+
+    def _require_loop(self) -> asyncio.AbstractEventLoop:
+        if self._loop is None:
+            raise RuntimeError("gitlab_webhook: event loop is not ready")
+        return self._loop
+
+    def _validate_token(self, token: str | None) -> None:
+        expected = self._config.secret_token
+        if expected and token != expected:
+            raise PermissionError("invalid GitLab webhook token")
+
+    def _is_duplicate(self, event_key: str) -> bool:
+        now = time.time()
+        ttl = self._config.dedupe_ttl_seconds
+        expired = [key for key, seen_at in self._seen_events.items() if now - seen_at > ttl]
+        for key in expired:
+            self._seen_events.pop(key, None)
+        if event_key in self._seen_events:
+            return True
+        self._seen_events[event_key] = now
+        return False
+
+
+def load_gitlab_webhook_config() -> GitLabWebhookConfig:
+    return GitLabWebhookConfig(
+        enabled=not _parse_bool(os.environ.get("BUB_GITLAB_WEBHOOK_DISABLED", "false")),
+        host=os.environ.get("BUB_GITLAB_WEBHOOK_HOST", "127.0.0.1"),
+        port=int(os.environ.get("BUB_GITLAB_WEBHOOK_PORT", "8765")),
+        path=os.environ.get("BUB_GITLAB_WEBHOOK_PATH", "/gitlab/webhook"),
+        secret_token=os.environ.get("BUB_GITLAB_WEBHOOK_TOKEN", ""),
+        project_ids=frozenset(_string_list(os.environ.get("BUB_GITLAB_PROJECT_IDS", ""))),
+        reviewer_name=os.environ.get("BUB_GITLAB_REVIEWER_NAME", "").strip(),
+        notify_channel=os.environ.get("BUB_GITLAB_NOTIFY_CHANNEL", "feishu").strip() or "feishu",
+        notify_chat_id=os.environ.get("BUB_GITLAB_NOTIFY_CHAT_ID", "").strip(),
+        dedupe_ttl_seconds=int(os.environ.get("BUB_GITLAB_WEBHOOK_DEDUPE_TTL", "600")),
+    )
+
+
+def normalize_gitlab_merge_request_event(payload: dict[str, Any], *, event_name: str) -> dict[str, Any]:
+    object_attributes = payload.get("object_attributes")
+    if not isinstance(object_attributes, dict):
+        object_attributes = {}
+
+    project = payload.get("project")
+    if not isinstance(project, dict):
+        project = {}
+
+    user = payload.get("user")
+    if not isinstance(user, dict):
+        user = {}
+
+    reviewers = _people(payload.get("reviewers")) or _people(object_attributes.get("reviewers"))
+    assignees = _people(payload.get("assignees")) or _people(object_attributes.get("assignees"))
+
+    project_id = str(project.get("id") or payload.get("project_id") or "").strip()
+    return {
+        "event_type": _event_type(str(payload.get("object_kind") or ""), event_name),
+        "event_name": event_name,
+        "action": str(object_attributes.get("action") or "").strip(),
+        "project_id": project_id,
+        "project": {
+            "id": project_id,
+            "name": project.get("name") or "",
+            "path_with_namespace": project.get("path_with_namespace") or "",
+            "web_url": project.get("web_url") or "",
+        },
+        "merge_request": {
+            "iid": str(object_attributes.get("iid") or "").strip(),
+            "title": object_attributes.get("title") or "",
+            "source_branch": object_attributes.get("source_branch") or "",
+            "target_branch": object_attributes.get("target_branch") or "",
+            "url": object_attributes.get("url") or object_attributes.get("web_url") or "",
+            "state": object_attributes.get("state") or "",
+        },
+        "author": {
+            "name": user.get("name") or payload.get("user_name") or "",
+            "username": user.get("username") or payload.get("user_username") or "",
+        },
+        "reviewers": reviewers,
+        "assignees": assignees,
+        "raw": payload,
+    }
+
+
+def should_trigger_review(event: dict[str, Any], config: GitLabWebhookConfig) -> bool:
+    if event["event_type"] != "merge_request":
+        return False
+    if config.project_ids and event["project_id"] not in config.project_ids:
+        return False
+    if event["action"] not in {"update", "open", "reopen"}:
+        return False
+    target = config.reviewer_name.strip().lower()
+    if not target:
+        return False
+    return any(_person_matches(person, target) for person in event["reviewers"] + event["assignees"])
+
+
+def build_review_message(
+    event: dict[str, Any], config: GitLabWebhookConfig, event_key: str
+) -> ChannelMessage:
+    merge_request = event["merge_request"]
+    session_id = f"gitlab:{event['project_id']}:merge_request:{merge_request['iid']}"
+    content = json.dumps(
+        {
+            "gitlab_event": {key: value for key, value in event.items() if key != "raw"},
+        },
+        ensure_ascii=False,
+    )
+    return ChannelMessage(
+        session_id=session_id,
+        channel="gitlab",
+        chat_id=config.notify_chat_id,
+        content=content,
+        is_active=True,
+        context={
+            "gitlab_event_key": event_key,
+            "gitlab_event_type": event["event_type"],
+            "gitlab_project_id": event["project_id"],
+            "gitlab_action": event["action"],
+            "gitlab_reviewer_name": config.reviewer_name,
+            "notify_channel": config.notify_channel,
+            "notify_chat_id": config.notify_chat_id,
+        },
+        output_channel=config.notify_channel,
+    )
+
+
+def event_fingerprint(event: dict[str, Any]) -> str:
+    stable = json.dumps({key: value for key, value in event.items() if key != "raw"}, sort_keys=True)
+    return hashlib.sha256(stable.encode("utf-8")).hexdigest()
+
+
+def _event_type(object_kind: str, event_name: str) -> str:
+    if object_kind:
+        return object_kind
+    return event_name.lower().replace(" hook", "").replace(" ", "_")
+
+
+def _people(value: Any) -> list[dict[str, str]]:
+    if not isinstance(value, list):
+        return []
+    people: list[dict[str, str]] = []
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        people.append(
+            {
+                "name": str(item.get("name") or ""),
+                "username": str(item.get("username") or item.get("user_name") or ""),
+            }
+        )
+    return people
+
+
+def _person_matches(person: dict[str, str], target: str) -> bool:
+    return person.get("name", "").strip().lower() == target or person.get("username", "").strip().lower() == target
+
+
+def _string_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [item.strip() for item in value.split(",") if item.strip()]
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    raise ValueError("expected string or list")
+
+
+def _parse_bool(value: str) -> bool:
+    return value.strip().lower() in {"1", "true", "yes", "on"}

--- a/src/bub_im_bridge/gitlab/plugin.py
+++ b/src/bub_im_bridge/gitlab/plugin.py
@@ -1,0 +1,78 @@
+"""Bub plugin entry point for GitLab webhook events."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from bub.envelope import content_of, field_of
+from bub.framework import BubFramework
+from bub.hookspecs import hookimpl
+from bub.types import MessageHandler, State
+
+from bub_im_bridge.gitlab.channel import (
+    GitLabWebhookChannel,
+    load_gitlab_webhook_config,
+)
+
+
+GITLAB_REVIEW_PROMPT = """你被指派为这个 GitLab Merge Request 的 reviewer。
+
+请基于 GitLab 事件上下文完成工程化 review，并将结果提交为 MR comment：
+
+1. 用 glab 获取 MR diff 和已有 discussions：`glab api projects/<project_id>/merge_requests/<iid>/changes`、`glab api projects/<project_id>/merge_requests/<iid>/discussions`。
+2. 分析 diff，识别安全风险、逻辑缺陷、代码风格问题，给出具体行号和修改建议。
+3. 必须使用 `glab mr note` 命令提交 review comment，不要用 `glab api` 或其他方式。命令格式：`glab mr note <iid> -R <path_with_namespace> -m "<review 内容>"`。多行内容直接作为 -m 的字符串值传入（支持换行）；内容太长时先写入临时文件，再用 `glab mr note <iid> -R <path_with_namespace> -m "$(cat /tmp/review.md)"`。
+4. review comment 格式：先给结论（LGTM / 需要修改 / 阻塞），再列具体问题（严重程度 + 行号 + 建议），最后给总结。
+5. 提交 comment 后，输出简短中文摘要作为飞书群通知内容（包含 MR 链接和 review 结论）。
+6. 不要尝试用 feishu CLI 或 lark-cli 发送消息——通知由框架自动完成，你只需输出摘要文本。
+7. 全程使用中文输出。不要输出英文思考过程、进度说明或 "Let me..." 之类过渡语。直接给出结果。"""
+
+
+class GitLabWebhookPlugin:
+    """Plugin that provides GitLab webhook event ingestion and review prompts."""
+
+    def __init__(self, framework: BubFramework) -> None:
+        self.framework = framework
+        self.config = load_gitlab_webhook_config()
+
+    @hookimpl
+    def provide_channels(self, message_handler: MessageHandler) -> list[Any]:
+        return [GitLabWebhookChannel(framework=self.framework)]
+
+    @hookimpl(tryfirst=True)
+    def build_prompt(self, message: Any, session_id: str, state: State) -> str | None:
+        if field_of(message, "channel") != "gitlab":
+            return None
+        content = content_of(message)
+        try:
+            payload = json.loads(content)
+        except json.JSONDecodeError:
+            return None
+        event = payload.get("gitlab_event")
+        if not isinstance(event, dict):
+            return None
+        return (
+            f"{GITLAB_REVIEW_PROMPT}\n\n"
+            "GitLab merge request event context:\n"
+            f"{json.dumps(event, ensure_ascii=False, indent=2)}"
+        )
+
+    @hookimpl(tryfirst=True)
+    async def dispatch_outbound(self, message: Any) -> bool:
+        if field_of(message, "channel") != "gitlab":
+            return False
+        context = field_of(message, "context", {})
+        if not isinstance(context, dict):
+            return False
+        notify_channel = context.get("notify_channel")
+        notify_chat_id = context.get("notify_chat_id")
+        if not notify_channel or not notify_chat_id:
+            return False
+        if isinstance(message, dict):
+            message["output_channel"] = notify_channel
+            message["chat_id"] = notify_chat_id
+        else:
+            message.output_channel = str(notify_channel)
+            message.chat_id = str(notify_chat_id)
+        return False

--- a/tests/test_gitlab_webhook_plugin.py
+++ b/tests/test_gitlab_webhook_plugin.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from bub.channels.message import ChannelMessage
+from bub_im_bridge.gitlab.channel import (
+    GitLabWebhookChannel,
+    GitLabWebhookConfig,
+    build_review_message,
+    normalize_gitlab_merge_request_event,
+    should_trigger_review,
+)
+from bub_im_bridge.gitlab.plugin import GitLabWebhookPlugin
+
+
+@pytest.fixture
+def config() -> GitLabWebhookConfig:
+    return GitLabWebhookConfig(
+        enabled=True,
+        host="127.0.0.1",
+        port=8765,
+        path="/gitlab/webhook",
+        secret_token="secret",
+        project_ids=frozenset({"123"}),
+        reviewer_name="Meta42",
+        notify_channel="feishu",
+        notify_chat_id="oc_123",
+        dedupe_ttl_seconds=600,
+    )
+
+
+@pytest.fixture
+def merge_request_payload() -> dict:
+    return {
+        "object_kind": "merge_request",
+        "project": {
+            "id": 123,
+            "name": "demo",
+            "path_with_namespace": "group/demo",
+            "web_url": "https://gitlab.example/group/demo",
+        },
+        "user": {"name": "Alice", "username": "alice"},
+        "object_attributes": {
+            "iid": 7,
+            "action": "update",
+            "title": "Add webhook support",
+            "source_branch": "feat/webhook",
+            "target_branch": "main",
+            "url": "https://gitlab.example/group/demo/-/merge_requests/7",
+            "state": "opened",
+        },
+        "reviewers": [{"name": "Meta42", "username": "meta42"}],
+        "assignees": [],
+    }
+
+
+def test_normalize_merge_request_review_event(merge_request_payload: dict) -> None:
+    event = normalize_gitlab_merge_request_event(
+        merge_request_payload, event_name="Merge Request Hook"
+    )
+
+    assert event["event_type"] == "merge_request"
+    assert event["project_id"] == "123"
+    assert event["action"] == "update"
+    assert event["merge_request"]["iid"] == "7"
+    assert event["merge_request"]["target_branch"] == "main"
+    assert event["reviewers"] == [{"name": "Meta42", "username": "meta42"}]
+
+
+def test_triggers_only_for_configured_reviewer(
+    merge_request_payload: dict, config: GitLabWebhookConfig
+) -> None:
+    event = normalize_gitlab_merge_request_event(
+        merge_request_payload, event_name="Merge Request Hook"
+    )
+
+    assert should_trigger_review(event, config) is True
+
+    other_config = GitLabWebhookConfig(
+        **{**config.__dict__, "reviewer_name": "Someone Else"}
+    )
+    assert should_trigger_review(event, other_config) is False
+
+
+def test_triggers_for_configured_assignee(
+    merge_request_payload: dict, config: GitLabWebhookConfig
+) -> None:
+    merge_request_payload["reviewers"] = []
+    merge_request_payload["assignees"] = [{"name": "Meta42", "username": "meta42"}]
+    event = normalize_gitlab_merge_request_event(
+        merge_request_payload, event_name="Merge Request Hook"
+    )
+
+    assert should_trigger_review(event, config) is True
+
+
+def test_build_review_message_keeps_gitlab_source_and_feishu_sink(
+    merge_request_payload: dict, config: GitLabWebhookConfig
+) -> None:
+    event = normalize_gitlab_merge_request_event(
+        merge_request_payload, event_name="Merge Request Hook"
+    )
+
+    message = build_review_message(event, config, "event-uuid")
+    content = json.loads(message.content)
+
+    assert message.channel == "gitlab"
+    assert message.session_id == "gitlab:123:merge_request:7"
+    assert message.chat_id == "oc_123"
+    assert message.output_channel == "feishu"
+    assert message.context["notify_channel"] == "feishu"
+    assert message.context["notify_chat_id"] == "oc_123"
+    assert "message" not in content
+    assert content["gitlab_event"]["project"]["path_with_namespace"] == "group/demo"
+
+
+def test_plugin_build_prompt_injects_review_prompt(
+    merge_request_payload: dict, config: GitLabWebhookConfig
+) -> None:
+    event = normalize_gitlab_merge_request_event(
+        merge_request_payload, event_name="Merge Request Hook"
+    )
+    message = build_review_message(event, config, "event-uuid")
+    plugin = GitLabWebhookPlugin(framework=MagicMock())
+    plugin.config = config
+
+    prompt = plugin.build_prompt(message, message.session_id, {})
+
+    assert prompt is not None
+    assert prompt.startswith("你被指派为这个 GitLab Merge Request 的 reviewer。")
+    assert "GitLab merge request event context" in prompt
+    assert "Add webhook support" in prompt
+
+
+@pytest.mark.asyncio
+async def test_handle_webhook_injects_review_request_into_framework(
+    merge_request_payload: dict, config: GitLabWebhookConfig
+) -> None:
+    framework = MagicMock()
+    framework.process_inbound = AsyncMock()
+    channel = GitLabWebhookChannel(framework=framework)
+    channel._config = config
+
+    accepted = await channel.handle_webhook(
+        merge_request_payload,
+        event_name="Merge Request Hook",
+        delivery_id="uuid-1",
+        token="secret",
+    )
+
+    assert accepted is True
+    await asyncio.sleep(0)
+    framework.process_inbound.assert_awaited_once()
+    message = framework.process_inbound.await_args.args[0]
+    assert isinstance(message, ChannelMessage)
+    assert message.channel == "gitlab"
+    assert message.output_channel == "feishu"
+
+
+@pytest.mark.asyncio
+async def test_handle_webhook_ignores_non_matching_reviewer(
+    merge_request_payload: dict, config: GitLabWebhookConfig
+) -> None:
+    merge_request_payload["reviewers"] = [{"name": "Other", "username": "other"}]
+    framework = MagicMock()
+    framework.process_inbound = AsyncMock()
+    channel = GitLabWebhookChannel(framework=framework)
+    channel._config = config
+
+    accepted = await channel.handle_webhook(
+        merge_request_payload,
+        event_name="Merge Request Hook",
+        delivery_id="uuid-1",
+        token="secret",
+    )
+
+    assert accepted is False
+    framework.process_inbound.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_webhook_deduplicates_delivery_id(
+    merge_request_payload: dict, config: GitLabWebhookConfig
+) -> None:
+    framework = MagicMock()
+    framework.process_inbound = AsyncMock()
+    channel = GitLabWebhookChannel(framework=framework)
+    channel._config = GitLabWebhookConfig(**{**config.__dict__, "secret_token": ""})
+
+    first = await channel.handle_webhook(
+        merge_request_payload,
+        event_name="Merge Request Hook",
+        delivery_id="uuid-1",
+    )
+    second = await channel.handle_webhook(
+        merge_request_payload,
+        event_name="Merge Request Hook",
+        delivery_id="uuid-1",
+    )
+
+    assert first is True
+    assert second is False
+    await asyncio.sleep(0)
+    framework.process_inbound.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_plugin_dispatch_outbound_sets_notify_sink() -> None:
+    plugin = GitLabWebhookPlugin(framework=MagicMock())
+    outbound = ChannelMessage(
+        session_id="gitlab:123:merge_request:7",
+        channel="gitlab",
+        chat_id="123",
+        content="review result",
+        context={"notify_channel": "feishu", "notify_chat_id": "oc_123"},
+    )
+
+    result = await plugin.dispatch_outbound(outbound)
+
+    assert result is False
+    assert outbound.output_channel == "feishu"
+    assert outbound.chat_id == "oc_123"


### PR DESCRIPTION
## Changes
- Add `GitLabWebhookChannel`: HTTP listener receives GitLab MR webhooks, filters by configured reviewer/assignee name, injects events into Bub via `process_inbound` (fire-and-forget pattern)
- Add `GitLabWebhookPlugin`: provides channel + `build_prompt` hook that injects hardcoded review prompt + MR event context
- `dispatch_outbound` routes review results to configured notify channel (feishu) and chat_id
- Token validation, event deduplication, project_id filtering
- Config via env: `BUB_GITLAB_REVIEWER_NAME`, `BUB_GITLAB_NOTIFY_CHAT_ID`, `BUB_GITLAB_WEBHOOK_TOKEN`, etc.
- Default enabled (`BUB_GITLAB_WEBHOOK_DISABLED` to opt out)

## Motivation
GitLab MR reviewer 指派事件触发自动化 review：agent 用 glab 获取 MR diff，分析后用 `glab mr note` 提交 review comment，摘要推送到飞书群。

## Testing
- [x] Unit tests: `tests/test_gitlab_webhook_plugin.py` (9 tests)
- [x] E2E 验证：philip 项目接入，真实 GitLab MR webhook 触发，review comment 成功提交到 MR，飞书群通知正常接收
- [x] Fire-and-forget 模式：webhook 立即返回 202，model 推理在后台异步执行